### PR TITLE
Fix word boundary assertions under C++20

### DIFF
--- a/src/rose/rose_graph.h
+++ b/src/rose/rose_graph.h
@@ -112,7 +112,7 @@ struct LeftEngInfo {
     }
     size_t hash() const;
     void reset(void);
-    operator bool() const;
+    explicit operator bool() const;
     bool tracksSom() const { return !!haig; }
 };
 
@@ -133,7 +133,7 @@ struct RoseSuffixInfo {
     bool operator<(const RoseSuffixInfo &b) const;
     size_t hash() const;
     void reset(void);
-    operator bool() const { return graph || castle || haig || rdfa || tamarama; }
+    explicit operator bool() const { return graph || castle || haig || rdfa || tamarama; }
 };
 
 /** \brief Properties attached to each Rose graph vertex. */

--- a/src/util/ue2_graph.h
+++ b/src/util/ue2_graph.h
@@ -176,7 +176,7 @@ public:
     vertex_descriptor() : p(nullptr), serial(0) {}
     explicit vertex_descriptor(vertex_node *pp) : p(pp), serial(pp->serial) {}
 
-    operator bool() const { return p; }
+    explicit operator bool() const { return p; }
     bool operator<(const vertex_descriptor b) const {
         if (p && b.p) {
             /* no vertices in the same graph can have the same serial */


### PR DESCRIPTION
See https://github.com/intel/hyperscan/pull/345.
Word boundary assertions are basically broken when using modern stdlib (with [P1614R2](https://wg21.link/P1614R2) implemented). This is caused by breaking change in `std::pair` comparison operators (after [P1614R2](https://wg21.link/P1614R2) `std::pair` uses `operator<=>`).

For more context on breaking change, see
https://www.reddit.com/r/cpp/comments/ra5cpy/the_spacesship_operator_silently_broke_my_code/