### PR TITLE
Set Ragel.rl char type to unsigned, #135

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,7 +544,6 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_CXX_FLAGS}")
 
-add_subdirectory(util)
 add_subdirectory(doc/dev-reference)
 
 # PCRE check, we have a fixed requirement for PCRE to use Chimera
@@ -603,6 +602,8 @@ set_source_files_properties(
         COMPILE_FLAGS "${RAGEL_C_FLAGS}")
 
 ragelmaker(src/parser/control_verbs.rl)
+
+add_subdirectory(util)
 
 SET(hs_HEADERS
     src/hs.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,7 +588,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
 endif()
 
-set(RAGEL_C_FLAGS "-Wno-unused")
+set(RAGEL_C_FLAGS "-Wno-unused -funsigned-char")
 
 set_source_files_properties(
     ${CMAKE_BINARY_DIR}/src/parser/Parser.cpp

--- a/cmake/ragel.cmake
+++ b/cmake/ragel.cmake
@@ -7,7 +7,7 @@ function(ragelmaker src_rl)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${src_dir}/${src_file}.cpp
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${src_dir}
-        COMMAND ${RAGEL} ${CMAKE_CURRENT_SOURCE_DIR}/${src_rl} -o ${rl_out -G0}
+        COMMAND ${RAGEL} ${CMAKE_CURRENT_SOURCE_DIR}/${src_rl} -o ${rl_out} -G0
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${src_rl}
         )
     add_custom_target(ragel_${src_file} DEPENDS ${rl_out})

--- a/cmake/ragel.cmake
+++ b/cmake/ragel.cmake
@@ -7,7 +7,7 @@ function(ragelmaker src_rl)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${src_dir}/${src_file}.cpp
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${src_dir}
-        COMMAND ${RAGEL} ${CMAKE_CURRENT_SOURCE_DIR}/${src_rl} -o ${rl_out}
+        COMMAND ${RAGEL} ${CMAKE_CURRENT_SOURCE_DIR}/${src_rl} -o ${rl_out -G0}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${src_rl}
         )
     add_custom_target(ragel_${src_file} DEPENDS ${rl_out})

--- a/src/fdr/teddy_runtime_common.h
+++ b/src/fdr/teddy_runtime_common.h
@@ -348,7 +348,7 @@ static really_inline
 m512 vectoredLoad512(m512 *p_mask, const u8 *ptr, const size_t start_offset,
                      const u8 *lo, const u8 *hi, const u8 *hbuf, size_t hlen,
                      const u32 nMasks) {
-    m512 val;
+    m512 val = zeroes512();
 
     uintptr_t copy_start;
     uintptr_t copy_len;

--- a/src/hs.h
+++ b/src/hs.h
@@ -43,7 +43,7 @@
 
 #define HS_MAJOR      5
 #define HS_MINOR      4
-#define HS_PATCH      0
+#define HS_PATCH      9
 
 #include "hs_compile.h"
 #include "hs_runtime.h"

--- a/src/parser/Parser.rl
+++ b/src/parser/Parser.rl
@@ -272,6 +272,7 @@ unichar readUtf8CodePoint4c(const char *s) {
 
 %%{
     machine regex;
+    alphtype unsigned char;
 
     action throwUnsupportedEscape {
         ostringstream str;

--- a/src/parser/control_verbs.rl
+++ b/src/parser/control_verbs.rl
@@ -54,6 +54,7 @@ const char *read_control_verbs(const char *ptr, const char *end, size_t start,
 
     %%{
         machine ControlVerbs;
+        alphtype unsigned char;
 
         # Verbs that we recognise but do not support.
         unhandledVerbs = '(*' (

--- a/tools/hscollider/ColliderCorporaParser.rl
+++ b/tools/hscollider/ColliderCorporaParser.rl
@@ -57,6 +57,7 @@ char unhex(const char *start, UNUSED const char *end) {
 
 %%{
     machine FileCorporaParser;
+    alphtype unsigned char;
 
     action accumulateNum {
         num = (num * 10) + (fc - '0');

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -6,8 +6,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS} ${HS_CXX_FLAGS}")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
     ${PROJECT_SOURCE_DIR})
 
+message("RAGEL_C_FLAGS" ${RAGEL_C_FLAGS})
+
 set_source_files_properties(
-    ${CMAKE_BINARY_DIR}/tools/ExpressionParser.cpp
+    ${CMAKE_BINARY_DIR}/util/ExpressionParser.cpp
     PROPERTIES
     COMPILE_FLAGS "${RAGEL_C_FLAGS}")
 

--- a/util/ExpressionParser.rl
+++ b/util/ExpressionParser.rl
@@ -55,6 +55,7 @@ enum ParamKey {
 
 %%{
     machine ExpressionParser;
+    alphtype unsigned char;
 
     action accumulateNum {
         num = (num * 10) + (fc - '0');


### PR DESCRIPTION
Thanks to @dmbaggett for suggesting the fix, we can confirm that this fixes #135 for Aarch64.