### PR TITLE
Fix missing hs_version.h header (closes #198)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
 endif()
 
 SET(hs_HEADERS
+    ${PROJECT_BINARY_DIR}/hs_version.h
     src/hs.h
     src/hs_common.h
     src/hs_compile.h


### PR DESCRIPTION
This PR adds the missing hs_version.h (issue #198) to the files to be installed