### PR TITLE
CMake: Use non-deprecated method for finding python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,10 @@ include_directories(SYSTEM include)
 include (${CMAKE_MODULE_PATH}/boost.cmake)
 
 # -- make this work? set(python_ADDITIONAL_VERSIONS 2.7 2.6)
-find_package(PythonInterp)
+find_package (Python COMPONENTS Interpreter Development)
 find_program(RAGEL ragel)
 
-if(PYTHONINTERP_FOUND)
-    set(PYTHON ${PYTHON_EXECUTABLE})
-else()
+if(NOT Python_Interpreter_FOUND)
     message(FATAL_ERROR "No python interpreter found")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,7 @@ include_directories(SYSTEM include)
 
 include (${CMAKE_MODULE_PATH}/boost.cmake)
 
-# -- make this work? set(python_ADDITIONAL_VERSIONS 2.7 2.6)
-find_package (Python COMPONENTS Interpreter Development)
+find_package(Python COMPONENTS Interpreter)
 find_program(RAGEL ragel)
 
 if(NOT Python_Interpreter_FOUND)

--- a/cmake/formatdate.py
+++ b/cmake/formatdate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 import os
 import sys
 import datetime

--- a/tools/fuzz/aristocrats.py
+++ b/tools/fuzz/aristocrats.py
@@ -33,13 +33,13 @@ if len(args) != 0:
     parser.error("incorrect number of arguments")
 
 if (options.full):
-    crange = range(0,256)
+    crange = list(range(0,256))
     crange.remove(ord('\n'))
 else:
-    crange = range(32, 127)
+    crange = list(range(32, 127))
 
-for i in xrange(0, options.count):
+for i in range(0, options.count):
     len = randint(1, options.depth)
-    s = [ chr(choice(crange)) for x in xrange(len) ]
+    s = [ chr(choice(crange)) for x in range(len) ]
     line = str(i) + ":/" + "".join(s) + "/" + generateRandomOptions()
-    print line
+    print(line)

--- a/tools/fuzz/completocrats.py
+++ b/tools/fuzz/completocrats.py
@@ -23,17 +23,17 @@ if len(args) != 0:
     parser.error("incorrect number of arguments")
 
 if (options.full):
-    crange = range(0,256)
+    crange = list(range(0,256))
     crange.remove(ord('\n'))
 elif (options.limited):
     crange = [ ord(c) for c in LIMITED_ALPHABET ]
 else:
-    crange = range(32, 127)
+    crange = list(range(32, 127))
 
 srange = [ chr(c) for c in crange ]
 
 i = 0
 for x in product(srange, repeat = options.depth):
     line = str(i) + ":/" + "".join(x) + "/"
-    print line
+    print(line)
     i += 1

--- a/tools/fuzz/heuristocrats.py
+++ b/tools/fuzz/heuristocrats.py
@@ -9,7 +9,7 @@ import sys
 def chooseLeafWidth(nChildren):
     width = randint(1, 5)
     width = min(width, nChildren-1)
-    s = sample(range(1, nChildren), width)
+    s = sample(list(range(1, nChildren)), width)
     s.sort()
     s = [0] + s + [nChildren]
     v = [ s[i+1] - s[i] for i in range(0, len(s)-1) if s[i+1] != s[i] ]
@@ -73,7 +73,7 @@ def generateCharClass(nChildren, atTop = False):
     else:
         nChars = randint(2,4)
 
-    for i in xrange(nChars):
+    for i in range(nChars):
         s += generateChar(1)
     return "[" + s + "]"
 
