### PR TITLE
Bugfix/disable fat macos arm

### DIFF
--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -24,6 +24,9 @@ int main() {
 endif ()
 
 if (ARCH_AARCH64)
+    if (APPLE)
+       set (FAT_RUNTIME OFF)
+    endif()
     set(PREV_FLAGS "${CMAKE_C_FLAGS}")
     if (BUILD_SVE2_BITPERM)
         set(CMAKE_C_FLAGS "-march=${GNUCC_ARCH} ${CMAKE_C_FLAGS}")

--- a/src/util/arch/arm/cpuid_inline.h
+++ b/src/util/arch/arm/cpuid_inline.h
@@ -30,7 +30,9 @@
 #ifndef AARCH64_CPUID_INLINE_H_
 #define AARCH64_CPUID_INLINE_H_
 
+#if defined(__linux__)
 #include <sys/auxv.h>
+#endif
 
 #include "ue2common.h"
 #include "util/arch/common/cpuid_flags.h"
@@ -40,6 +42,7 @@ int check_neon(void) {
     return 1;
 }
 
+#if defined(__linux__)
 static inline
 int check_sve(void) {
     unsigned long hwcap = getauxval(AT_HWCAP);
@@ -57,5 +60,16 @@ int check_sve2(void) {
     }
     return 0;
 }
+#else
+static inline
+int check_sve(void) {
+    return 0;
+}
+
+static inline
+int check_sve2(void) {
+    return 0;
+}
+#endif
 
 #endif // AARCH64_CPUID_INLINE_H_


### PR DESCRIPTION
FAT runtime should be disabled on MacOS builds, unfortunately Mac builds are not properly integrated into the CI yet so this was not caught.