### PR TITLE
Fix compilation with libcxx 16

### DIFF
--- a/src/rose/rose_build_program.cpp
+++ b/src/rose/rose_build_program.cpp
@@ -204,6 +204,15 @@ void RoseProgram::add_block(RoseProgram &&block) {
                 make_move_iterator(block.prog.end()));
 }
 
+template<class Iter>
+void RoseProgram::replace(Iter it, std::unique_ptr<RoseInstruction> ri) {
+    assert(!prog.empty());
+
+    const RoseInstruction *old_ptr = it->get();
+    *it = move(ri);
+    update_targets(prog.begin(), prog.end(), old_ptr, it->get());
+}
+
 bytecode_ptr<char> writeProgram(RoseEngineBlob &blob,
                                 const RoseProgram &program) {
     u32 total_len = 0;

--- a/src/rose/rose_build_program.h
+++ b/src/rose/rose_build_program.h
@@ -124,13 +124,7 @@ public:
      * \brief Replace the instruction pointed to by the given iterator.
      */
     template<class Iter>
-    void replace(Iter it, std::unique_ptr<RoseInstruction> ri) {
-        assert(!prog.empty());
-
-        const RoseInstruction *old_ptr = it->get();
-        *it = move(ri);
-        update_targets(prog.begin(), prog.end(), old_ptr, it->get());
-    }
+    void replace(Iter it, std::unique_ptr<RoseInstruction> ri);
 };
 
 bytecode_ptr<char> writeProgram(RoseEngineBlob &blob,


### PR DESCRIPTION
After upgrading our (ClickHouse's) libcxx from 15 to 16, the compiler started to complain about usage of an incomplete type "RoseInstruction" in this (header) function:

```cpp
  void RoseProgram::replace(Iter it, std::unique_ptr<RoseInstruction> ri) {
    ...
```

The reason is that libcxx 16 is the first version which implements C++23 constexpr std::unique_ptr (P2273R3, see (*)). RoseProgram::replace() happens to be be const-evaluatable and the compiler tries to run std::unique_ptr's ctor + dtor. This fails because at this point RoseInstruction isn't defined yet.

There are two ways of fixing this:
1. Include rose_build_instruction.h (which contains RoseInstruction) into rose_build_program.h. Disadvantage: The new include will propagate transitively into all callers.
2. Move the function implementation into the source file which sees RoseInstruction's definition already. Disadvantage: Template instantiation is no longer automatic, instead there must be either a) explicit template instantiation (e.g. in rose_build_program.cpp) or b) all callers which instantiate the function must live in the same source file and do the instantiations by themselves. Fortunately, the latter is the case here, but potential future code outside rose_build_program.cpp will require ugly explicit instantiation.

(*) https://en.cppreference.com/w/cpp/23