### PR TITLE
Fix all ASAN issues in vectorscan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,8 @@ if (RELEASE_BUILD)
     set(HS_OPTIMIZE ON)
 endif()
 
+include (${CMAKE_MODULE_PATH}/sanitize.cmake)
+
 CMAKE_DEPENDENT_OPTION(DUMP_SUPPORT "Dump code support; normally on, except in release builds" ON "NOT RELEASE_BUILD" OFF)
 
 CMAKE_DEPENDENT_OPTION(DISABLE_ASSERTS "Disable assert(); Asserts are enabled in debug builds, disabled in release builds" OFF "NOT RELEASE_BUILD" ON)

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -1,0 +1,40 @@
+# Possible values:
+# - `address` (ASan)
+# - `memory` (MSan)
+# - `undefined` (UBSan)
+# - "" (no sanitizing)
+option (SANITIZE "Enable one of the code sanitizers" "")
+
+set (SAN_FLAGS "${SAN_FLAGS} -g -fno-omit-frame-pointer -DSANITIZER")
+
+if (SANITIZE)
+    if (SANITIZE STREQUAL "address")
+        set (ASAN_FLAGS "-fsanitize=address -fsanitize-address-use-after-scope")
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} ${ASAN_FLAGS}")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_FLAGS} ${ASAN_FLAGS}")
+
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ASAN_FLAGS}")
+        endif()
+
+    elseif (SANITIZE STREQUAL "memory")
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	    set (FATAL_ERROR "GCC does not have memory sanitizer")
+        endif()
+	# MemorySanitizer flags are set according to the official documentation:
+        # https://clang.llvm.org/docs/MemorySanitizer.html#usage
+        set (MSAN_FLAGS "-fsanitize=memory -fsanitize-memory-use-after-dtor -fsanitize-memory-track-origins -fno-optimize-sibling-calls")
+
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} ${MSAN_FLAGS}")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_FLAGS} ${MSAN_FLAGS}")
+    elseif (SANITIZE STREQUAL "undefined")
+        set (UBSAN_FLAGS "-fsanitize=undefined")
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} ${UBSAN_FLAGS}")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_FLAGS} ${UBSAN_FLAGS}")
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined")
+        endif()
+    else ()
+        message (FATAL_ERROR "Unknown sanitizer type: ${SANITIZE}")
+    endif ()
+endif()

