### PR TITLE
Ubuntu 20.04 gcc does not define HWCAP2_SVE2 #180

### DIFF
--- a/src/util/arch/arm/cpuid_inline.h
+++ b/src/util/arch/arm/cpuid_inline.h
@@ -32,6 +32,11 @@
 
 #if defined(__linux__)
 #include <sys/auxv.h>
+/* This is to help fix https://github.com/envoyproxy/envoy/pull/29881
+ */
+#if !defined(HWCAP2_SVE2)
+#include <asm/hwcap.h>
+#endif
 #endif
 
 #include "ue2common.h"


### PR DESCRIPTION
Gcc on Ubuntu 20.04 does not define HWCAP2 defines, incl. HWCAP2_SVE2.
We suggest this patch to enable integration of Vectorscan on Envoyproxy on non-x86 platforms:

https://github.com/envoyproxy/envoy/pull/29881