### PR TITLE
make pkgconfig a requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include (${CMAKE_MODULE_PATH}/platform.cmake)
 include (${CMAKE_MODULE_PATH}/boost.cmake)
 include (${CMAKE_MODULE_PATH}/ragel.cmake)
 
-find_package(PkgConfig QUIET)
+find_package(PkgConfig REQUIRED)
 
 find_program(RAGEL ragel)
 


### PR DESCRIPTION
There is no reason not to use pkg-config these days, this should help the build failure with sqlite detection in #186.