### PR TITLE
cppcheck warnings 5,6 

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -126,7 +126,7 @@ static void run_benchmarks(int size, int loops, int max_matches,
         /*convert to MB/s*/
         max_bw /= 1048576.0;
         printf("%-18s, %-12s, %-10d, %-6d, %-10.3f, %-9.3f, %-8.3f, %-7s\n",
-               bench.label, size ,loops, total_sec, avg_time, max_bw );
+               bench.label, "0", size, loops, total_sec, avg_time, max_bw, "0");
     }
 }
 

--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -102,7 +102,7 @@ static void run_benchmarks(int size, int loops, int max_matches, bool is_reverse
         avg_bw /= max_matches;
 	total_sec /= 1000000.0;
         /*convert average time to us*/
-        printf(KMAG "%s: %u matches, %u * %u iterations," KBLU " total elapsed time =" RST " %.3f s, " 
+        printf(KMAG "%s: %d matches, %d * %d iterations," KBLU " total elapsed time =" RST " %.3f s, " 
                KBLU "average time per call =" RST " %.3f μs," KBLU " max bandwidth = " RST " %.3f MB/s," KBLU " average bandwidth =" RST " %.3f MB/s \n",
                bench.label, max_matches, size ,loops, total_sec, avg_time, max_bw, avg_bw);
     } else {
@@ -122,7 +122,7 @@ static void run_benchmarks(int size, int loops, int max_matches, bool is_reverse
         max_bw = total_size / total_sec;
         /*convert to MB/s*/
         max_bw /= 1048576.0;
-        printf(KMAG "%s: no matches, %u * %u iterations," KBLU " total elapsed time =" RST " %.3f s, " 
+        printf(KMAG "%s: no matches, %d * %d iterations," KBLU " total elapsed time =" RST " %.3f s, " 
                KBLU "average time per call =" RST " %.3f μs ," KBLU " bandwidth = " RST " %.3f MB/s \n",
                bench.label, size ,loops, total_sec, avg_time, max_bw );
     }

--- a/tools/hsbench/engine_hyperscan.cpp
+++ b/tools/hsbench/engine_hyperscan.cpp
@@ -456,7 +456,7 @@ buildEngineHyperscan(const ExpressionMap &expressions, ScanMode scan_mode,
 
         if (err == HS_COMPILER_ERROR) {
             if (compile_err->expression >= 0) {
-                printf("Compile error for signature #%u: %s\n",
+                printf("Compile error for signature #%d: %s\n",
                        compile_err->expression, compile_err->message);
             } else {
                 printf("Compile error: %s\n", compile_err->message);


### PR DESCRIPTION
mostly false positives.. 
src/nfa/nfa_api_queue.h:254 [nullPointerRedundantCheck] -> false positive
src/nfa/nfa_api_queue.h:255: [nullPointerRedundantCheck] -> false positive
src/nfa/nfa_api_queue.h:256: [nullPointerRedundantCheck] -> false positive
src/nfa/nfa_api_queue.h:257: [nullPointerRedundantCheck] -> false positive
src/nfa/nfa_api_queue.h:258: [nullPointerRedundantCheck] -> false positive

unit/internal/multi_bit.cpp:58: [arithOperationsOnVoidPointer] -> not actually a
 void pointer, it's declared as unique_ptr<u8[]>
unit/internal/multi_bit.cpp:62: [arithOperationsOnVoidPointer] -> not actually a
 void pointer, it's declared as unique_ptr<u8[]>

unit/internal/multi_bit_compress.cpp:97 [arithOperationsOnVoidPointer] -> not ac
tually a void pointer, it's declared as unique_ptr<u8[]>
unit/internal/multi_bit_compress.cpp:101 [arithOperationsOnVoidPointer] -> not a
ctually a void pointer, it's declared as unique_ptr<u8[]>
unit/internal/multi_bit_compress.cpp:119 [arithOperationsOnVoidPointer] -> not a
ctually a void pointer, it's declared as unique_ptr<u8[]>
unit/internal/multi_bit_compress.cpp:123 [arithOperationsOnVoidPointer] -> not a
ctually a void pointer, it's declared as unique_ptr<u8[]>

src/nfa/rdfa.h:81 [uninitMemberVar] -> not a problem, the logic for this is else
where.
src/util/graph_undirected.h:154  [uninitMemberVar] -> yes, it actually is initia
lized in the constructor.
src/util/graph_undirected.h:244  [uninitMemberVar] -> yes, it actually is initia
lized in the constructor.

src/util/ue2_graph.h:263 [uninitMemberVar] -> it looks like the variable in ques
tion is set elsewhere
src/util/ue2_graph.h:279 [uninitMemberVar] -> it looks like the variable in ques
tion is set elsewhere

benchmarks/benchmarks.hpp:55 [uninitMemberVar] -> yes, it is initialized in the
constructor