@@ -247,13 +247,13 @@ parser.add_option("-H", "--hybrid",
 if len(args) != 0:
     parser.error("incorrect number of arguments")
 
-alphabet = range(ord('a'), ord('a') + options.alphabet)
+alphabet = list(range(ord('a'), ord('a') + options.alphabet))
 if options.nocase:
-    alphabet += range(ord('A'), ord('A') + options.alphabet)
+    alphabet += list(range(ord('A'), ord('A') + options.alphabet))
     
-for i in xrange(0, options.count):
-    print "%08d:/%s/%s%s" % (i, generateRE(randint(1, options.depth), atTop = True), generateRandomOptions(), generateRandomExtParam(options.depth, options.extparam))
+for i in range(0, options.count):
+    print("%08d:/%s/%s%s" % (i, generateRE(randint(1, options.depth), atTop = True), generateRandomOptions(), generateRandomExtParam(options.depth, options.extparam)))
 
 if options.logical:
-    for i in xrange(options.count, options.count + 3000):
-        print "%08d:/%s/C" % (i, generateCombination(randint(1, options.depth), atTop = True))
+    for i in range(options.count, options.count + 3000):
+        print("%08d:/%s/C" % (i, generateCombination(randint(1, options.depth), atTop = True)))

--- a/tools/hsbench/scripts/gutenbergCorpus.py
+++ b/tools/hsbench/scripts/gutenbergCorpus.py
@@ -16,7 +16,7 @@ def addBlocks(builder, block_size, stream_size, text_id, text):
     global stream_id
     global stream_bytes
 
-    print "text", text_id, "len", len(text)
+    print("text", text_id, "len", len(text))
     i = 0
     while i < len(text):
         chunk = text[i:min(len(text), i + block_size)]
@@ -26,11 +26,11 @@ def addBlocks(builder, block_size, stream_size, text_id, text):
         if stream_bytes >= stream_size:
             stream_id += 1
             stream_bytes = 0
-    print "Text", text_id, ": added", i/block_size, "blocks of", block_size, "bytes."
+    print("Text", text_id, ": added", i/block_size, "blocks of", block_size, "bytes.")
 
 def buildCorpus(outFN, block_size, stream_size, text_ids):
     if len(text_ids) == 0:
-        print >>sys.stderr, "Must provide at least one input ID"
+        print("Must provide at least one input ID", file=sys.stderr)
         sys.exit(0)
 
     builder = CorpusBuilder(outFN)
@@ -48,12 +48,12 @@ def buildCorpus(outFN, block_size, stream_size, text_ids):
 
     builder.finish()
 
-    print "Total:", total_bytes, "bytes."
+    print("Total:", total_bytes, "bytes.")
 
 def usage(exeName):
     errmsg = "Usage: %s -o <output file> -b <block size> -s <max stream size> <gutenberg text id>..."
     errmsg = errmsg % exeName
-    print >> sys.stderr, errmsg
+    print(errmsg, file=sys.stderr)
     sys.exit(-1)
 
 if __name__ == '__main__':
@@ -62,7 +62,7 @@ if __name__ == '__main__':
 
     requiredKeys = [ '-o', '-b', '-s' ]
     for k in requiredKeys:
-        if not opts.has_key(k):
+        if k not in opts:
             usage(os.path.basename(sys.argv[0]))
 
     buildCorpus(opts['-o'], int(opts['-b']), int(opts['-s']), args)

--- a/tools/hsbench/scripts/linebasedCorpus.py
+++ b/tools/hsbench/scripts/linebasedCorpus.py
@@ -15,13 +15,13 @@ def lineCorpus(inFN, outFN):
     '''
 
     if not os.path.exists(inFN):
-        print >> sys.stderr, "Input file '%s' does not exist. Exiting." % outFN
+        print("Input file '%s' does not exist. Exiting." % outFN, file=sys.stderr)
         sys.exit(-1)
 
     lines = open(inFN).readlines()
 
     if len(lines) == 0:
-        print >> sys.stderr, "Input file contained no lines. Exiting."
+        print("Input file contained no lines. Exiting.", file=sys.stderr)
         sys.exit(0)
 
     builder = CorpusBuilder(outFN)
@@ -37,7 +37,7 @@ def lineCorpus(inFN, outFN):
 def usage(exeName):
     errmsg = "Usage: %s -i <input file> -o <output file>"
     errmsg = errmsg % exeName
-    print >> sys.stderr, errmsg
+    print(errmsg, file=sys.stderr)
     sys.exit(-1)
 
 if __name__ == '__main__':
@@ -46,7 +46,7 @@ if __name__ == '__main__':
 
     requiredKeys = [ '-i', '-o' ]
     for k in requiredKeys:
-        if not args.has_key(k):
+        if k not in args:
             usage(os.path.basename(sys.argv[0]))
 
     fnArgs = tuple([args[k] for k in requiredKeys])

--- a/tools/hsbench/scripts/pcapCorpus.py
+++ b/tools/hsbench/scripts/pcapCorpus.py
@@ -35,7 +35,7 @@ cur_stream_id = 0
 def usage(exeName) :
     errmsg = "Usage: %s -i <pcap-file> -o <sqlite-file>"
     errmsg = errmsg % exeName
-    print >> sys.stderr, errmsg
+    print(errmsg, file=sys.stderr)
     sys.exit(-1)
 
 class FiveTuple(object):
@@ -208,7 +208,7 @@ def enchunk_pcap(pcapFN, sqliteFN):
     """
 
     if not os.path.exists(pcapFN):
-        print >> sys.stderr, "Input file '%s' does not exist. Exiting." % pcapFN
+        print("Input file '%s' does not exist. Exiting." % pcapFN, file=sys.stderr)
         sys.exit(-1)
 
     builder = CorpusBuilder(sqliteFN)
@@ -225,7 +225,7 @@ def enchunk_pcap(pcapFN, sqliteFN):
 
     while not done:
         try:
-            ts, packet = pcap_ref.next()
+            ts, packet = next(pcap_ref)
         except:
             break
 
@@ -285,10 +285,10 @@ def enchunk_pcap(pcapFN, sqliteFN):
     # Having read the contents of the pcap, we fill the database with any
     # remaining TCP and UDP segments
     #
-    for tcp_stream in tcp_streams.itervalues():
+    for tcp_stream in tcp_streams.values():
         db_add_tcp_stream_segments(builder, tcp_stream)
 
-    for udp_stream in udp_streams.itervalues():
+    for udp_stream in udp_streams.values():
         db_add_udp_stream_segments(builder, udp_stream)
 
     #
@@ -303,7 +303,7 @@ if __name__ == '__main__' :
 
     requiredKeys = [ '-i', '-o']
     for k in requiredKeys :
-        if not args.has_key(k) :
+        if k not in args :
             usage(os.path.basename(sys.argv[0]))
 
     fnArgs = tuple([ args[k] for k in requiredKeys ])


### PR DESCRIPTION
Building vectorscan did not work out of the box for me on MacOS 12.3.1 on M1 because CMake could not find the Python installed via homebrew.
After doing some digging I've found that the method currently used to find Python is deprecated ([CMake Manual](https://cmake.org/cmake/help/latest/module/FindPythonInterp.html)). I've adapted CMakeLists.txt to the method currently recommended.

Tested on Ubuntu 22.04 and macOS