### PR TITLE
fix missing installation of static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1118,7 +1118,7 @@ else ()
     endif (ARCH_AARCH64)
 endif (NOT FAT_RUNTIME)
 
-if (NOT BUILD_SHARED_LIBS)
+if (BUILD_STATIC_LIBS)
     install(TARGETS hs_runtime DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
@@ -1150,7 +1150,7 @@ if (BUILD_STATIC_LIBS)
     add_dependencies(hs ragel_Parser)
 endif ()
 
-if (NOT BUILD_SHARED_LIBS)
+if (BUILD_STATIC_LIBS)
     install(TARGETS hs DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 


### PR DESCRIPTION
While testing building the Debian package, it became apparent that installation was not copying the static libs: libhs.a/libhs_runtime.a and package building was failing. This provides a fix for that.