### PR TITLE
Make sqlite optional, use OS installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include (${CMAKE_MODULE_PATH}/platform.cmake)
 include (${CMAKE_MODULE_PATH}/boost.cmake)
 include (${CMAKE_MODULE_PATH}/ragel.cmake)
 
-find_package(PkgConfig REQUIRED)
+find_package(PkgConfig QUIET)
 
 find_program(RAGEL ragel)
 

--- a/cmake/sqlite3.cmake
+++ b/cmake/sqlite3.cmake
@@ -1,15 +1,9 @@
 #
-# a lot of noise to find sqlite
+# sqlite is only used in hsbench, no need to special case its build, depend only on OS installations using pkg-config
 #
-
-option(SQLITE_PREFER_STATIC "Build sqlite3 statically instead of using an installed lib" OFF)
-
-if(NOT SQLITE_PREFER_STATIC)
-find_package(PkgConfig QUIET)
 
 # first check for sqlite on the system
 pkg_check_modules(SQLITE3 sqlite3)
-endif()
 
 # now do version checks
 if (SQLITE3_FOUND)
@@ -17,20 +11,9 @@ if (SQLITE3_FOUND)
     if (SQLITE_VERSION LESS "3.8.10")
         message(FATAL_ERROR "sqlite3 is broken from 3.8.7 to 3.8.10 - please find a working version")
     endif()
-endif()
 
-if (NOT SQLITE3_BUILD_SOURCE)
-    set(_SAVED_FLAGS ${CMAKE_REQUIRED_FLAGS})
     list(INSERT CMAKE_REQUIRED_LIBRARIES 0 ${SQLITE3_LDFLAGS})
     CHECK_SYMBOL_EXISTS(sqlite3_open_v2 sqlite3.h HAVE_SQLITE3_OPEN_V2)
     list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${SQLITE3_INCLUDE_DIRS}")
     list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES ${SQLITE3_LDFLAGS})
-else()
-    if (NOT TARGET sqlite3_static)
-    # build sqlite as a static lib to compile into our test programs
-    add_library(sqlite3_static STATIC "${PROJECT_SOURCE_DIR}/sqlite3/sqlite3.c")
-    set_target_properties(sqlite3_static PROPERTIES COMPILE_FLAGS "-Wno-error -Wno-extra -Wno-unused -Wno-cast-qual -DSQLITE_OMIT_LOAD_EXTENSION")
-    endif()
 endif()
-
-# that's enough about sqlite


### PR DESCRIPTION
Make sqlite optional as suggested in #208 

Sqlite3 is only used in the hsbench tool, there is no other use and as such there is no point in including it in the source or even support using it from an external source like eg. boost is handled. Only OS installation is supported using pkg-config -which is the standard cross-distro method to detect and use libraries.