### PR TITLE
Fix msan issues detected during upgrade to Clang 16

### DIFF
--- a/src/rose/program_runtime.c
+++ b/src/rose/program_runtime.c
@@ -959,7 +959,7 @@ m128 getData128(const struct core_info *ci, s64a offset, u32 *valid_data_mask) {
         *valid_data_mask = 0xffff;
         return loadu128(ci->buf + offset);
     }
-    ALIGN_DIRECTIVE u8 data[sizeof(m128)];
+    ALIGN_DIRECTIVE u8 data[sizeof(m128)] = { 0 };
     *valid_data_mask = getBufferDataComplex(ci, offset, data, 16);
     return *(m128 *)data;
 }

--- a/src/util/small_vector.h
+++ b/src/util/small_vector.h
@@ -29,7 +29,11 @@
 #ifndef UTIL_SMALL_VECTOR_H
 #define UTIL_SMALL_VECTOR_H
 
-#include <vector>
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+#define BUILD_WITH_MSAN
+#  endif
+#endif
 
 #include <boost/version.hpp>
 
@@ -37,8 +41,16 @@
  * We use the small_vector constructors introduced in Boost 1.61 (trac bug
  * #11866, github commit b436c91). If the Boost version is too old, we fall
  * back to using std::vector.
+ *
+ * Also with MSan boost::container::small_vector cannot be used because MSan
+ * reports some issues there, it looks similar to [1], but even adding
+ * __attribute__((no_sanitize_memory)) for ~small_vector_base() [2] is not
+ * enough since clang-16, so let's simply use std::vector under MSan.
+ *
+ *   [1]: https://github.com/google/sanitizers/issues/854
+ *   [2]: https://github.com/ClickHouse/boost/commit/229354100
  */
-#if BOOST_VERSION >= 106100
+#if !defined(BUILD_WITH_MSAN) && BOOST_VERSION >= 106100
 #  define HAVE_BOOST_CONTAINER_SMALL_VECTOR
 #endif
 
@@ -55,6 +67,8 @@ template <class T, std::size_t N,
 using small_vector = boost::container::small_vector<T, N, Allocator>;
 
 #else
+
+#include <vector>
 
 // Boost version isn't new enough, fall back to just using std::vector.
 template <class T, std::size_t N, typename Allocator = std::allocator<T>>


### PR DESCRIPTION
This PR is an amalgamation of
- https://github.com/VectorCamp/vectorscan/pull/148 and 
- https://github.com/VectorCamp/vectorscan/pull/149

Pushing them as a single PR because we (ClickHouse) can then continue [to reference](https://github.com/ClickHouse/ClickHouse/pull/49678/files/e5c4eb35e8e85f948a44730a8970e40eeb4b7f6f#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584) the upstream vectorscan repository.