### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vectorscan (5.4.8-3) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Fri, 16 Sep 2022 09:27:31 -0000
+
 vectorscan (5.4.8-2) unstable; urgency=medium
 
   * Remove constraints unnecessary since buster (oldstable):
@@ -7,7 +13,7 @@ vectorscan (5.4.8-2) unstable; urgency=medium
 
 vectorscan (5.4.8-1) unstable; urgency=medium
 
-  * New upstream release 
+  * New upstream release
 
  -- Konstantinos Margaritis <markos@debian.org>  Tue, 13 Sep 2022 16:38:56 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
 vectorscan (5.4.8-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Bump debhelper from old 12 to 13.
+    + debian/rules: Drop --fail-missing argument to dh_missing, which is now the
+      default.
 
  -- Debian Janitor <janitor@jelmer.uk>  Fri, 16 Sep 2022 09:27:31 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vectorscan
 Priority: optional
 Maintainer: Konstantinos Margaritis <markos@debian.org>
 Build-Depends: cmake,
-               debhelper-compat (= 12),
+               debhelper-compat (= 13),
                libboost-dev,
                libpcap-dev,
                pkg-config,

--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,3 @@ override_dh_auto_configure:
 		-DBUILD_STATIC_AND_SHARED=1 \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		${DEB_CMAKE_FLAGS}
-
-override_dh_missing:
-	dh_missing --fail-missing


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/vectorscan/2536fcea-f973-4c40-a8af-1966b73b95fe.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/2536fcea-f973-4c40-a8af-1966b73b95fe/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/2536fcea-f973-4c40-a8af-1966b73b95fe/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/2536fcea-f973-4c40-a8af-1966b73b95fe/diffoscope)).
