### PR TITLE
Add CMake options for more build granularity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1221,11 +1221,17 @@ if (NOT BUILD_STATIC_LIBS)
 endif ()
 
 add_subdirectory(util)
-add_subdirectory(unit)
 
-if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt)
+option(BUILD_UNIT "Build Hyperscan unit tests (default TRUE)" TRUE)
+if(BUILD_UNIT)
+    add_subdirectory(unit)
+endif()
+
+option(BUILD_TOOLS "Build Hyperscan tools (default TRUE)" TRUE)
+if(EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt AND BUILD_TOOLS)
     add_subdirectory(tools)
 endif()
+
 if (EXISTS ${CMAKE_SOURCE_DIR}/chimera/CMakeLists.txt AND BUILD_CHIMERA)
     add_subdirectory(chimera)
 endif()
@@ -1240,4 +1246,7 @@ if(BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif()
 
-add_subdirectory(doc/dev-reference)
+option(BUILD_DOC "Build the Hyperscan documentation (default TRUE)" TRUE)
+if(BUILD_DOC)
+    add_subdirectory(doc/dev-reference)
+endif()


### PR DESCRIPTION
I vendor Vectorscan as part of [Nosey Parker](https://github.com/praetorian-inc/noseyparker). In that use case, I only build vectorscan for its runtime system, and don't build the tests, docs, standalone tools, or a few other pieces. I've had to patch Vectorscan locally to exclude several parts from the build.

Some parts that I have disabled may be useful for other users of Vectorscan, so I've put them in a pull request here.

This pull request adds three new CMake options, all defaulting to true, making it possible to opt-out of building parts of Vectorscan that are not essential for deployment of the matching runtime.

These new options:

- `BUILD_UNIT`: control whether the `unit` directory is included
- `BUILD_DOC`: control whether the `doc` directory is included
- `BUILD_TOOLS`: control whether the `tools` directory is included