### PR TITLE
Feature/refactor noodle masked loads

### DIFF
--- a/src/hwlm/noodle_engine_simd.hpp
+++ b/src/hwlm/noodle_engine_simd.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017, Intel Corporation
- * Copyright (c) 2020-2021, VectorCamp PC
+ * Copyright (c) 2020-2023, VectorCamp PC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -34,7 +34,7 @@
 
 static really_really_inline
 hwlm_error_t single_zscan(const struct noodTable *n,const u8 *d, const u8 *buf,
-		Z_TYPE z, size_t len, const struct cb_info *cbi) {
+                          Z_TYPE z, size_t len, const struct cb_info *cbi) {
     while (unlikely(z)) {
         Z_TYPE pos = JOIN(findAndClearLSB_, Z_BITS)(&z) >> Z_POSSHIFT;
         size_t matchPos = d - buf + pos;
@@ -47,125 +47,16 @@ hwlm_error_t single_zscan(const struct noodTable *n,const u8 *d, const u8 *buf,
 
 static really_really_inline
 hwlm_error_t double_zscan(const struct noodTable *n,const u8 *d, const u8 *buf,
-		Z_TYPE z, size_t len, const struct cb_info *cbi) {
+                          Z_TYPE z, size_t len, const struct cb_info *cbi) {
     while (unlikely(z)) {
         Z_TYPE pos = JOIN(findAndClearLSB_, Z_BITS)(&z) >> Z_POSSHIFT;
+        DEBUG_PRINTF("pos %u\n", pos);
         size_t matchPos = d - buf + pos - 1;
         DEBUG_PRINTF("match pos %zu\n", matchPos);
         hwlmcb_rv_t rv = final(n, buf, len, true, cbi, matchPos);
         RETURN_IF_TERMINATED(rv);
     }
     return HWLM_SUCCESS;
-}
-
-
-template<uint16_t S>
-static really_inline
-hwlm_error_t scanSingleShort(const struct noodTable *n, const u8 *buf,
-                                 SuperVector<S> caseMask, SuperVector<S> mask1,
-                                 const struct cb_info *cbi, size_t len, size_t start,
-                                 size_t end) {
-    const u8 *d = buf + start;
-    DEBUG_PRINTF("start %zu end %zu\n", start, end);
-    const size_t l = end - start;
-    DEBUG_PRINTF("l = %ld\n", l);
-    //assert(l <= 64);
-    if (!l) {
-        return HWLM_SUCCESS;
-    }
-
-    SuperVector<S> v = SuperVector<S>::Zeroes();
-    memcpy(&v.u, d, l);
-
-    typename SuperVector<S>::comparemask_type mask =
-        SINGLE_LOAD_MASK(l * SuperVector<S>::mask_width());
-    v = v & caseMask;
-    typename SuperVector<S>::comparemask_type z = mask & mask1.eqmask(v);
-    z = SuperVector<S>::iteration_mask(z);
-
-    return single_zscan(n, d, buf, z, len, cbi);
-}
-
-// The short scan routine. It is used both to scan data up to an
-// alignment boundary if needed and to finish off data that the aligned scan
-// function can't handle (due to small/unaligned chunk at end)
-template<uint16_t S>
-static really_inline
-hwlm_error_t scanSingleUnaligned(const struct noodTable *n, const u8 *buf,
-                                 SuperVector<S> caseMask, SuperVector<S> mask1,
-                                 const struct cb_info *cbi, size_t len, size_t offset,
-                                     size_t start,
-                                 size_t end) {
-    const u8 *d = buf + offset;
-    DEBUG_PRINTF("start %zu end %zu offset %zu\n", start, end, offset);
-    const size_t l = end - start;
-    DEBUG_PRINTF("l = %ld\n", l);
-    assert(l <= 64);
-    if (!l) {
-        return HWLM_SUCCESS;
-    }
-    size_t buf_off = start - offset;
-    typename SuperVector<S>::comparemask_type mask =
-        SINGLE_LOAD_MASK(l * SuperVector<S>::mask_width())
-        << (buf_off * SuperVector<S>::mask_width());
-    SuperVector<S> v = SuperVector<S>::loadu(d) & caseMask;
-    typename SuperVector<S>::comparemask_type z = mask & mask1.eqmask(v);
-    z = SuperVector<S>::iteration_mask(z);
-
-    return single_zscan(n, d, buf, z, len, cbi);
-}
-
-template<uint16_t S>
-static really_inline
-hwlm_error_t scanDoubleShort(const struct noodTable *n, const u8 *buf,
-                                 SuperVector<S> caseMask, SuperVector<S> mask1, SuperVector<S> mask2,
-                                 const struct cb_info *cbi, size_t len, size_t start, size_t end) {
-    const u8 *d = buf + start;
-    DEBUG_PRINTF("start %zu end %zu\n", start, end);
-    const size_t l = end - start;
-    assert(l <= S);
-    if (!l) {
-        return HWLM_SUCCESS;
-    }
-    SuperVector<S> v = SuperVector<S>::Zeroes();
-    memcpy(&v.u, d, l);
-    v = v & caseMask;
-
-    typename SuperVector<S>::comparemask_type mask =
-        DOUBLE_LOAD_MASK(l * SuperVector<S>::mask_width());
-    typename SuperVector<S>::comparemask_type z1 = mask1.eqmask(v);
-    typename SuperVector<S>::comparemask_type z2 = mask2.eqmask(v);
-    typename SuperVector<S>::comparemask_type z =
-        mask & (z1 << (SuperVector<S>::mask_width())) & z2;
-    z = SuperVector<S>::iteration_mask(z);
-
-    return double_zscan(n, d, buf, z, len, cbi);
-}
-
-template<uint16_t S>
-static really_inline
-hwlm_error_t scanDoubleUnaligned(const struct noodTable *n, const u8 *buf,
-                                 SuperVector<S> caseMask, SuperVector<S> mask1, SuperVector<S> mask2,
-                                 const struct cb_info *cbi, size_t len, size_t offset, size_t start, size_t end) {
-    const u8 *d = buf + offset;
-    DEBUG_PRINTF("start %zu end %zu offset %zu\n", start, end, offset);
-    const size_t l = end - start;
-    assert(l <= S);
-    if (!l) {
-        return HWLM_SUCCESS;
-    }
-    SuperVector<S> v = SuperVector<S>::loadu(d) & caseMask;
-    size_t buf_off = start - offset;
-    typename SuperVector<S>::comparemask_type mask =
-        DOUBLE_LOAD_MASK(l * SuperVector<S>::mask_width())
-        << (buf_off * SuperVector<S>::mask_width());
-    typename SuperVector<S>::comparemask_type z1 = mask1.eqmask(v);
-    typename SuperVector<S>::comparemask_type z2 = mask2.eqmask(v);
-    typename SuperVector<S>::comparemask_type z =
-        mask & (z1 << SuperVector<S>::mask_width()) & z2;
-    z = SuperVector<S>::iteration_mask(z);
-
-    return double_zscan(n, d, buf, z, len, cbi);
 }
 
 template <uint16_t S>
@@ -175,32 +66,36 @@ hwlm_error_t scanSingleMain(const struct noodTable *n, const u8 *buf,
                             SuperVector<S> caseMask, SuperVector<S> mask1,
                             const struct cb_info *cbi) {
     size_t start = offset + n->msk_len - 1;
-    size_t end = len;
 
     const u8 *d = buf + start;
-    const u8 *e = buf + end;
-    DEBUG_PRINTF("start %p end %p \n", d, e);
-    assert(d < e);
-    if (e - d < S) {
-      return scanSingleShort(n, buf, caseMask, mask1, cbi, len, start, end);
-    }
-    if (d + S <= e) {
-        // peel off first part to cacheline boundary
-        const u8 *d1 = ROUNDUP_PTR(d, S);
-        DEBUG_PRINTF("until aligned %p \n", d1);
-        if (scanSingleUnaligned(n, buf, caseMask, mask1, cbi, len, start, start, d1 - buf) == HWLM_TERMINATED) {
-            return HWLM_TERMINATED;
+    const u8 *buf_end = buf + len;
+    assert(d < buf_end);
+
+    DEBUG_PRINTF("noodle %p start %zu len %zu\n", buf, start, buf_end - buf);
+    DEBUG_PRINTF("b %s\n", buf);
+    DEBUG_PRINTF("start %p end %p \n", d, buf_end);
+
+    __builtin_prefetch(d + 16*64);
+    assert(d < buf_end);
+    if (d + S <= buf_end) {
+        // Reach vector aligned boundaries
+        DEBUG_PRINTF("until aligned %p \n", ROUNDUP_PTR(d, S));
+        if (!ISALIGNED_N(d, S)) {
+            const u8 *d1 = ROUNDUP_PTR(d, S);
+            DEBUG_PRINTF("d1 - d: %ld \n", d1 - d);
+            size_t l = d1 - d;
+            SuperVector<S> chars = SuperVector<S>::loadu(d) & caseMask;
+            typename SuperVector<S>::comparemask_type mask = SINGLE_LOAD_MASK(l * SuperVector<S>::mask_width());
+            typename SuperVector<S>::comparemask_type z = mask & mask1.eqmask(chars);
+
+            hwlm_error_t rv = single_zscan(n, d, buf, z, len, cbi);
+            RETURN_IF_TERMINATED(rv);
+            d = d1;
         }
-        d = d1;
 
-        size_t loops = (end - (d - buf)) / S;
-        DEBUG_PRINTF("loops %ld \n", loops);
-
-        for (size_t i = 0; i < loops; i++, d+= S) {
+        while(d + S <= buf_end) {
+            __builtin_prefetch(d + 16*64);
             DEBUG_PRINTF("d %p \n", d);
-            const u8 *base = ROUNDUP_PTR(d, 64);
-            // On large packet buffers, this prefetch appears to get us about 2%.
-            __builtin_prefetch(base + 256);
 
             SuperVector<S> v = SuperVector<S>::load(d) & caseMask;
             typename SuperVector<S>::comparemask_type z = mask1.eqmask(v);
@@ -208,17 +103,23 @@ hwlm_error_t scanSingleMain(const struct noodTable *n, const u8 *buf,
 
             hwlm_error_t rv = single_zscan(n, d, buf, z, len, cbi);
             RETURN_IF_TERMINATED(rv);
+            d += S;
         }
     }
 
-    DEBUG_PRINTF("d %p e %p \n", d, e);
+    DEBUG_PRINTF("d %p e %p \n", d, buf_end);
     // finish off tail
-    size_t s2End = ROUNDDOWN_PTR(e, S) - buf;
-    if (s2End == end) {
-      return HWLM_SUCCESS;
+
+    if (d != buf_end) {
+        SuperVector<S> chars = SuperVector<S>::loadu(d) & caseMask;
+        size_t l = buf_end - d;
+        typename SuperVector<S>::comparemask_type mask = SINGLE_LOAD_MASK(l * SuperVector<S>::mask_width());
+        typename SuperVector<S>::comparemask_type z = mask & mask1.eqmask(chars);
+        hwlm_error_t rv = single_zscan(n, d, buf, z, len, cbi);
+        RETURN_IF_TERMINATED(rv);
     }
 
-    return scanSingleUnaligned(n, buf, caseMask, mask1, cbi, len, end - S, s2End, len);
+    return HWLM_SUCCESS;
 }
 
 template <uint16_t S>
@@ -227,66 +128,84 @@ hwlm_error_t scanDoubleMain(const struct noodTable *n, const u8 *buf,
                             size_t len, size_t offset,
                             SuperVector<S> caseMask, SuperVector<S> mask1, SuperVector<S> mask2,
                             const struct cb_info *cbi) {
-    // we stop scanning for the key-fragment when the rest of the key can't
-    // possibly fit in the remaining buffer
     size_t end = len - n->key_offset + 2;
-
     size_t start = offset + n->msk_len - n->key_offset;
+
+    const u8 *d = buf + start;
+    const u8 *buf_end = buf + end;
+    assert(d < buf_end);
+
+    DEBUG_PRINTF("noodle %p start %zu len %zu\n", buf, start, buf_end - buf);
+    DEBUG_PRINTF("b %s\n", buf);
+    DEBUG_PRINTF("start %p end %p \n", d, buf_end);
 
     typename SuperVector<S>::comparemask_type lastz1{0};
 
-    const u8 *d = buf + start;
-    const u8 *e = buf + end;
-    DEBUG_PRINTF("start %p end %p \n", d, e);
-    assert(d < e);
-    if (e - d < S) {
-      return scanDoubleShort(n, buf, caseMask, mask1, mask2, cbi, len, d - buf, end);
-    }
-    if (d + S <= e) {
-        // peel off first part to cacheline boundary
-        const u8 *d1 = ROUNDUP_PTR(d, S) + 1;
-        DEBUG_PRINTF("until aligned %p \n", d1);
-        if (scanDoubleUnaligned(n, buf, caseMask, mask1, mask2, cbi, len, start, start, d1 - buf) == HWLM_TERMINATED) {
-            return HWLM_TERMINATED;
-        }
-        d = d1 - 1;
-
-        size_t loops = (end - (d - buf)) / S;
-        DEBUG_PRINTF("loops %ld \n", loops);
-
-        for (size_t i = 0; i < loops; i++, d+= S) {
-            DEBUG_PRINTF("d %p \n", d);
-            const u8 *base = ROUNDUP_PTR(d, 64);
-            // On large packet buffers, this prefetch appears to get us about 2%.
-            __builtin_prefetch(base + 256);
-
-            SuperVector<S> v = SuperVector<S>::load(d) & caseMask;
-            typename SuperVector<S>::comparemask_type z1 = mask1.eqmask(v);
-            typename SuperVector<S>::comparemask_type z2 = mask2.eqmask(v);
-            typename SuperVector<S>::comparemask_type z =
-                (z1 << SuperVector<S>::mask_width() | lastz1) & z2;
+    __builtin_prefetch(d + 16*64);
+    assert(d < buf_end);
+    if (d + S <= buf_end) {
+        // Reach vector aligned boundaries
+        DEBUG_PRINTF("until aligned %p \n", ROUNDUP_PTR(d, S));
+        if (!ISALIGNED_N(d, S)) {
+            const u8 *d1 = ROUNDUP_PTR(d, S);
+            size_t l = d1 - d;
+            SuperVector<S> chars = SuperVector<S>::loadu(d) & caseMask;
+            typename SuperVector<S>::comparemask_type mask = DOUBLE_LOAD_MASK(l * SuperVector<S>::mask_width());
+            typename SuperVector<S>::comparemask_type z1 = mask1.eqmask(chars);
+            typename SuperVector<S>::comparemask_type z2 = mask2.eqmask(chars);
+            typename SuperVector<S>::comparemask_type z = mask & (z1 << SuperVector<S>::mask_width()) & z2;
             lastz1 = z1 >> (Z_SHIFT * SuperVector<S>::mask_width());
             z = SuperVector<S>::iteration_mask(z);
 
             hwlm_error_t rv = double_zscan(n, d, buf, z, len, cbi);
             RETURN_IF_TERMINATED(rv);
+            d = d1;
         }
-        if (loops == 0) {
-          d = d1;
+
+        while(d + S <= buf_end) {
+            __builtin_prefetch(d + 16*64);
+            DEBUG_PRINTF("d %p \n", d);
+
+            SuperVector<S> chars = SuperVector<S>::load(d) & caseMask;
+            typename SuperVector<S>::comparemask_type z1 = mask1.eqmask(chars);
+            typename SuperVector<S>::comparemask_type z2 = mask2.eqmask(chars);
+            typename SuperVector<S>::comparemask_type z = (z1 << SuperVector<S>::mask_width() | lastz1) & z2;
+            lastz1 = z1 >> (Z_SHIFT * SuperVector<S>::mask_width());
+            z = SuperVector<S>::iteration_mask(z);
+
+            hwlm_error_t rv = double_zscan(n, d, buf, z, len, cbi);
+            RETURN_IF_TERMINATED(rv);
+            d += S;
         }
     }
+
+    DEBUG_PRINTF("d %p e %p \n", d, buf_end);
     // finish off tail
-    size_t s2End = ROUNDDOWN_PTR(e, S) - buf;
-    if (s2End == end) {
-      return HWLM_SUCCESS;
+
+    if (d != buf_end) {
+        size_t l = buf_end - d;
+        SuperVector<S> chars = SuperVector<S>::loadu(d) & caseMask;
+        typename SuperVector<S>::comparemask_type mask = DOUBLE_LOAD_MASK(l * SuperVector<S>::mask_width());
+        typename SuperVector<S>::comparemask_type z1 = mask1.eqmask(chars);
+        typename SuperVector<S>::comparemask_type z2 = mask2.eqmask(chars);
+        typename SuperVector<S>::comparemask_type z = mask & (z1 << SuperVector<S>::mask_width() | lastz1) & z2;
+        z = SuperVector<S>::iteration_mask(z);
+
+        hwlm_error_t rv = double_zscan(n, d, buf, z, len, cbi);
+        RETURN_IF_TERMINATED(rv);
     }
-    return scanDoubleUnaligned(n, buf, caseMask, mask1, mask2, cbi, len, end - S, d - buf, end);
+
+    return HWLM_SUCCESS;
 }
 
 // Single-character specialisation, used when keyLen = 1
 static really_inline
 hwlm_error_t scanSingle(const struct noodTable *n, const u8 *buf, size_t len,
                         size_t start, bool noCase, const struct cb_info *cbi) {
+/*    if (len < VECTORSIZE) {
+      return scanSingleSlow(n, buf, len, start, noCase, n->key0, cbi);
+    }*/
+
     if (!ourisalpha(n->key0)) {
         noCase = 0; // force noCase off if we don't have an alphabetic char
     }

--- a/src/hwlm/noodle_engine_simd.hpp
+++ b/src/hwlm/noodle_engine_simd.hpp
@@ -37,7 +37,7 @@ static really_really_inline
 hwlm_error_t single_zscan(const struct noodTable *n,const u8 *d, const u8 *buf,
                           typename SuperVector<S>::comparemask_type z, size_t len, const struct cb_info *cbi) {
     while (unlikely(z)) {
-        typename SuperVector<S>::comparemask_type pos = SuperVector<S>::findLSB(z) >> Z_POSSHIFT;
+        typename SuperVector<S>::comparemask_type pos = SuperVector<S>::findLSB(z);
         size_t matchPos = d - buf + pos;
         DEBUG_PRINTF("match pos %zu\n", matchPos);
         hwlmcb_rv_t rv = final(n, buf, len, n->msk_len != 1, cbi, matchPos);
@@ -51,7 +51,7 @@ static really_really_inline
 hwlm_error_t double_zscan(const struct noodTable *n,const u8 *d, const u8 *buf,
                           typename SuperVector<S>::comparemask_type z, size_t len, const struct cb_info *cbi) {
     while (unlikely(z)) {
-        typename SuperVector<S>::comparemask_type pos = SuperVector<S>::findLSB(z) >> Z_POSSHIFT;
+        typename SuperVector<S>::comparemask_type pos = SuperVector<S>::findLSB(z);
         size_t matchPos = d - buf + pos - 1;
         DEBUG_PRINTF("match pos %zu\n", matchPos);
         hwlmcb_rv_t rv = final(n, buf, len, true, cbi, matchPos);

--- a/src/util/arch/arm/match.hpp
+++ b/src/util/arch/arm/match.hpp
@@ -34,7 +34,6 @@ const u8 *first_non_zero_match<16>(const u8 *buf, SuperVector<16> mask, u16 cons
     uint64_t vmax = vgetq_lane_u64 (vreinterpretq_u64_u32 (vpmaxq_u32(m, m)), 0);
     if (vmax != 0) {
         typename SuperVector<16>::comparemask_type z = mask.comparemask();
-        DEBUG_PRINTF("z %08llx\n", z);
         DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
         u32 pos = ctz64(z) / SuperVector<16>::mask_width();
         DEBUG_PRINTF("match @ pos %u\n", pos);
@@ -54,7 +53,6 @@ const u8 *last_non_zero_match<16>(const u8 *buf, SuperVector<16> mask, u16 const
     if (vmax != 0) {
         typename SuperVector<16>::comparemask_type z = mask.comparemask();
         DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-        DEBUG_PRINTF("z %08llx\n", z);
         u32 pos = clz64(z) / SuperVector<16>::mask_width();
         DEBUG_PRINTF("match @ pos %u\n", pos);
         return buf + (15 - pos);
@@ -70,7 +68,6 @@ const u8 *first_zero_match_inverted<16>(const u8 *buf, SuperVector<16> mask, u16
     uint64_t vmax = vgetq_lane_u64 (vreinterpretq_u64_u32 (vpmaxq_u32(m, m)), 0);
     if (vmax != 0) {
         typename SuperVector<16>::comparemask_type z = mask.comparemask();
-        DEBUG_PRINTF("z %08llx\n", z);
         DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
         u32 pos = ctz64(z) / SuperVector<16>::mask_width();
         DEBUG_PRINTF("match @ pos %u\n", pos);
@@ -90,7 +87,6 @@ const u8 *last_zero_match_inverted<16>(const u8 *buf, SuperVector<16> mask, u16 
     if (vmax != 0) {
         typename SuperVector<16>::comparemask_type z = mask.comparemask();
         DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-        DEBUG_PRINTF("z %08llx\n", z);
         u32 pos = clz64(z) / SuperVector<16>::mask_width();
         DEBUG_PRINTF("match @ pos %u\n", pos);
         return buf + (15 - pos);

--- a/src/util/arch/ppc64el/match.hpp
+++ b/src/util/arch/ppc64el/match.hpp
@@ -31,11 +31,10 @@ template <>
 really_really_inline
 const u8 *first_non_zero_match<16>(const u8 *buf, SuperVector<16> v, u16 const UNUSED len) {
     SuperVector<16>::comparemask_type z = v.comparemask();
-    DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-    DEBUG_PRINTF("z %08llx\n", z);
+    DEBUG_PRINTF("buf %p z %08x \n", buf, z);
     if (unlikely(z)) {
         u32 pos = ctz32(z);
-        DEBUG_PRINTF("~z %08llx\n", ~z);
+        DEBUG_PRINTF("~z %08x\n", ~z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
         assert(pos < 16);
         return buf + pos;
@@ -48,8 +47,7 @@ template <>
 really_really_inline
 const u8 *last_non_zero_match<16>(const u8 *buf, SuperVector<16> v, u16 const UNUSED len) {
     SuperVector<16>::comparemask_type z = v.comparemask();
-    DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-    DEBUG_PRINTF("z %08llx\n", z);
+    DEBUG_PRINTF("buf %p z %08x \n", buf, z);
     if (unlikely(z)) {
         u32 pos = clz32(z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
@@ -64,11 +62,10 @@ template <>
 really_really_inline
 const u8 *first_zero_match_inverted<16>(const u8 *buf, SuperVector<16> v, u16 const UNUSED len) {
     SuperVector<16>::comparemask_type z = v.comparemask();
-    DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-    DEBUG_PRINTF("z %08llx\n", z);
+    DEBUG_PRINTF("buf %p z %08x \n", buf, z);
     if (unlikely(z != 0xffff)) {
         u32 pos = ctz32(~z & 0xffff);
-        DEBUG_PRINTF("~z %08llx\n", ~z);
+        DEBUG_PRINTF("~z %08x\n", ~z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
         assert(pos < 16);
         return buf + pos;
@@ -82,11 +79,10 @@ template <>
 really_really_inline
 const u8 *last_zero_match_inverted<16>(const u8 *buf, SuperVector<16> v, uint16_t UNUSED len ) {
     SuperVector<16>::comparemask_type z = v.comparemask();
-    DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-    DEBUG_PRINTF("z %08llx\n", z);
+    DEBUG_PRINTF("buf %p z %08x \n", buf, z);
     if (unlikely(z != 0xffff)) {
         u32 pos = clz32(~z & 0xffff);
-        DEBUG_PRINTF("~z %08llx\n", ~z);
+        DEBUG_PRINTF("~z %08x\n", ~z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
         assert(pos >= 16 && pos < 32);
         return buf + (31 - pos);

--- a/src/util/arch/x86/match.hpp
+++ b/src/util/arch/x86/match.hpp
@@ -32,11 +32,10 @@ really_really_inline
 const u8 *first_non_zero_match<16>(const u8 *buf, SuperVector<16> v, u16 const UNUSED len) {
     assert(SuperVector<16>::mask_width() == 1);
     SuperVector<16>::comparemask_type z = v.comparemask();
-    DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-    DEBUG_PRINTF("z %08llx\n", z);
+    DEBUG_PRINTF("buf %p z %08x\n", buf, z);
     if (unlikely(z)) {
         u32 pos = ctz32(z);
-        DEBUG_PRINTF("~z %08llx\n", ~z);
+        DEBUG_PRINTF("~z %08x\n", ~z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
         assert(pos < 16);
         return buf + pos;
@@ -85,8 +84,7 @@ really_really_inline
 const u8 *last_non_zero_match<16>(const u8 *buf, SuperVector<16> v, u16 const UNUSED len) {
     assert(SuperVector<16>::mask_width() == 1);
     SuperVector<16>::comparemask_type z = v.comparemask();
-    DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-    DEBUG_PRINTF("z %08llx\n", z);
+    DEBUG_PRINTF("buf %p z %08x \n", buf, z);
     if (unlikely(z)) {
         u32 pos = clz32(z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
@@ -137,11 +135,10 @@ really_really_inline
 const u8 *first_zero_match_inverted<16>(const u8 *buf, SuperVector<16> v, u16 const UNUSED len) {
     assert(SuperVector<16>::mask_width() == 1);
     SuperVector<16>::comparemask_type z = v.comparemask();
-    DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-    DEBUG_PRINTF("z %08llx\n", z);
+    DEBUG_PRINTF("buf %p z %08x \n", buf, z);
     if (unlikely(z != 0xffff)) {
         u32 pos = ctz32(~z & 0xffff);
-        DEBUG_PRINTF("~z %08llx\n", ~z);
+        DEBUG_PRINTF("~z %08x\n", ~z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
         assert(pos < 16);
         return buf + pos;
@@ -174,7 +171,7 @@ const u8 *first_zero_match_inverted<64>(const u8 *buf, SuperVector<64>v, u16 con
     u64a mask = (~0ULL) >> (64 - len);
     DEBUG_PRINTF("mask %016llx\n", mask);
     z = ~z & mask;
-    DEBUG_PRINTF("z 0x%016llx\n", z);
+    DEBUG_PRINTF("z 0x%016llx\n", (u64a) z);
     if (unlikely(z)) {
         u32 pos = ctz64(z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
@@ -190,11 +187,10 @@ really_really_inline
 const u8 *last_zero_match_inverted<16>(const u8 *buf, SuperVector<16> v, uint16_t UNUSED len ) {
     assert(SuperVector<16>::mask_width() == 1);
     SuperVector<16>::comparemask_type z = v.comparemask();
-    DEBUG_PRINTF("buf %p z %08llx \n", buf, z);
-    DEBUG_PRINTF("z %08llx\n", z);
+    DEBUG_PRINTF("buf %p z %08x \n", buf, z);
     if (unlikely(z != 0xffff)) {
         u32 pos = clz32(~z & 0xffffu);
-        DEBUG_PRINTF("~z %08llx\n", ~z);
+        DEBUG_PRINTF("~z %08x\n", ~z);
         DEBUG_PRINTF("match @ pos %u\n", pos);
         assert(pos >= 16 && pos < 32);
         return buf + (31 - pos);

--- a/src/util/arch/x86/x86.h
+++ b/src/util/arch/x86/x86.h
@@ -61,6 +61,7 @@
 
 #if defined(__AVX512BW__) && defined(BUILD_AVX512)
 #define HAVE_AVX512
+#define HAVE_MASKED_LOADS
 #define HAVE_SIMD_512_BITS
 #endif
 

--- a/src/util/supervector/arch/arm/impl.cpp
+++ b/src/util/supervector/arch/arm/impl.cpp
@@ -525,9 +525,24 @@ really_inline SuperVector<16> SuperVector<16>::load(void const *ptr)
 template <>
 really_inline SuperVector<16> SuperVector<16>::loadu_maskz(void const *ptr, uint8_t const len)
 {
-    SuperVector mask = Ones_vshr(16 -len);
-    SuperVector<16> v = loadu(ptr);
+    SuperVector mask = Ones_vshr(16 - len);
+    SuperVector v = loadu(ptr);
     return mask & v;
+}
+
+template <>
+really_inline SuperVector<16> SuperVector<16>::loadu_maskz(void const *ptr, typename base_type::comparemask_type const mask)
+{
+    DEBUG_PRINTF("mask = %08llx\n", mask);
+    SuperVector v = loadu(ptr);
+    (void)mask;
+    return v; // FIXME: & mask
+}
+
+template<>
+really_inline typename SuperVector<16>::comparemask_type SuperVector<16>::findLSB(typename SuperVector<16>::comparemask_type &z)
+{
+  return findAndClearLSB_64(&z) >> 2;
 }
 
 template<>

--- a/src/util/supervector/arch/ppc64el/impl.cpp
+++ b/src/util/supervector/arch/ppc64el/impl.cpp
@@ -556,6 +556,12 @@ really_inline SuperVector<16> SuperVector<16>::loadu_maskz(void const *ptr, uint
 }
 
 template<>
+really_inline typename SuperVector<16>::comparemask_type SuperVector<16>::findLSB(typename SuperVector<16>::comparemask_type &z)
+{
+  return findAndClearLSB_32(&z);
+}
+
+template<>
 really_inline SuperVector<16> SuperVector<16>::alignr(SuperVector<16> &other, int8_t offset)
 {   
     if (offset == 0) return other;

--- a/src/util/supervector/supervector.hpp
+++ b/src/util/supervector/supervector.hpp
@@ -48,18 +48,6 @@
 
 #include <util/bitutils.h>
 
-#if defined(HAVE_SIMD_512_BITS)
-#define Z_POSSHIFT 0
-#elif defined(HAVE_SIMD_256_BITS)
-#define Z_POSSHIFT 0
-#elif defined(HAVE_SIMD_128_BITS)
-#if !defined(VS_SIMDE_BACKEND) && (defined(ARCH_ARM32) || defined(ARCH_AARCH64))
-#define Z_POSSHIFT 2
-#else
-#define Z_POSSHIFT 0
-#endif
-#endif
-
 // Define a common assume_aligned using an appropriate compiler built-in, if
 // it's available. Note that we need to handle C or C++ compilation.
 #ifdef __cplusplus

--- a/src/util/supervector/supervector.hpp
+++ b/src/util/supervector/supervector.hpp
@@ -130,7 +130,11 @@ struct BaseVector<16>
   static constexpr bool      is_valid = true;
   static constexpr u16           size = 16;
   using                          type = m128;
+#if defined(ARCH_ARM32) || defined(ARCH_AARCH64)
+  using              comparemask_type = u64a;
+#else
   using              comparemask_type = u32;
+#endif
   static constexpr bool  has_previous = false;
   using                 previous_type = u64a;
   static constexpr u16  previous_size = 8;
@@ -229,8 +233,7 @@ public:
   static typename base_type::comparemask_type
   iteration_mask(typename base_type::comparemask_type mask);
 
-  static typename base_type::comparemask_type single_load_mask(uint8_t const len) { return (((1ULL) << (len)) - 1ULL); }
-  static typename base_type::comparemask_type double_load_mask(uint8_t const len) { return (((1ULL) << (len)) - 1ULL); }
+  static typename base_type::comparemask_type load_mask(uint8_t const len) { return (((1ULL) << (len)) - 1ULL); }
   static typename base_type::comparemask_type findLSB(typename base_type::comparemask_type &z);
   static SuperVector loadu(void const *ptr);
   static SuperVector load(void const *ptr);


### PR DESCRIPTION
Refactored Noodle engine to be closer to already refactored Shufti/Truffle/etc. 
Up to 2x as fast than previous version.
Also implemented masked loads, this will be used as a model for masked loads on AVX512 and SVE2 but also other future vector archictectures that will provide predicated/masked loads (SVP64?).