### PR TITLE
Clang / Apple Silicon Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,11 +251,14 @@ else()
         set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -DNDEBUG")
     endif()
 
-    if (NOT CMAKE_C_FLAGS MATCHES .*march.* AND NOT CMAKE_C_FLAGS MATCHES .*mtune.*)
+    CHECK_C_COMPILER_FLAG(-march=native HAS_C_MARCH_NATIVE)
+    CHECK_CXX_COMPILER_FLAG(-march=native HAS_CXX_MARCH_NATIVE)
+
+    if (HAS_C_MARCH_NATIVE AND NOT CMAKE_C_FLAGS MATCHES .*march.* AND NOT CMAKE_C_FLAGS MATCHES .*mtune.*)
         set(ARCH_C_FLAGS "-march=native -mtune=${TUNE_FLAG}")
     endif()
 
-    if (NOT CMAKE_CXX_FLAGS MATCHES .*march.* AND NOT CMAKE_CXX_FLAGS MATCHES .*mtune.*)
+    if (HAS_CXX_MARCH_NATIVE AND NOT CMAKE_CXX_FLAGS MATCHES .*march.* AND NOT CMAKE_CXX_FLAGS MATCHES .*mtune.*)
         set(ARCH_CXX_FLAGS "-march=native -mtune=${TUNE_FLAG}")
     endif()
 

--- a/src/util/arch/arm/simd_utils.h
+++ b/src/util/arch/arm/simd_utils.h
@@ -93,14 +93,9 @@ m128 sub_2x64(m128 a, m128 b) {
     return (m128) vsubq_u64((int64x2_t)a, (int64x2_t)b);
 }
 
