### PR TITLE
Correct set_source_files_properties usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,14 +193,14 @@ endif()
 set(RAGEL_C_FLAGS "-Wno-unused -funsigned-char")
 
 set_source_files_properties(
-    ${CMAKE_BINARY_DIR}/src/parser/Parser.cpp
+    src/parser/Parser.cpp
     PROPERTIES
         COMPILE_FLAGS "${RAGEL_C_FLAGS}")
 
 ragelmaker(src/parser/Parser.rl)
 
 set_source_files_properties(
-    ${CMAKE_BINARY_DIR}/src/parser/control_verbs.cpp
+   src/parser/control_verbs.cpp
     PROPERTIES
         COMPILE_FLAGS "${RAGEL_C_FLAGS}")
 

--- a/tools/hscollider/CMakeLists.txt
+++ b/tools/hscollider/CMakeLists.txt
@@ -17,7 +17,7 @@ CHECK_FUNCTION_EXISTS(sigaction HAVE_SIGACTION)
 CHECK_FUNCTION_EXISTS(setrlimit HAVE_SETRLIMIT)
 
 set_source_files_properties(
-    ${CMAKE_CURRENT_BINARY_DIR}/ColliderCorporaParser.cpp
+    ColliderCorporaParser.cpp
     PROPERTIES
     COMPILE_FLAGS "${RAGEL_C_FLAGS} -I${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
 message("RAGEL_C_FLAGS" ${RAGEL_C_FLAGS})
 
 set_source_files_properties(
-    ${CMAKE_BINARY_DIR}/util/ExpressionParser.cpp
+    ExpressionParser.cpp
     PROPERTIES
     COMPILE_FLAGS "${RAGEL_C_FLAGS}")
 


### PR DESCRIPTION
The use of `CMAKE_BINARY_DIR` and `CMAKE_CURRENT_BINARY_DIR` when specifying files to set_source_files_properties caused problems when this project is used from another CMake project.

More specifically, these variables aren't set to the expected path, and the properties are attempted to be set for non-existant files.

This was benign before vectorscan 5.4.8 as the only properties set were warning suppression flags.

Starting with 5.4.9, `-funsigned-char` was applied to Ragel outputs using this method. The result is projects depending on Vectorscan through Cmake do not have this compile flag properly applied.