### PR TITLE
when compiling with mingw64, use __mingw_aligned_malloc() and __mingw_aligned_free()

### DIFF
--- a/src/util/alloc.cpp
+++ b/src/util/alloc.cpp
@@ -47,7 +47,15 @@ namespace ue2 {
 #endif
 
 /* get us a posix_memalign from somewhere */
-#if !defined(HAVE_POSIX_MEMALIGN)
+#if defined(__MINGW32__) || defined(__MINGW64__)
+  #include <stdlib.h>
+  #include <intrin.h>
+  #include <malloc.h>
+  #include <windows.h>
+
+  #define posix_memalign(A, B, C) ((*A = (void *)__mingw_aligned_malloc(C, B)) == nullptr)
+
+#elif !defined(HAVE_POSIX_MEMALIGN)
 # if defined(HAVE_MEMALIGN)
     #define posix_memalign(A, B, C) ((*A = (void *)memalign(B, C)) == nullptr)
 # elif defined(HAVE__ALIGNED_MALLOC)
@@ -77,7 +85,11 @@ void aligned_free_internal(void *ptr) {
         return;
     }
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+    __mingw_aligned_free(ptr);
+#else
     free(ptr);
+#endif
 }
 
 /** \brief 64-byte aligned, zeroed malloc.


### PR DESCRIPTION
use __mingw_aligned_malloc in lieu of posix_memalign and __mingw_aligned_free in aligned_free_internal

With this change, I can successfully compile the library, and simplegrep.exe, using mingw64 (after setting env vars to point to the mingw64 toolchain) using the following steps (I'm cross-compiling from OSX, so the steps may be different / simpler on a native setup) and assuming my target PREFIX is /opt/mingw64. Note that the -DBUILD_AVX2=1 was necessary because otherwise AVX2 detection failed, and -DCMAKE_BUILD_TYPE=DEBUG fails for reasons I did not bother to investigate

```
cmake .. -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_C_INCLUDE_PATH=/opt/mingw64/include -DC_INCLUDE_PATH=/opt/mingw64/include -DFAT_RUNTIME=off -DCMAKE_INSTALL_NAME_TOOL= -DBUILD_AVX2=1 -DCMAKE_BUILD_TYPE=RELEASE

# remove -search_paths_first flag which will cause minGW's gcc to error. probably this should be a separate issue and fix, but here's the quick & dirty workaround
find . -name 'link.txt' -exec sed -i.bak 's#-Wl,-search_paths_first ##g' {} \;

# build as static binary to remove dependency on non-standard DLLs (and strip symbols, though that's probably not necessary)
find . -name 'link.txt' -exec sed -i.bak 's#../lib/libhs.a#../lib/libhs.a -static -Wl,--strip-all#g' {} \;

# build simplegrep.exe
make -C examples simplegrep
```