-static really_really_inline
-m128 lshift_m128(m128 a, unsigned b) {
-    return (m128) vshlq_n_s32((int64x2_t)a, b);
-}
-
-static really_really_inline
-m128 rshift_m128(m128 a, unsigned b) {
-    return (m128) vshrq_n_s32((int64x2_t)a, b);
+static really_inline
+m128 lshift64_m128(m128 a, unsigned b) {
+    return (m128) vshlq_s64((int64x2_t)(a), vdupq_n_s64(b));
 }
 
 #define rshift64_m128(a, b) vshrq_n_s64((int64x2_t)(a), b)

--- a/src/util/arch/arm/simd_utils.h
+++ b/src/util/arch/arm/simd_utils.h
@@ -103,15 +103,7 @@ m128 rshift_m128(m128 a, unsigned b) {
     return (m128) vshrq_n_s32((int64x2_t)a, b);
 }
 
-static really_really_inline
-m128 lshift64_m128(m128 a, unsigned b) {
-    return (m128) vshlq_n_s64((int64x2_t)a, b);
-}
-
-static really_really_inline
-m128 rshift64_m128(m128 a, unsigned b) {
-    return (m128) vshrq_n_s64((int64x2_t)a, b);
-}
+#define rshift64_m128(a, b) vshrq_n_s64((int64x2_t)(a), b)
 
 static really_inline m128 eq128(m128 a, m128 b) {
     return (m128) vceqq_s8((int8x16_t)a, (int8x16_t)b);
@@ -161,10 +153,10 @@ m128 load_m128_from_u64a(const u64a *p) {
     return (m128) vsetq_lane_u64(*p, zeroes128(), 0);
 }
 
-static really_inline u32 extract32from128(const m128 in, unsigned imm) {
 #if defined(HS_OPTIMIZE)
-    return vgetq_lane_u32((uint32x4_t) in, imm);
+#define extract32from128(in, imm) vgetq_lane_u32((uint32x4_t) (in), imm)
 #else
+static really_inline u32 extract32from128(const m128 in, unsigned imm) {
     switch (imm) {
     case 0:
         return vgetq_lane_u32((uint32x4_t) in, 0);
@@ -182,13 +174,13 @@ static really_inline u32 extract32from128(const m128 in, unsigned imm) {
 	return 0;
 	break;
     }
-#endif
 }
+#endif
 
-static really_inline u64a extract64from128(const m128 in, unsigned imm) {
 #if defined(HS_OPTIMIZE)
-    return vgetq_lane_u64((uint64x2_t) in, imm);
+#define extract64from128(in, imm) vgetq_lane_u64((uint32x4_t) (in), imm)
 #else
+static really_inline u64a extract64from128(const m128 in, unsigned imm) {
     switch (imm) {
     case 0:
         return vgetq_lane_u64((uint32x4_t) in, 0);
@@ -200,8 +192,9 @@ static really_inline u64a extract64from128(const m128 in, unsigned imm) {
 	return 0;
 	break;
     }
-#endif
 }
+#endif
+
 
 static really_inline m128 low64from128(const m128 in) {
     return vcombine_u64(vget_low_u64(in), vdup_n_u64(0));
@@ -298,31 +291,18 @@ m128 palignr_imm(m128 r, m128 l, int offset) {
     }
 }
 
+#if defined(HS_OPTIMIZE)
+#define palignr(r, l, offset) vextq_s8((int8x16_t)(l), (int8x16_t)(r), offset)
+#else
 static really_really_inline
 m128 palignr(m128 r, m128 l, int offset) {
-#if defined(HS_OPTIMIZE)
-    return (m128)vextq_s8((int8x16_t)l, (int8x16_t)r, offset);
-#else
     return palignr_imm(r, l, offset);
-#endif
 }
+#endif
 #undef CASE_ALIGN_VECTORS
 
-static really_really_inline
-m128 rshiftbyte_m128(m128 a, unsigned b) {
-    if (b == 0) {
-        return a;
-    }
-    return palignr(zeroes128(), a, b);
-}
-
-static really_really_inline
-m128 lshiftbyte_m128(m128 a, unsigned b) {
-    if (b == 0) {
-        return a;
-    }
-    return palignr(a, zeroes128(), 16 - b);
-}
+#define rshiftbyte_m128(a, b) palignr(zeroes128(), a, b)
+#define lshiftbyte_m128(a, b) palignr(a, zeroes128(), 16 - (b))
 
 static really_inline
 m128 variable_byte_shift_m128(m128 in, s32 amount) {

--- a/src/util/arch/common/simd_utils.h
+++ b/src/util/arch/common/simd_utils.h
@@ -101,13 +101,14 @@ m256 lshift64_m256(m256 a, int b) {
     return rv;
 }
 
-static really_inline
-m256 rshift64_m256(m256 a, int b) {
-    m256 rv = a;
-    rv.lo = rshift64_m128(rv.lo, b);
-    rv.hi = rshift64_m128(rv.hi, b);
-    return rv;
-}
+#define rshift64_m256(a, b)                                                    \
+    ({                                                                         \
+        m256 __ret;                                                            \
+        __ret = a;                                                             \
+        __ret.lo = rshift64_m128(__ret.lo, b);                                 \
+        __ret.hi = rshift64_m128(__ret.hi, b);                                 \
+        __ret;                                                                 \
+    })
 
 static really_inline
 m256 eq256(m256 a, m256 b) {

--- a/unit/internal/simd_utils.cpp
+++ b/unit/internal/simd_utils.cpp
@@ -721,8 +721,6 @@ TEST(SimdUtilsTest, variableByteShift128) {
     char base[] = "0123456789ABCDEF";
     m128 in = loadu128(base);
 
-    EXPECT_TRUE(!diff128(rshiftbyte_m128(in, 0),
-                         variable_byte_shift_m128(in, 0)));
     EXPECT_TRUE(!diff128(rshiftbyte_m128(in, 1),
                          variable_byte_shift_m128(in, -1)));
     EXPECT_TRUE(!diff128(rshiftbyte_m128(in, 2),
@@ -744,8 +742,6 @@ TEST(SimdUtilsTest, variableByteShift128) {
     EXPECT_TRUE(!diff128(rshiftbyte_m128(in, 10),
                          variable_byte_shift_m128(in, -10)));
 
-    EXPECT_TRUE(!diff128(lshiftbyte_m128(in, 0),
-                         variable_byte_shift_m128(in, 0)));
     EXPECT_TRUE(!diff128(lshiftbyte_m128(in, 1),
                          variable_byte_shift_m128(in, 1)));
     EXPECT_TRUE(!diff128(lshiftbyte_m128(in, 2),


### PR DESCRIPTION
This PR addresses compatibility of the NEON SIMD intrinsics with clang.

It also fixes the use of an compiler flag which is not available on the Apple M1 (https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1).

See the multi-line commit messages for the reasons behind the particular changes.