--- a/src/nfa/arm/vermicelli.hpp
+++ b/src/nfa/arm/vermicelli.hpp
@@ -67,7 +67,7 @@ const u8 *rvermicelliBlockNeg(SuperVector<S> const data, SuperVector<S> const ch
     return last_zero_match_inverted<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *vermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2, SuperVector<S> const casemask,
                                 u8 const c1, u8 const c2, u8 const casechar, u8 const *buf, u16 const len) {
@@ -78,14 +78,16 @@ const u8 *vermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const 
     SuperVector<S> mask = mask1 & (mask2 >> 1);
 
     DEBUG_PRINTF("rv[0] = %02hhx, rv[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
+    bool partial_match = (check_partial && ((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
-    if (partial_match) return buf - 1;
+    if (partial_match) {
+        mask = mask | ((SuperVector<S>::Ones() >> (S-1)) << (S-1));
+    }
 
     return first_non_zero_match<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2, SuperVector<S> const casemask,
                                  u8 const c1, u8 const c2, u8 const casechar, u8 const *buf, u16 const len) {
@@ -96,7 +98,7 @@ const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const
     SuperVector<S> mask = (mask1 << 1)& mask2;
 
     DEBUG_PRINTF("buf[0] = %02hhx, buf[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
+    bool partial_match = (check_partial && ((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
     if (partial_match) {
         mask = mask | (SuperVector<S>::Ones() >> (S-1));
@@ -105,7 +107,7 @@ const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const
     return last_non_zero_match<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *vermicelliDoubleMaskedBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2,
                                       SuperVector<S> const mask1, SuperVector<S> const mask2,
@@ -116,9 +118,11 @@ const u8 *vermicelliDoubleMaskedBlock(SuperVector<S> const data, SuperVector<S> 
     SuperVector<S> mask = v1 & (v2 >> 1);
 
     DEBUG_PRINTF("rv[0] = %02hhx, rv[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & m1) == c2) && ((buf[-1] & m2) == c1));
+    bool partial_match = (check_partial && ((buf[0] & m2) == c2) && ((buf[-1] & m1) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
-    if (partial_match) return buf - 1;
+    if (partial_match) {
+        mask = mask | ((SuperVector<S>::Ones() >> (S-1)) << (S-1));
+    }
 
     return first_non_zero_match<S>(buf, mask, len);
 }

--- a/src/nfa/ppc64el/vermicelli.hpp
+++ b/src/nfa/ppc64el/vermicelli.hpp
@@ -67,7 +67,7 @@ const u8 *rvermicelliBlockNeg(SuperVector<S> const data, SuperVector<S> const ch
     return last_zero_match_inverted<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *vermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2, SuperVector<S> const casemask,
                                 u8 const c1, u8 const c2, u8 const casechar, u8 const *buf, u16 const len) {
@@ -78,14 +78,16 @@ const u8 *vermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const 
     SuperVector<S> mask = mask1 & (mask2 >> 1);
 
     DEBUG_PRINTF("rv[0] = %02hhx, rv[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
+    bool partial_match = (check_partial && ((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
-    if (partial_match) return buf - 1;
+    if (partial_match) {
+        mask = mask | ((SuperVector<S>::Ones() >> (S-1)) << (S-1));
+    }
 
     return first_non_zero_match<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2, SuperVector<S> const casemask,
                                  u8 const c1, u8 const c2, u8 const casechar, u8 const *buf, u16 const len) {
@@ -96,7 +98,7 @@ const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const
     SuperVector<S> mask = (mask1 << 1)& mask2;
 
     DEBUG_PRINTF("buf[0] = %02hhx, buf[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
+    bool partial_match = (check_partial && ((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
     if (partial_match) {
         mask = mask | (SuperVector<S>::Ones() >> (S-1));
@@ -105,7 +107,7 @@ const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const
     return last_non_zero_match<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *vermicelliDoubleMaskedBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2,
                                       SuperVector<S> const mask1, SuperVector<S> const mask2,
@@ -116,9 +118,11 @@ const u8 *vermicelliDoubleMaskedBlock(SuperVector<S> const data, SuperVector<S> 
     SuperVector<S> mask = v1 & (v2 >> 1);
 
     DEBUG_PRINTF("rv[0] = %02hhx, rv[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & m1) == c2) && ((buf[-1] & m2) == c1));
+    bool partial_match = (check_partial && ((buf[0] & m2) == c2) && ((buf[-1] & m1) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
-    if (partial_match) return buf - 1;
+    if (partial_match) {
+        mask = mask | ((SuperVector<S>::Ones() >> (S-1)) << (S-1));
+    }
 
     return first_non_zero_match<S>(buf, mask, len);
 }

--- a/src/nfa/truffle_simd.hpp
+++ b/src/nfa/truffle_simd.hpp
@@ -107,8 +107,16 @@ const u8 *truffleExecReal(m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_highse
     // finish off tail
 
     if (d != buf_end) {
-        SuperVector<S> chars = SuperVector<S>::loadu_maskz(d, buf_end - d);
-        rv = fwdBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d);
+        SuperVector<S> chars = SuperVector<S>::Zeroes();
+        const u8* end_buf;
+        if (buf_end - buf < S) {
+          memcpy(&chars.u, buf, buf_end - buf);
+          end_buf = buf;
+        } else {
+          chars = SuperVector<S>::loadu(buf_end - S);
+          end_buf = buf_end - S;
+        }
+        rv = fwdBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, end_buf);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end) return rv;
     }
@@ -171,7 +179,12 @@ const u8 *rtruffleExecReal(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highse
     // finish off head
 
     if (d != buf) {
-        SuperVector<S> chars = SuperVector<S>::loadu(buf);
+        SuperVector<S> chars = SuperVector<S>::Zeroes();
+        if (buf_end - buf < S) {
+          memcpy(&chars.u, buf, buf_end - buf);
+        } else {
+          chars = SuperVector<S>::loadu(buf);
+        }
         rv = revBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, buf);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end) return rv;

--- a/src/nfa/vermicelli_simd.cpp
+++ b/src/nfa/vermicelli_simd.cpp
@@ -310,7 +310,7 @@ static const u8 *vermicelliDoubleExecReal(u8 const c1, u8 const c2, SuperVector<
     __builtin_prefetch(d + 4*64);
     DEBUG_PRINTF("start %p end %p \n", d, buf_end);
     assert(d < buf_end);
-    if (d + S <= buf_end) {
+    if (d + S < buf_end) {
         // Reach vector aligned boundaries
         DEBUG_PRINTF("until aligned %p \n", ROUNDUP_PTR(d, S));
         if (!ISALIGNED_N(d, S)) {
@@ -336,15 +336,12 @@ static const u8 *vermicelliDoubleExecReal(u8 const c1, u8 const c2, SuperVector<
 
     if (d != buf_end) {
         SuperVector<S> data = SuperVector<S>::Zeroes();
-        const u8* end_buf;
-        if (buf_end - buf < S) {
-          memcpy(&data.u, buf, buf_end - buf);
-          end_buf = buf;
+        if (buf_end - d < S) {
+          memcpy(&data.u, d, buf_end - d);
         } else {
-          data = SuperVector<S>::loadu(buf_end - S);
-          end_buf = buf_end - S;
+          data = SuperVector<S>::loadu(d);
         }
-        rv = vermicelliDoubleBlock<S, false>(data, chars1, chars2, casemask, c1, c2, casechar, end_buf, buf_end - d);
+        rv = vermicelliDoubleBlock<S, false>(data, chars1, chars2, casemask, c1, c2, casechar, d, buf_end - d);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end) return rv;
     }
@@ -383,7 +380,7 @@ const u8 *rvermicelliDoubleExecReal(char c1, char c2, SuperVector<S> const casem
     __builtin_prefetch(d - 4*64);
     DEBUG_PRINTF("start %p end %p \n", buf, d);
     assert(d > buf);
-    if (d - S >= buf) {
+    if (d - S > buf) {
         // Reach vector aligned boundaries
         DEBUG_PRINTF("until aligned %p \n", ROUNDDOWN_PTR(d, S));
         if (!ISALIGNED_N(d, S)) {
@@ -395,7 +392,7 @@ const u8 *rvermicelliDoubleExecReal(char c1, char c2, SuperVector<S> const casem
             d = d1;
         }
 
-        while (d - S >= buf) {
+        while (d - S > buf) {
             DEBUG_PRINTF("aligned %p \n", d);
             // On large packet buffers, this prefetch appears to get us about 2%.
             __builtin_prefetch(d - 64);
@@ -447,7 +444,7 @@ static const u8 *vermicelliDoubleMaskedExecReal(u8 const c1, u8 const c2, u8 con
     __builtin_prefetch(d + 4*64);
     DEBUG_PRINTF("start %p end %p \n", d, buf_end);
     assert(d < buf_end);
-    if (d + S <= buf_end) {
+    if (d + S < buf_end) {
         // Reach vector aligned boundaries
         DEBUG_PRINTF("until aligned %p \n", ROUNDUP_PTR(d, S));
         if (!ISALIGNED_N(d, S)) {
@@ -473,15 +470,12 @@ static const u8 *vermicelliDoubleMaskedExecReal(u8 const c1, u8 const c2, u8 con
 
     if (d != buf_end) {
         SuperVector<S> data = SuperVector<S>::Zeroes();
-        const u8* end_buf;
-        if (buf_end - buf < S) {
-          memcpy(&data.u, buf, buf_end - buf);
-          end_buf = buf;
+        if (buf_end - d < S) {
+          memcpy(&data.u, d, buf_end - d);
         } else {
-          data = SuperVector<S>::loadu(buf_end - S);
-          end_buf = buf_end - S;
+          data = SuperVector<S>::loadu(d);
         }
-        rv = vermicelliDoubleMaskedBlock<S, false>(data, chars1, chars2, mask1, mask2, c1, c2, m1, m2, end_buf, buf_end - d);
+        rv = vermicelliDoubleMaskedBlock<S, false>(data, chars1, chars2, mask1, mask2, c1, c2, m1, m2, d, buf_end - d);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end) return rv;
     }

--- a/src/nfa/x86/vermicelli.hpp
+++ b/src/nfa/x86/vermicelli.hpp
@@ -67,7 +67,7 @@ const u8 *rvermicelliBlockNeg(SuperVector<S> const data, SuperVector<S> const ch
     return last_zero_match_inverted<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *vermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2, SuperVector<S> const casemask,
                                 u8 const c1, u8 const c2, u8 const casechar, u8 const *buf, u16 const len) {
@@ -78,14 +78,16 @@ const u8 *vermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const 
     SuperVector<S> mask = mask1 & (mask2 >> 1);
 
     DEBUG_PRINTF("rv[0] = %02hhx, rv[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
+    bool partial_match = (check_partial && ((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
-    if (partial_match) return buf - 1;
+    if (partial_match) {
+        mask = mask | ((SuperVector<S>::Ones() >> (S-1)) << (S-1));
+    }
 
     return first_non_zero_match<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2, SuperVector<S> const casemask,
                                  u8 const c1, u8 const c2, u8 const casechar, u8 const *buf, u16 const len) {
@@ -96,7 +98,7 @@ const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const
     SuperVector<S> mask = (mask1 << 1)& mask2;
 
     DEBUG_PRINTF("buf[0] = %02hhx, buf[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
+    bool partial_match = (check_partial && ((buf[0] & casechar) == c2) && ((buf[-1] & casechar) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
     if (partial_match) {
         mask = mask | (SuperVector<S>::Ones() >> (S-1));
@@ -105,7 +107,7 @@ const u8 *rvermicelliDoubleBlock(SuperVector<S> const data, SuperVector<S> const
     return last_non_zero_match<S>(buf, mask, len);
 }
 
-template <uint16_t S>
+template <uint16_t S, bool check_partial>
 static really_inline
 const u8 *vermicelliDoubleMaskedBlock(SuperVector<S> const data, SuperVector<S> const chars1, SuperVector<S> const chars2,
                                       SuperVector<S> const mask1, SuperVector<S> const mask2,
@@ -116,9 +118,11 @@ const u8 *vermicelliDoubleMaskedBlock(SuperVector<S> const data, SuperVector<S> 
     SuperVector<S> mask = v1 & (v2 >> 1);
 
     DEBUG_PRINTF("rv[0] = %02hhx, rv[-1] = %02hhx\n", buf[0], buf[-1]);
-    bool partial_match = (((buf[0] & m1) == c2) && ((buf[-1] & m2) == c1));
+    bool partial_match = (check_partial && ((buf[0] & m2) == c2) && ((buf[-1] & m1) == c1));
     DEBUG_PRINTF("partial = %d\n", partial_match);
-    if (partial_match) return buf - 1;
+    if (partial_match) {
+        mask = mask | ((SuperVector<S>::Ones() >> (S-1)) << (S-1));
+    }
 
     return first_non_zero_match<S>(buf, mask, len);
 }

--- a/unit/hyperscan/allocators.cpp
+++ b/unit/hyperscan/allocators.cpp
@@ -99,7 +99,7 @@ TEST(CustomAllocator, TwoAlignedCompileError) {
     ASSERT_NE(nullptr, compile_err);
     EXPECT_STREQ("Allocator returned misaligned memory.", compile_err->message);
     hs_free_compile_error(compile_err);
-    hs_set_database_allocator(nullptr, nullptr);
+    hs_set_misc_allocator(nullptr, nullptr);
 }
 
 TEST(CustomAllocator, TwoAlignedDatabaseInfo) {

--- a/unit/internal/shuffle.cpp
+++ b/unit/internal/shuffle.cpp
@@ -36,6 +36,9 @@
 #include"util/supervector/supervector.hpp"
 #include "nfa/limex_shuffle.hpp"
 
+#ifdef setbit
+#undef setbit
+#endif
 
 namespace {
 

--- a/unit/internal/simd_utils.cpp
+++ b/unit/internal/simd_utils.cpp
@@ -33,6 +33,10 @@
 #include "util/bytecode_ptr.h"
 #include "util/simd_utils.h"
 
+#ifdef setbit
+#undef setbit
+#endif
+
 using namespace std;
 using namespace ue2;
 


### PR DESCRIPTION
Closes https://github.com/VectorCamp/vectorscan/issues/91
Closes https://github.com/VectorCamp/vectorscan/issues/100

There were lots of problems in small ranges, I tried to fix them all by carefully reading the code.

Also adopt all changes we made to make it compile like setbit unsetting in tests.

We tested with all combinations HS_OPTIMIZE/DEBUG/HASWELL/SSE4.2/ARM/ASAN/MSAN/NOSANITIZERS. Haven't tested AVX512, PPC and SVE2

Resubmitting to a develop branch. I'll take a look at AVX512 failure from FAT_RUNTIME