### PR TITLE
remove adding CMAKE_CXX_IMPLICIT_LINK_LIBRARIES to PRIVATE_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,14 +473,6 @@ configure_file(${CMAKE_MODULE_PATH}/config.h.in ${PROJECT_BINARY_DIR}/config.h)
 configure_file(src/hs_version.h.in ${PROJECT_BINARY_DIR}/hs_version.h)
 
 
-# expand out library names for pkgconfig static link info
-foreach (LIB ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
-    # this is fragile, but protects us from toolchain specific files
-    if (NOT EXISTS ${LIB})
-        set(PRIVATE_LIBS "${PRIVATE_LIBS} -l${LIB}")
-    endif()
-endforeach()
-
 configure_file(libhs.pc.in libhs.pc @ONLY) # only replace @ quoted vars
 install(FILES ${CMAKE_BINARY_DIR}/libhs.pc
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/libhs.pc.in
+++ b/libhs.pc.in
@@ -7,5 +7,4 @@ Name: libhs
 Description: Intel(R) Hyperscan Library
 Version: @HS_VERSION@
 Libs: -L${libdir} -lhs
-Libs.private: @PRIVATE_LIBS@
 Cflags: -I${includedir}/hs


### PR DESCRIPTION
as on alpine linux this add gcc_s which is a shared library

on alpine:
Libs.private: -lstdc++ -lm -lssp_nonshared -lgcc_s -lgcc -lc -lgcc_s -lgcc