### PR TITLE
fix the pcre versio check error on clang 16

### DIFF
--- a/cmake/pcre.cmake
+++ b/cmake/pcre.cmake
@@ -30,7 +30,7 @@ if (PCRE_BUILD_SOURCE)
     #if PCRE_MAJOR != ${PCRE_REQUIRED_MAJOR_VERSION} || PCRE_MINOR < ${PCRE_REQUIRED_MINOR_VERSION}
     #error Incorrect pcre version
     #endif
-    main() {}" CORRECT_PCRE_VERSION)
+    int main(void) {return 0;}" CORRECT_PCRE_VERSION)
     set (CMAKE_REQUIRED_INCLUDES "${saved_INCLUDES}")
 
     if (NOT CORRECT_PCRE_VERSION)


### PR DESCRIPTION
Description: on MacOS 12.3 and debian 12.4, tested with clang 16, the pcre version check will fail. complete the C code to avoid check error.