### PR TITLE
Add truffle SVE implementation

### DIFF
--- a/src/nfa/arm/truffle.hpp
+++ b/src/nfa/arm/truffle.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017, Intel Corporation
  * Copyright (c) 2020-2021, VectorCamp PC
+ * Copyright (c) 2023, Arm Limited
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,6 +33,76 @@
  *
  */
 
+#ifdef HAVE_SVE
+
+/*
+ * blockSingleMask takes in a character set (as masks) and a string and return for each character
+ * of the string weither or not it is part of the set.
+ *
+ * 'shuf_mask_lo_highclear' and 'shuf_mask_lo_highset' are 128-bit masks where each bit
+ * represents whether or not a character is in the character set. The 'highclear' and
+ * 'highset' in the name refers to the MSb of the byte of the character (allowing two
+ * 128-bit masks to cover all 256 values).
+ * 
+ * The masks are arrays of 16 bytes each and are encoded this way:
+ * Let C be a character in the set. The bit describing that character is at byte[C%16] and
+ * within that byte, it's at bit[C/16]
+ * As example, 'a' = 0x61, so the resulting mask will be: 0x00 0x40 0x00 0x00 0x00 ...
+ * 
+ * Assume both mask are 128b wide. If they are larger, the additional bits must be zero
+ */
+static really_inline
+svuint8_t blockSingleMask(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_highset, svuint8_t chars) {
+
+    const svuint8_t highconst = svdup_u8(0x80);
+    const svuint8_t pshub_mask = svdup_u8(0x8f);
+    const svuint8_t unique_bit_per_lane_mask = svreinterpret_u8(svdup_u64(0x8040201008040201));
+
+    /*
+     * svtbl does a table lookup. Each byte in the second argument indexes into the array of bytes
+     * in shuf_mask_lo_highclear and saves the result in the corresponding byte of byte_select_low.
+     * We mask the chars so that we are using the low nibble of char as the index but we keep the
+     * MSb so that high characters (not represented by the highclear mask) become an index out of
+     * bounds and result in a 0.
+     */
+    svuint8_t byte_select_low = svtbl(shuf_mask_lo_highclear, svand_x(svptrue_b8(), chars, pshub_mask));
+
+    /* 
+     * We flip the MSb of the chars and do the same table lookup with the highset mask.
+     * This way it's the characters with MSb cleared that will result in out of bands indexes.
+     * This allows us to cover the full range (0-127 and 128-255)
+     */
+    svuint8_t char_high_flipped = sveor_x(svptrue_b8(), chars, highconst);
+    svuint8_t byte_select_high = svtbl(shuf_mask_lo_highset, svand_x(svptrue_b8(), char_high_flipped, pshub_mask));
+
+    /*
+     * We now have selected the byte that contain the bit corresponding to the char. We need to
+     * further filter it, otherwise we'd get a match for any character % 16 to a searched character
+     * 
+     * The low nibble was used previously to select the byte out of the mask. The high nibble is
+     * used to select the bit out of the byte. So we shift everything right by 4.
+     * 
+     * Using svtbl, we can make an array where each element is a different bit. Using the high
+     * nibble we can get a mask selecting only the bit out of a byte that may have the relevant
+     * charset char.
+     */
+    svuint8_t char_high_nibble = svlsr_x(svptrue_b8(), chars, 4);
+    svuint8_t bit_select = svtbl(unique_bit_per_lane_mask, char_high_nibble);
+    /*
+     * For every lane, only one of the byte selected may have a value, so we can OR them. We
+     * then apply the bit_select mask. What is left is the bit in the charset encoding the
+     * character in char. A non zero value means the char was in the charset
+     * 
+     * The _x suffix only works if we process a full char vector. If we were to use a partial
+     * vector, then _z and a mask would be required on this svand only. Otherwise, the disabled
+     * lanes may have arbitrary values
+     */
+    svuint8_t res = svand_x(svptrue_b8(), svorr_x(svptrue_b8(), byte_select_low, byte_select_high), bit_select);
+
+    return res;
+}
+#else
+
 template <uint16_t S>
 static really_inline
 const SuperVector<S> blockSingleMask(SuperVector<S> shuf_mask_lo_highclear, SuperVector<S> shuf_mask_lo_highset, SuperVector<S> chars) {
@@ -60,3 +131,4 @@ const SuperVector<S> blockSingleMask(SuperVector<S> shuf_mask_lo_highclear, Supe
 
     return !res.eq(SuperVector<S>::Zeroes());
 }
+#endif //HAVE_SVE

--- a/src/nfa/truffle.cpp
+++ b/src/nfa/truffle.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017, Intel Corporation
  * Copyright (c) 2020, 2021, VectorCamp PC
+ * Copyright (c) 2023, Arm Limited
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -37,7 +38,17 @@
 #include "util/bitutils.h"
 
 #include "truffle_simd.hpp"
+#ifdef HAVE_SVE
+const u8 *truffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
+                      const u8 *buf_end) {
+    return truffleExecSVE(mask_lo, mask_hi, buf, buf_end);
+}
 
+const u8 *rtruffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
+                       const u8 *buf_end) {
+    return rtruffleExecSVE(mask_lo, mask_hi, buf, buf_end);
+}
+#else
 const u8 *truffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
                       const u8 *buf_end) {
     return truffleExecReal<VECTORSIZE>(mask_lo, mask_hi, buf, buf_end);
@@ -47,3 +58,4 @@ const u8 *rtruffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
                        const u8 *buf_end) {
     return rtruffleExecReal<VECTORSIZE>(mask_lo, mask_hi, buf, buf_end);
 }
+#endif //HAVE_SVE

--- a/src/util/supervector/supervector.hpp
+++ b/src/util/supervector/supervector.hpp
@@ -138,7 +138,7 @@ struct BaseVector<64>
   static constexpr u16  previous_size = 32;
 };
 
-// 128 bit implementation
+// 256 bit implementation
 template <>
 struct BaseVector<32>
 {


### PR DESCRIPTION
This PR adds an implementation of truffle using SVE as per planned in https://github.com/VectorCamp/vectorscan/issues/190. It  speeds truffle's benchmark up by about 15% and pass the unit tests.