### PR TITLE
addressing some cppcheck warnings. 

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -113,7 +113,7 @@ static void run_benchmarks(int size, int loops, int max_matches, bool is_reverse
         auto end = std::chrono::steady_clock::now();
         total_sec += std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
         /*calculate transferred size*/
-        total_size = size * loops;
+        total_size = (u64a)size * (u64a)loops;
         /*calculate average time*/
         avg_time = total_sec / loops;
         /*convert microseconds to seconds*/

--- a/src/nfagraph/ng.cpp
+++ b/src/nfagraph/ng.cpp
@@ -193,9 +193,6 @@ void reduceGraph(NGHolder &g, som_type som, bool utf8,
 
     if (!som) {
         mergeCyclicDotStars(g);
-    }
-
-    if (!som) {
         removeSiblingsOfStartDotStar(g);
     }
 }

--- a/src/nfagraph/ng_limex_accel.cpp
+++ b/src/nfagraph/ng_limex_accel.cpp
@@ -811,11 +811,11 @@ depth_done:
                 return true;
             }
         }
-    }
+    // } 
 
     // Second option: a two-byte shufti (i.e. less than eight 2-byte
     // literals)
-    if (depth > 1) {
+    // if (depth > 1) {
         for (unsigned int i = 0; i < (depth - 1); i++) {
             if (depthReach[i].count() * depthReach[i+1].count()
                 <= DOUBLE_SHUFTI_LIMIT) {

--- a/src/nfagraph/ng_limex_accel.cpp
+++ b/src/nfagraph/ng_limex_accel.cpp
@@ -811,11 +811,9 @@ depth_done:
                 return true;
             }
         }
-    // } 
 
     // Second option: a two-byte shufti (i.e. less than eight 2-byte
     // literals)
-    // if (depth > 1) {
         for (unsigned int i = 0; i < (depth - 1); i++) {
             if (depthReach[i].count() * depthReach[i+1].count()
                 <= DOUBLE_SHUFTI_LIMIT) {

--- a/src/nfagraph/ng_som_util.cpp
+++ b/src/nfagraph/ng_som_util.cpp
@@ -267,17 +267,18 @@ bool somMayGoBackwards(NFAVertex u, const NGHolder &g,
     boost::depth_first_search(c_g, visitor(backEdgeVisitor)
                                    .root_vertex(c_g.start));
 
-    for (const auto &e : be) {
-        NFAVertex s = source(e, c_g);
-        NFAVertex t = target(e, c_g);
-        DEBUG_PRINTF("back edge %zu %zu\n", c_g[s].index, c_g[t].index);
-        if (s != t) {
-            assert(0);
-            DEBUG_PRINTF("eek big cycle\n");
-            rv = true; /* big cycle -> eek */
-            goto exit;
-        }
-    }
+    // with be.clear right above does this ever run at all?
+    //for (const auto &e : be) {
+    //    NFAVertex s = source(e, c_g);
+    //    NFAVertex t = target(e, c_g);
+    //    DEBUG_PRINTF("back edge %zu %zu\n", c_g[s].index, c_g[t].index);
+    //    if (s != t) {
+    //        assert(0);
+    //        DEBUG_PRINTF("eek big cycle\n");
+    //        rv = true; /* big cycle -> eek */
+    //        goto exit;
+    //    }
+    //}
 
     DEBUG_PRINTF("checking acyclic+selfloop graph\n");
 

--- a/src/nfagraph/ng_som_util.cpp
+++ b/src/nfagraph/ng_som_util.cpp
@@ -267,19 +267,6 @@ bool somMayGoBackwards(NFAVertex u, const NGHolder &g,
     boost::depth_first_search(c_g, visitor(backEdgeVisitor)
                                    .root_vertex(c_g.start));
 
-    // with be.clear right above does this ever run at all?
-    //for (const auto &e : be) {
-    //    NFAVertex s = source(e, c_g);
-    //    NFAVertex t = target(e, c_g);
-    //    DEBUG_PRINTF("back edge %zu %zu\n", c_g[s].index, c_g[t].index);
-    //    if (s != t) {
-    //        assert(0);
-    //        DEBUG_PRINTF("eek big cycle\n");
-    //        rv = true; /* big cycle -> eek */
-    //        goto exit;
-    //    }
-    //}
-
     DEBUG_PRINTF("checking acyclic+selfloop graph\n");
 
     rv = !firstMatchIsFirst(c_g);

--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -2975,7 +2975,8 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
             !lit_prog.empty()) {
             auto &cfrag = fragments[pfrag.included_frag_id];
             assert(pfrag.s.length() >= cfrag.s.length() &&
-                   !pfrag.s.any_nocase() >= !cfrag.s.any_nocase());
+                   !pfrag.s.any_nocase() == !cfrag.s.any_nocase());
+                   /** !pfrag.s.any_nocase() >= !cfrag.s.any_nocase()); **/
             u32 child_offset = cfrag.lit_program_offset;
             DEBUG_PRINTF("child %u offset %u\n", cfrag.fragment_id,
                          child_offset);
@@ -2993,7 +2994,8 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
         if (pfrag.included_delay_frag_id != INVALID_FRAG_ID &&
             !rebuild_prog.empty()) {
             auto &cfrag = fragments[pfrag.included_delay_frag_id];
-            assert(pfrag.s.length() >= cfrag.s.length() &&
+            /** assert(pfrag.s.length() >= cfrag.s.length() && **/
+            assert(pfrag.s.length() == cfrag.s.length() &&
                    !pfrag.s.any_nocase() >= !cfrag.s.any_nocase());
             u32 child_offset = cfrag.delay_program_offset;
             DEBUG_PRINTF("child %u offset %u\n", cfrag.fragment_id,

--- a/src/rose/rose_build_castle.cpp
+++ b/src/rose/rose_build_castle.cpp
@@ -170,7 +170,7 @@ void renovateCastle(RoseBuildImpl &tbi, CastleProto *castle,
                 return; /* bail - TODO: be less lazy */
             }
 
-            vector<CharReach> rem_local_cr;
+            //vector<CharReach> rem_local_cr;
             u32 ok_count = 0;
             for (auto it = e.s.end() - g[v].left.lag; it != e.s.end(); ++it) {
                 if (!isSubsetOf(*it, cr)) {

--- a/src/rose/rose_build_castle.cpp
+++ b/src/rose/rose_build_castle.cpp
@@ -170,7 +170,6 @@ void renovateCastle(RoseBuildImpl &tbi, CastleProto *castle,
                 return; /* bail - TODO: be less lazy */
             }
 
-            //vector<CharReach> rem_local_cr;
             u32 ok_count = 0;
             for (auto it = e.s.end() - g[v].left.lag; it != e.s.end(); ++it) {
                 if (!isSubsetOf(*it, cr)) {

--- a/tools/hscheck/main.cpp
+++ b/tools/hscheck/main.cpp
@@ -97,7 +97,7 @@ unsigned int countFailures = 0;
 
 class ParsedExpr {
 public:
-    ParsedExpr(string regex_in, unsigned int flags_in, hs_expr_ext ext_in)
+    ParsedExpr(string regex_in, unsigned int flags_in, hs_expr_ext& ext_in)
         : regex(regex_in), flags(flags_in), ext(ext_in) {}
     ~ParsedExpr() {}
     string regex;

--- a/tools/hscheck/main.cpp
+++ b/tools/hscheck/main.cpp
@@ -97,12 +97,12 @@ unsigned int countFailures = 0;
 
 class ParsedExpr {
 public:
-    ParsedExpr(string regex_in, unsigned int flags_in, hs_expr_ext& ext_in)
+    ParsedExpr(string regex_in, unsigned int flags_in, const hs_expr_ext& ext_in)
         : regex(regex_in), flags(flags_in), ext(ext_in) {}
     ~ParsedExpr() {}
     string regex;
     unsigned int flags;
-    hs_expr_ext ext;
+    const hs_expr_ext& ext;
 };
 
 typedef map<unsigned int, ParsedExpr> ExprExtMap;

--- a/util/ExpressionParser.rl
+++ b/util/ExpressionParser.rl
@@ -152,7 +152,7 @@ bool HS_CDECL readExpression(const std::string &input, std::string &expr,
     UNUSED const char *eof = pe;
     UNUSED const char *ts = p, *te = p;
     int cs;
-    UNUSED int act;
+    //UNUSED int act;
 
     assert(p);
     assert(pe);

--- a/util/ExpressionParser.rl
+++ b/util/ExpressionParser.rl
@@ -152,7 +152,6 @@ bool HS_CDECL readExpression(const std::string &input, std::string &expr,
     UNUSED const char *eof = pe;
     UNUSED const char *ts = p, *te = p;
     int cs;
-    //UNUSED int act;
 
     assert(p);
     assert(pe);

--- a/util/ng_corpus_generator.h
+++ b/util/ng_corpus_generator.h
@@ -47,7 +47,7 @@ class NGHolder;
 } // namespace ue2
 
 struct CorpusGenerationFailure {
-    explicit CorpusGenerationFailure(const std::string s) :
+    explicit CorpusGenerationFailure(const std::string& s) :
         message(std::move(s)) {}
     std::string message;
 };


### PR DESCRIPTION
yes this will be cleaned up in a following commit. tests pass.
some commentary on cppcheck warnings not addressed in this change: 
src/rose/rose_build_add_mask.cpp:192:18
: error: Out of bounds access in expression 'curr.back()' because 'curr' is empty. [containerOutOfBounds]
 this one is a false positive

/benchmarks/benchmarks.cpp:243:20: error
: Out of bounds access in 'str[char_len+1]', if 'str' size is 6 and 'char_len+1' is 6 [containerOutOfBounds]
could actually be a different bug here, the way that code reads it looks like the writer 
intended to use j there and not char_len. left a comment. 

src/scratch.c:85:9: style: Same expression used in consecutive assignments of 'som_store_size' and 'som_attempted_store_size'. [dupl
icateAssignExpression]
false positive

/var/lib/buildbot/workers/runner-d13-aarch64-01/release-linux-aarch64-gcc-14-cppcheck/source/src/parser/ComponentBoundary.cpp:171:12
: warning: Identical condition and return expression 'at_start', return value is always false [identicalConditionAfterEarlyExit]

false positive, the logic there makes sense as it is. 

/var/lib/buildbot/workers/runner-d13-aarch64-01/release-linux-aarch64-gcc-14-cppcheck/source/src/parser/ComponentBoundary.cpp:183
: warning: Identical condition and return expression 'at_end', return value is always false [identicalConditionAfterEarlyExit]

false positive, the logic there makes sense as it is. 

/var/lib/buildbot/workers/runner-d13-aarch64-01/release-linux-aarch64-gcc-14-cppcheck/source/src/nfa/goughcompile.cpp:924:24: style:
 Iterating over container 'eji' that is always empty. [knownEmptyContainer]

false positive, the very line before that is probably going to populate that value.

/var/lib/buildbot/workers/runner-d13-aarch64-01/release-linux-aarch64-gcc-14-cppcheck/source/unit/internal/repeat.cpp:67:1: style: T
he class 'RepeatTest' does not declare a constructor although it has private member variables which likely require initialization. [
noConstructor]
false positive. it has a setup function which looks like it does everything a constructor would do. 

/var/lib/buildbot/workers/runner-d13-aarch64-01/release-linux-aarch64-gcc-14-cppcheck/source/unit/internal/repeat.cpp:730:1: style: 
The class 'SparseOptimalTest' does not declare a constructor although it has private member variables which likely require initializ
ation. [noConstructor]
same thing, it has a SetUp finction which does the work of a constructor.


/var/lib/buildbot/workers/runner-d13-aarch64-01/release-linux-aarch64-gcc-14-cppcheck/source/tools/hsbench/huge.cpp:186:20: style: i
nt result is assigned to long variable. If the variable is long to avoid loss of information, then you have loss of information. [tr
uncLongCastAssignment]
false positive. the types are for compatibility with the functions called and the required return value, 
the actual values which would ever be encountered will never risk an overflow. besides long is the same as int in almost any machine
 this would ever be compiled on. 


/var/lib/buildbot/workers/runner-d13-aarch64-01/release-linux-aarch64-gcc-14-cppcheck/source/src/parser/ucp_table.h:818:1: error: Th
ere is an unknown macro here somewhere. Configuration is required. If UCP_FN is a macro then please configure it. [unknownMacro]
UCP_FN(C)

false positive. the .h file has a warning that it is autogenerated. the macro is defined in the cpp and the .h 
is included shortly below. the macro is known at compile time.

/var/lib/buildbot/workers/runner-d13-aarch64-01/release-linux-aarch64-gcc-14-cppcheck/source/unit/gtest/gtest-all.cc:1686:17: error:
 There is an unknown macro here somewhere. Configuration is required. If GTEST_NAME_ is a macro then please configure it. [unknownMa
cro]
    "True iff " GTEST_NAME_
false positive. it's defined in gtest.h which is included in that file.
