### PR TITLE
prefix assume_aligned to avoid clash with std::assume_aligned in c++20

### DIFF
--- a/src/util/arch/common/simd_utils.h
+++ b/src/util/arch/common/simd_utils.h
@@ -254,7 +254,7 @@ static really_inline m256 loadu2x128(const void *ptr) {
 // aligned store
 static really_inline void store256(void *ptr, m256 a) {
     assert(ISALIGNED_N(ptr, alignof(m256)));
-    ptr = assume_aligned(ptr, 16);
+    ptr = vectorscan_assume_aligned(ptr, 16);
     *(m256 *)ptr = a;
 }
 
@@ -486,7 +486,7 @@ static really_inline m384 load384(const void *ptr) {
 // aligned store
 static really_inline void store384(void *ptr, m384 a) {
     assert(ISALIGNED_16(ptr));
-    ptr = assume_aligned(ptr, 16);
+    ptr = vectorscan_assume_aligned(ptr, 16);
     *(m384 *)ptr = a;
 }
 

--- a/src/util/arch/x86/simd_utils.h
+++ b/src/util/arch/x86/simd_utils.h
@@ -278,14 +278,14 @@ static really_inline m128 andnot128(m128 a, m128 b) {
 // aligned load
 static really_inline m128 load128(const void *ptr) {
     assert(ISALIGNED_N(ptr, alignof(m128)));
-    ptr = assume_aligned(ptr, 16);
+    ptr = vectorscan_assume_aligned(ptr, 16);
     return _mm_load_si128((const m128 *)ptr);
 }
 
 // aligned store
 static really_inline void store128(void *ptr, m128 a) {
     assert(ISALIGNED_N(ptr, alignof(m128)));
-    ptr = assume_aligned(ptr, 16);
+    ptr = vectorscan_assume_aligned(ptr, 16);
     *(m128 *)ptr = a;
 }
 

--- a/src/util/simd_utils.h
+++ b/src/util/simd_utils.h
@@ -40,17 +40,17 @@
 // it's available. Note that we need to handle C or C++ compilation.
 #ifdef __cplusplus
 #  ifdef HAVE_CXX_BUILTIN_ASSUME_ALIGNED
-#    define assume_aligned(x, y) __builtin_assume_aligned((x), (y))
+#    define vectorscan_assume_aligned(x, y) __builtin_assume_aligned((x), (y))
 #  endif
 #else
 #  ifdef HAVE_CC_BUILTIN_ASSUME_ALIGNED
-#    define assume_aligned(x, y) __builtin_assume_aligned((x), (y))
+#    define vectorscan_assume_aligned(x, y) __builtin_assume_aligned((x), (y))
 #  endif
 #endif
 
 // Fallback to identity case.
-#ifndef assume_aligned
-#define assume_aligned(x, y) (x)
+#ifndef vectorscan_assume_aligned
+#define vectorscan_assume_aligned(x, y) (x)
 #endif
 
 #ifdef __cplusplus

--- a/src/util/supervector/arch/arm/impl.cpp
+++ b/src/util/supervector/arch/arm/impl.cpp
@@ -518,7 +518,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::load(void const *ptr)
 {
     assert(ISALIGNED_N(ptr, alignof(SuperVector::size)));
-    ptr = assume_aligned(ptr, SuperVector::size);
+    ptr = vectorscan_assume_aligned(ptr, SuperVector::size);
     return {vld1q_s32((const int32_t *)ptr)};
 }
 

--- a/src/util/supervector/arch/x86/impl.cpp
+++ b/src/util/supervector/arch/x86/impl.cpp
@@ -515,7 +515,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::load(void const *ptr)
 {
     assert(ISALIGNED_N(ptr, alignof(SuperVector::size)));
-    ptr = assume_aligned(ptr, SuperVector::size);
+    ptr = vectorscan_assume_aligned(ptr, SuperVector::size);
     return _mm_load_si128((const m128 *)ptr);
 }
 
@@ -1119,7 +1119,7 @@ template <>
 really_inline SuperVector<32> SuperVector<32>::load(void const *ptr)
 {
     assert(ISALIGNED_N(ptr, alignof(SuperVector::size)));
-    ptr = assume_aligned(ptr, SuperVector::size);
+    ptr = vectorscan_assume_aligned(ptr, SuperVector::size);
     return {_mm256_load_si256((const m256 *)ptr)};
 }
 
@@ -1769,7 +1769,7 @@ template <>
 really_inline SuperVector<64> SuperVector<64>::load(void const *ptr)
 {
     assert(ISALIGNED_N(ptr, alignof(SuperVector::size)));
-    ptr = assume_aligned(ptr, SuperVector::size);
+    ptr = vectorscan_assume_aligned(ptr, SuperVector::size);
     return {_mm512_load_si512((const m512 *)ptr)};
 }
 

--- a/src/util/supervector/supervector.hpp
+++ b/src/util/supervector/supervector.hpp
@@ -76,17 +76,17 @@ using Z_TYPE = u32;
 // it's available. Note that we need to handle C or C++ compilation.
 #ifdef __cplusplus
 #  ifdef HAVE_CXX_BUILTIN_ASSUME_ALIGNED
-#    define assume_aligned(x, y) __builtin_assume_aligned((x), (y))
+#    define vectorscan_assume_aligned(x, y) __builtin_assume_aligned((x), (y))
 #  endif
 #else
 #  ifdef HAVE_CC_BUILTIN_ASSUME_ALIGNED
-#    define assume_aligned(x, y) __builtin_assume_aligned((x), (y))
+#    define vectorscan_assume_aligned(x, y) __builtin_assume_aligned((x), (y))
 #  endif
 #endif
 
 // Fallback to identity case.
-#ifndef assume_aligned
-#define assume_aligned(x, y) (x)
+#ifndef vectorscan_assume_aligned
+#define vectorscan_assume_aligned(x, y) (x)
 #endif
 
 template <uint16_t SIZE>


### PR DESCRIPTION
As discussed in https://github.com/VectorCamp/vectorscan/issues/134