### PR TITLE
addressing 47,48,58

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -129,7 +129,7 @@ static void run_benchmarks(int size, int loops, int max_matches, bool is_reverse
 }
 
 int main(){
-    int matches[] = {0, MAX_MATCHES};
+    const int matches[] = {0, MAX_MATCHES};
     std::vector<size_t> sizes;
     for (size_t i = 0; i < N; i++) sizes.push_back(16000 << i*2);
     const char charset[] = "aAaAaAaAAAaaaaAAAAaaaaAAAAAAaaaAAaaa"; 

--- a/examples/patbench.cc
+++ b/examples/patbench.cc
@@ -389,7 +389,7 @@ public:
     // Close all open Hyperscan streams (potentially generating any
     // end-anchored matches)
     void closeStreams() {
-        for (auto &stream : streams) {
+        for (const auto &stream : streams) {
             hs_error_t err =
                 hs_close_stream(stream, scratch, onMatch, &matchCount);
             if (err != HS_SUCCESS) {
@@ -565,7 +565,7 @@ double measure_block_time(Benchmark &bench, unsigned int repeatCount) {
 }
 
 static
-double eval_set(Benchmark &bench, Sigdata &sigs, unsigned int mode,
+double eval_set(Benchmark &bench, const Sigdata &sigs, unsigned int mode,
                 unsigned repeatCount, Criterion criterion,
                 bool diagnose = true) {
     double compileTime = 0;

--- a/examples/pcapscan.cc
+++ b/examples/pcapscan.cc
@@ -281,7 +281,7 @@ public:
     // Close all open Hyperscan streams (potentially generating any
     // end-anchored matches)
     void closeStreams() {
-        for (auto &stream : streams) {
+        for (const auto &stream : streams) {
             hs_error_t err = hs_close_stream(stream, scratch, onMatch,
                                              &matchCount);
             if (err != HS_SUCCESS) {

--- a/src/fdr/fdr_confirm_compile.cpp
+++ b/src/fdr/fdr_confirm_compile.cpp
@@ -159,7 +159,7 @@ bytecode_ptr<FDRConfirm> getFDRConfirm(const vector<hwlmLiteral> &lits,
     map<u32, vector<LiteralIndex> > res2lits;
     hwlm_group_t gm = 0;
     for (LiteralIndex i = 0; i < lits.size(); i++) {
-        LitInfo & li = tmpLitInfo[i];
+        const LitInfo & li = tmpLitInfo[i];
         u32 hash = CONF_HASH_CALL(li.v, andmsk, mult, nBits);
         DEBUG_PRINTF("%016llx --> %u\n", li.v, hash);
         res2lits[hash].emplace_back(i);

--- a/src/fdr/teddy_compile.cpp
+++ b/src/fdr/teddy_compile.cpp
@@ -622,7 +622,7 @@ bytecode_ptr<FDR> TeddyCompiler::build() {
 static
 bool assignStringsToBuckets(
                 const vector<hwlmLiteral> &lits,
-                TeddyEngineDescription &eng,
+                const TeddyEngineDescription &eng,
                 map<BucketIndex, vector<LiteralIndex>> &bucketToLits) {
     assert(eng.numMasks <= MAX_NUM_MASKS);
     if (lits.size() > eng.getNumBuckets() * TEDDY_BUCKET_LOAD) {

--- a/src/nfa/goughcompile.cpp
+++ b/src/nfa/goughcompile.cpp
@@ -1017,7 +1017,7 @@ void update_accel_prog_offset(const gough_build_strat &gbs,
         verts[gbs.gg[v].state_id] = v;
     }
 
-    for (auto &m : gbs.built_accel) {
+    for (const auto &m : gbs.built_accel) {
         gough_accel *ga = m.first;
         assert(!ga->prog_offset);
         GoughVertex v = verts[m.second];

--- a/src/nfa/goughcompile_reg.cpp
+++ b/src/nfa/goughcompile_reg.cpp
@@ -438,7 +438,7 @@ void create_slot_mapping(const GoughGraph &cfg, UNUSED u32 old_slot_count,
 }
 
 static
-void update_local_slots(GoughGraph &g, set<GoughSSAVar *> &locals,
+void update_local_slots(GoughGraph &g, const set<GoughSSAVar *> &locals,
                         u32 local_base) {
     DEBUG_PRINTF("%zu local variables\n", locals.size());
     /* local variables only occur on edges (joins are never local) */

--- a/src/nfa/mcclellancompile.cpp
+++ b/src/nfa/mcclellancompile.cpp
@@ -361,7 +361,7 @@ struct raw_report_list {
     raw_report_list(const flat_set<ReportID> &reports_in,
                     const ReportManager &rm, bool do_remap) {
         if (do_remap) {
-            for (auto &id : reports_in) {
+            for (const auto &id : reports_in) {
                 reports.insert(rm.getProgramOffset(id));
             }
         } else {
@@ -540,7 +540,7 @@ size_t calcWideRegionSize(const dfa_info &info) {
 static
 void fillInAux(mstate_aux *aux, dstate_id_t i, const dfa_info &info,
                const vector<u32> &reports, const vector<u32> &reports_eod,
-               vector<u32> &reportOffsets) {
+               const vector<u32> &reportOffsets) {
     const dstate &raw_state = info.states[i];
     aux->accept = raw_state.reports.empty() ? 0 : reportOffsets[reports[i]];
     aux->accept_eod = raw_state.reports_eod.empty() ? 0
@@ -794,8 +794,8 @@ bytecode_ptr<NFA> mcclellanCompile16(dfa_info &info, const CompileContext &cc,
         }
 
         for (size_t i : order) {
-            vector<dstate_id_t> &state_chain = info.wide_state_chain[i];
-            vector<symbol_t> &symbol_chain = info.wide_symbol_chain[i];
+            const vector<dstate_id_t> &state_chain = info.wide_state_chain[i];
+            const vector<symbol_t> &symbol_chain = info.wide_symbol_chain[i];
 
             u16 width = verify_u16(symbol_chain.size());
             *(u16 *)(curr_wide_entry + WIDE_WIDTH_OFFSET) = width;
@@ -1367,11 +1367,11 @@ bool store_chain_longest(vector<vector<dstate_id_t>> &candidate_chain,
 /* \brief Generate wide_symbol_chain from wide_state_chain. */
 static
 void generate_symbol_chain(dfa_info &info, vector<symbol_t> &chain_tail) {
-    raw_dfa &rdfa = info.raw;
+    const raw_dfa &rdfa = info.raw;
     assert(chain_tail.size() == info.wide_state_chain.size());
 
     for (size_t i = 0; i < info.wide_state_chain.size(); i++) {
-        vector<dstate_id_t> &state_chain = info.wide_state_chain[i];
+        const vector<dstate_id_t> &state_chain = info.wide_state_chain[i];
         vector<symbol_t> symbol_chain;
 
         info.extra[state_chain[0]].wideHead = true;

--- a/src/nfa/mcsheng_compile.cpp
+++ b/src/nfa/mcsheng_compile.cpp
@@ -955,7 +955,7 @@ bool is_cyclic_near(const raw_dfa &raw, dstate_id_t root) {
 }
 
 static
-void fill_in_sherman(NFA *nfa, dfa_info &info, UNUSED u16 sherman_limit) {
+void fill_in_sherman(NFA *nfa, const dfa_info &info, UNUSED u16 sherman_limit) {
     char *nfa_base = (char *)nfa;
     mcsheng *m = (mcsheng *)getMutableImplNfa(nfa);
     char *sherman_table = nfa_base + m->sherman_offset;
@@ -1109,7 +1109,7 @@ void fill_in_succ_table_8(NFA *nfa, const dfa_info &info,
 }
 
 static
-void fill_in_sherman64(NFA *nfa, dfa_info &info, UNUSED u16 sherman_limit) {
+void fill_in_sherman64(NFA *nfa, const dfa_info &info, UNUSED u16 sherman_limit) {
     char *nfa_base = (char *)nfa;
     mcsheng64 *m = (mcsheng64 *)getMutableImplNfa(nfa);
     char *sherman_table = nfa_base + m->sherman_offset;

--- a/src/nfa/shengcompile.cpp
+++ b/src/nfa/shengcompile.cpp
@@ -99,7 +99,7 @@ struct dfa_info {
         return next(idx, TOP);
     }
     dstate &next(dstate_id_t idx, u16 chr) {
-        auto &src = (*this)[idx];
+        const auto &src = (*this)[idx];
         auto next_id = src.next[raw.alpha_remap[chr]];
         return states[next_id];
     }
@@ -109,7 +109,7 @@ struct dfa_info {
         // if DFA can't die, shift all indices left by 1
         return can_die ? idx : idx + 1;
     }
-    bool isDead(dstate &state) {
+    bool isDead(const dstate &state) {
         return raw_id(state.impl_id) == DEAD_STATE;
     }
     bool isDead(dstate_id_t idx) {
@@ -117,7 +117,7 @@ struct dfa_info {
     }
 
 private:
-    static bool dfaCanDie(raw_dfa &rdfa) {
+    static bool dfaCanDie(const raw_dfa &rdfa) {
         for (unsigned chr = 0; chr < 256; chr++) {
             for (dstate_id_t state = 0; state < rdfa.states.size(); state++) {
                 auto succ = rdfa.states[state].next[rdfa.alpha_remap[chr]];
@@ -138,7 +138,7 @@ struct raw_report_list {
     raw_report_list(const flat_set<ReportID> &reports_in,
                     const ReportManager &rm, bool do_remap) {
         if (do_remap) {
-            for (auto &id : reports_in) {
+            for (const auto &id : reports_in) {
                 reports.insert(rm.getProgramOffset(id));
             }
         } else {

--- a/src/nfa/truffle_simd.hpp
+++ b/src/nfa/truffle_simd.hpp
@@ -227,7 +227,7 @@ const u8 *fwdBlock(SuperVector<S> shuf_mask_lo_highclear, SuperVector<S> shuf_ma
 }
 
 template <uint16_t S>
-const u8 *truffleExecReal(m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_highset, const u8 *buf, const u8 *buf_end) {
+const u8 *truffleExecReal(const m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_highset, const u8 *buf, const u8 *buf_end) {
     assert(buf && buf_end);
     assert(buf < buf_end);
     DEBUG_PRINTF("truffle %p len %zu\n", buf, buf_end - buf);

--- a/src/nfagraph/ng.cpp
+++ b/src/nfagraph/ng.cpp
@@ -292,7 +292,7 @@ bool addComponent(NG &ng, NGHolder &g, const ExpressionInfo &expr,
 
 // Returns true if all components have been added.
 static
-bool processComponents(NG &ng, ExpressionInfo &expr,
+bool processComponents(NG &ng, const ExpressionInfo &expr,
                        deque<unique_ptr<NGHolder>> &g_comp,
                        const som_type som) {
     const u32 num_components = g_comp.size();

--- a/src/nfagraph/ng_anchored_dots.cpp
+++ b/src/nfagraph/ng_anchored_dots.cpp
@@ -257,7 +257,7 @@ void reformAnchoredRepeatsComponent(NGHolder &g,
 
 static
 void reformUnanchoredRepeatsComponent(NGHolder &g,
-                                      set<NFAVertex> &compAnchoredStarts,
+                                      const set<NFAVertex> &compAnchoredStarts,
                                       set<NFAVertex> &compUnanchoredStarts,
                                       set<NFAVertex> &dead,
                                       depth *startBegin, depth *startEnd) {
@@ -555,7 +555,7 @@ void collapseVariableRepeats(NGHolder &g, depth *startBegin, depth *startEnd) {
 }
 
 static
-void addDotsBetween(NGHolder &g, NFAVertex lhs, vector<NFAVertex> &rhs,
+void addDotsBetween(NGHolder &g, NFAVertex lhs, const vector<NFAVertex> &rhs,
                     depth min_repeat, depth max_repeat) {
     const bool unbounded = max_repeat.is_infinite();
     if (unbounded) {

--- a/src/nfagraph/ng_equivalence.cpp
+++ b/src/nfagraph/ng_equivalence.cpp
@@ -159,7 +159,7 @@ public:
         return id;
     }
 
-    void append(WorkQueue &other) {
+    void append(const WorkQueue &other) {
         for (const auto &e : other) {
             push(e);
         }
@@ -193,7 +193,7 @@ private:
 }
 
 static
-bool outIsIrreducible(NFAVertex &v, const NGHolder &g) {
+bool outIsIrreducible(const NFAVertex &v, const NGHolder &g) {
     unsigned nonSpecialVertices = 0;
     for (auto w : adjacent_vertices_range(v, g)) {
         if (!is_special(w, g) && w != v) {
@@ -204,7 +204,7 @@ bool outIsIrreducible(NFAVertex &v, const NGHolder &g) {
 }
 
 static
-bool inIsIrreducible(NFAVertex &v, const NGHolder &g) {
+bool inIsIrreducible(const NFAVertex &v, const NGHolder &g) {
     unsigned nonSpecialVertices = 0;
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (!is_special(u, g) && u != v) {

--- a/src/nfagraph/ng_extparam.cpp
+++ b/src/nfagraph/ng_extparam.cpp
@@ -430,7 +430,7 @@ NFAVertex findSingleCyclic(const NGHolder &g) {
 }
 
 static
-bool hasOffsetAdjust(const ReportManager &rm, NGHolder &g,
+bool hasOffsetAdjust(const ReportManager &rm, const NGHolder &g,
                      int *adjust) {
     const auto &reports = all_reports(g);
     if (reports.empty()) {

--- a/src/nfagraph/ng_fuzzy.cpp
+++ b/src/nfagraph/ng_fuzzy.cpp
@@ -582,7 +582,7 @@ private:
 
         // set up all reports
         bool clone = false;
-        for (auto &pair : reports_to_vertices) {
+        for (const auto &pair : reports_to_vertices) {
             const auto &reports = pair.first;
             const auto &vertices = pair.second;
 

--- a/src/nfagraph/ng_literal_component.cpp
+++ b/src/nfagraph/ng_literal_component.cpp
@@ -98,7 +98,7 @@ void addToString(string &s, const NGHolder &g, NFAVertex v) {
 }
 
 static
-bool splitOffLiteral(NG &ng, NGHolder &g, NFAVertex v, const bool anchored,
+bool splitOffLiteral(NG &ng, const NGHolder &g, NFAVertex v, const bool anchored,
                      set<NFAVertex> &dead) {
     DEBUG_PRINTF("examine vertex %zu\n", g[v].index);
     bool nocase = false, casefixed = false;

--- a/src/nfagraph/ng_puff.cpp
+++ b/src/nfagraph/ng_puff.cpp
@@ -241,7 +241,7 @@ u32 allowedSquashDistance(const CharReach &cr, u32 min_width, const NGHolder &g,
 /** Gives a stronger puff trigger when the trigger is connected to a wide
  * cyclic state (aside from sds) */
 static
-void improveHead(NGHolder &g, NFAVertex *a, vector<NFAVertex> *nodes) {
+void improveHead(const NGHolder &g, NFAVertex *a, vector<NFAVertex> *nodes) {
     DEBUG_PRINTF("attempting to improve puff trigger\n");
     assert(!nodes->empty());
     const CharReach &puff_cr = g[nodes->back()].char_reach;
@@ -260,7 +260,7 @@ void improveHead(NGHolder &g, NFAVertex *a, vector<NFAVertex> *nodes) {
 }
 
 static
-void constructPuff(NGHolder &g, const NFAVertex a, const NFAVertex puffv,
+void constructPuff(const NGHolder &g, const NFAVertex a, const NFAVertex puffv,
                    const CharReach &cr, const ReportID report, u32 width,
                    bool fixed_depth, bool unbounded, bool auto_restart,
                    RoseBuild &rose, ReportManager &rm,

--- a/src/nfagraph/ng_redundancy.cpp
+++ b/src/nfagraph/ng_redundancy.cpp
@@ -323,7 +323,7 @@ bool doUselessMergePass(NGHolder &g, som_type som, VertexInfoMap &infoMap,
 
     bool changed = false;
     for (auto v : vertices_range(g)) {
-        VertexInfo &info = infoMap[v];
+        const VertexInfo &info = infoMap[v];
 
         if (info.isRemoved) {
             continue;
@@ -439,7 +439,7 @@ bool doUselessMergePass(NGHolder &g, som_type som, VertexInfoMap &infoMap,
                 continue; // Conservatively skip anything with nonzero tops.
             }
 
-            CharReach &otherReach = g[t].char_reach;
+            const CharReach &otherReach = g[t].char_reach;
             if (currReach.isSubsetOf(otherReach)) {
                 DEBUG_PRINTF("removing redundant vertex %zu (keeping %zu)\n",
                              g[v].index, g[t].index);
@@ -745,7 +745,7 @@ u32 findCyclic(const NGHolder &g, vector<bool> &cyclic) {
 }
 
 static
-void findCyclicDom(NGHolder &g, vector<bool> &cyclic,
+void findCyclicDom(const NGHolder &g, vector<bool> &cyclic,
                    set<NFAEdge> &dead, som_type som) {
     auto dominators = findDominators(g);
 
@@ -789,7 +789,7 @@ void findCyclicDom(NGHolder &g, vector<bool> &cyclic,
 }
 
 static
-void findCyclicPostDom(NGHolder &g, vector<bool> &cyclic,
+void findCyclicPostDom(const NGHolder &g, vector<bool> &cyclic,
                        set<NFAEdge> &dead) {
     auto postdominators = findPostDominators(g);
 

--- a/src/nfagraph/ng_repeat.cpp
+++ b/src/nfagraph/ng_repeat.cpp
@@ -1874,7 +1874,7 @@ void buildFeeder(NGHolder &g, const BoundedRepeatData &rd,
  * offset.
  */
 static
-bool improveLeadingRepeat(NGHolder &g, BoundedRepeatData &rd,
+bool improveLeadingRepeat(NGHolder &g, const BoundedRepeatData &rd,
                           unordered_set<NFAVertex> &created,
                           const vector<BoundedRepeatData> &all_repeats) {
     assert(edge(g.startDs, g.startDs, g).second);
@@ -1944,7 +1944,7 @@ bool improveLeadingRepeat(NGHolder &g, BoundedRepeatData &rd,
 }
 
 static
-vector<NFAVertex> makeOwnStraw(NGHolder &g, BoundedRepeatData &rd,
+vector<NFAVertex> makeOwnStraw(NGHolder &g, const BoundedRepeatData &rd,
                                const vector<NFAVertex> &straw) {
     // Straw runs from startDs to our pos trigger.
     assert(!straw.empty());

--- a/src/nfagraph/ng_som.cpp
+++ b/src/nfagraph/ng_som.cpp
@@ -1177,7 +1177,7 @@ void expandGraph(NGHolder &g, unordered_map<NFAVertex, u32> &regions,
 }
 
 static
-bool doTreePlanningIntl(NGHolder &g,
+bool doTreePlanningIntl(const NGHolder &g,
             const unordered_map<NFAVertex, u32> &regions,
             const map<u32, region_info> &info,
             map<u32, region_info>::const_iterator picked, u32 bad_region,
@@ -1855,7 +1855,7 @@ bool doSomRevNfa(NG &ng, NGHolder &g, const CompileContext &cc) {
 }
 
 static
-u32 doSomRevNfaPrefix(NG &ng, const ExpressionInfo &expr, NGHolder &g,
+u32 doSomRevNfaPrefix(NG &ng, const ExpressionInfo &expr, const NGHolder &g,
                       const CompileContext &cc) {
     depth maxWidth = findMaxWidth(g);
 
@@ -2011,7 +2011,7 @@ void setReportOnHaigPrefix(RoseBuild &rose, NGHolder &h) {
 }
 
 static
-bool tryHaig(RoseBuild &rose, NGHolder &g,
+bool tryHaig(RoseBuild &rose, const NGHolder &g,
              const unordered_map<NFAVertex, u32> &regions,
              som_type som, u32 somPrecision,
              map<u32, region_info>::const_iterator picked,
@@ -2442,7 +2442,7 @@ void makeReportsSomPass(ReportManager &rm, NGHolder &g) {
 }
 
 static
-bool doLitHaigSom(NG &ng, NGHolder &g, som_type som) {
+bool doLitHaigSom(NG &ng, const NGHolder &g, som_type som) {
     ue2_literal lit;
     shared_ptr<NGHolder> rhs = make_shared<NGHolder>();
     if (!rhs) {
@@ -2659,7 +2659,7 @@ bool doHaigLitHaigSom(NG &ng, NGHolder &g,
 }
 
 static
-bool doMultiLitHaigSom(NG &ng, NGHolder &g, som_type som) {
+bool doMultiLitHaigSom(NG &ng, const NGHolder &g, som_type som) {
     set<ue2_literal> lits;
     shared_ptr<NGHolder> rhs = make_shared<NGHolder>();
     if (!ng.cc.grey.allowLitHaig) {

--- a/src/nfagraph/ng_som_add_redundancy.cpp
+++ b/src/nfagraph/ng_som_add_redundancy.cpp
@@ -112,7 +112,7 @@ bool forkVertex(NFAVertex v, NGHolder &g, vector<DepthMinMax> &depths,
     }
     *numNewVertices += predGroups.size();
 
-    for (auto &group : predGroups) {
+    for (const auto &group : predGroups) {
         const depth &predDepth = group.first;
         const vector<NFAEdge> &preds = group.second;
 

--- a/src/nfagraph/ng_uncalc_components.cpp
+++ b/src/nfagraph/ng_uncalc_components.cpp
@@ -454,8 +454,8 @@ void buildNfaMergeQueue(const vector<NGHolder *> &cluster,
                 }
             }
 
-            NGHolder &g_i = *(cluster[ci]);
-            NGHolder &g_j = *(cluster[cj]);
+            const NGHolder &g_i = *(cluster[ci]);
+            const NGHolder &g_j = *(cluster[cj]);
 
             if (!compatibleStarts(g_i, g_j)) {
                 continue;

--- a/src/nfagraph/ng_violet.cpp
+++ b/src/nfagraph/ng_violet.cpp
@@ -688,7 +688,7 @@ unique_ptr<VertLitInfo> findBestSplit(const NGHolder &g,
     }
 
     if (seeking_transient) {
-        for (auto &a : lits) {
+        for (const auto &a : lits) {
             a->creates_transient
                 = createsTransientLHS(g, a->vv, *depths, cc.grey);
         }
@@ -697,7 +697,7 @@ unique_ptr<VertLitInfo> findBestSplit(const NGHolder &g,
     if (last_chance) {
         const size_t num_verts = num_vertices(g);
         auto color_map = make_small_color_map(g);
-        for (auto &a : lits) {
+        for (const auto &a : lits) {
             size_t num_reachable = count_reachable(g, a->vv, color_map);
             double ratio = (double)num_reachable / (double)num_verts;
             a->split_ratio = ratio > 0.5 ? 1 - ratio : ratio;
@@ -1172,7 +1172,7 @@ bool splitRoseEdge(const NGHolder &base_graph, RoseInGraph &vg,
 #define MAX_LEN_2_LITERALS_PER_CUT 3
 
 static
-bool checkValidNetflowLits(NGHolder &h, const vector<u64a> &scores,
+bool checkValidNetflowLits(const NGHolder &h, const vector<u64a> &scores,
                            const map<NFAEdge, set<ue2_literal>> &cut_lits,
                            u32 min_allowed_length) {
     DEBUG_PRINTF("cut width %zu; min allowed %u\n", cut_lits.size(),
@@ -1209,7 +1209,7 @@ bool checkValidNetflowLits(NGHolder &h, const vector<u64a> &scores,
 }
 
 static
-void splitEdgesByCut(NGHolder &h, RoseInGraph &vg,
+void splitEdgesByCut(const NGHolder &h, RoseInGraph &vg,
                      const vector<RoseInEdge> &to_cut,
                      const vector<NFAEdge> &cut,
                      const map<NFAEdge, set<ue2_literal>> &cut_lits) {
@@ -1805,7 +1805,7 @@ void removeRedundantLiterals(RoseInGraph &g, const CompileContext &cc) {
 }
 
 static
-RoseInVertex getStart(RoseInGraph &vg) {
+RoseInVertex getStart(const RoseInGraph &vg) {
     for (RoseInVertex v : vertices_range(vg)) {
         if (vg[v].type == RIV_START || vg[v].type == RIV_ANCHORED_START) {
             return v;
@@ -1870,7 +1870,7 @@ unique_ptr<NGHolder> make_chain(u32 count) {
 #define SHORT_TRIGGER_LEN 16
 
 static
-bool makeTransientFromLongLiteral(NGHolder &h, RoseInGraph &vg,
+bool makeTransientFromLongLiteral(const NGHolder &h, RoseInGraph &vg,
                                   const vector<RoseInEdge> &ee,
                                   const CompileContext &cc) {
     /* check max width and literal lengths to see if possible */
@@ -2150,7 +2150,7 @@ void findBetterPrefixes(RoseInGraph &vg, const CompileContext &cc) {
 #define MAX_EXTRACT_STRONG_LITERAL_GRAPHS 10
 
 static
-bool extractStrongLiteral(NGHolder &h, RoseInGraph &vg,
+bool extractStrongLiteral(const NGHolder &h, RoseInGraph &vg,
                           const vector<RoseInEdge> &ee,
                           const CompileContext &cc) {
     DEBUG_PRINTF("looking for string literal\n");
@@ -2805,7 +2805,7 @@ bool tryForEarlyDfa(const NGHolder &h, const CompileContext &cc) {
 }
 
 static
-vector<vector<CharReach>> getDfaTriggers(RoseInGraph &vg,
+vector<vector<CharReach>> getDfaTriggers(const RoseInGraph &vg,
                                          const vector<RoseInEdge> &edges,
                                          bool *single_trigger) {
     vector<vector<CharReach>> triggers;
@@ -2927,7 +2927,7 @@ bool ensureImplementable(RoseBuild &rose, RoseInGraph &vg, bool allow_changes,
                               vector<RoseInEdge>> edges_by_graph;
         for (const RoseInEdge &ve : edges_range(vg)) {
             if (vg[ve].graph && !vg[ve].dfa) {
-                auto &h = vg[ve].graph;
+                const auto &h = vg[ve].graph;
                 edges_by_graph[h].emplace_back(ve);
             }
         }

--- a/src/parser/ComponentRepeat.cpp
+++ b/src/parser/ComponentRepeat.cpp
@@ -110,7 +110,7 @@ void addBase(Position base, vector<PositionInfo> &firsts,
 }
 
 static
-void checkPositions(vector<PositionInfo> &v, const GlushkovBuildState &bs) {
+void checkPositions(const vector<PositionInfo> &v, const GlushkovBuildState &bs) {
     const NFABuilder& builder = bs.getBuilder();
     for (const auto &e : v) {
         if (builder.isSpecialState(e.pos)) {

--- a/src/parser/buildstate.cpp
+++ b/src/parser/buildstate.cpp
@@ -242,7 +242,7 @@ Position makeNewlineAssertPos(GlushkovBuildState &bs) {
 static
 void generateAccepts(GlushkovBuildStateImpl &bs, const PositionInfo &from,
                      vector<PositionInfo> *tolist) {
-    NFABuilder &builder = bs.getBuilder();
+    const NFABuilder &builder = bs.getBuilder();
     u32 flags = from.flags;
 
     bool require_eod = flags & POS_FLAG_WIRE_EOD;

--- a/src/rose/rose_build_add.cpp
+++ b/src/rose/rose_build_add.cpp
@@ -353,7 +353,7 @@ void createVertices(RoseBuildImpl *tbi,
                          edge_props.minBound, edge_props.maxBound);
         }
 
-        for (auto &m : created) {
+        for (const auto &m : created) {
             tbi->ghost[m.second] = g_v;
         }
     }
@@ -938,7 +938,7 @@ void shift_accepts_to_end(const RoseInGraph &ig,
 }
 
 static
-void populateRoseGraph(RoseBuildImpl *tbi, RoseBuildData &bd) {
+void populateRoseGraph(RoseBuildImpl *tbi, const RoseBuildData &bd) {
     const RoseInGraph &ig = bd.ig;
 
     /* add the pattern in to the main rose graph */

--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -674,7 +674,7 @@ buildSuffix(const ReportManager &rm, const SomSlotManager &ssm,
     }
 
     assert(suff.graph());
-    NGHolder &holder = *suff.graph();
+    const NGHolder &holder = *suff.graph();
     assert(holder.kind == NFA_SUFFIX);
     const bool oneTop = onlyOneTop(holder);
     bool compress_state = cc.streaming;
@@ -1378,7 +1378,7 @@ void updateExclusiveSuffixProperties(const RoseBuildImpl &build,
                                 const vector<ExclusiveInfo> &exclusive_info,
                                 set<u32> *no_retrigger_queues) {
     const RoseGraph &g = build.g;
-    for (auto &info : exclusive_info) {
+    for (const auto &info : exclusive_info) {
         const auto &qi = info.queue;
         const auto &subengines = info.subengines;
         bool no_retrigger = true;
@@ -1627,11 +1627,11 @@ public:
                             build.rm);
     }
 
-    bytecode_ptr<NFA> operator()(unique_ptr<NGHolder> &holder) const {
+    bytecode_ptr<NFA> operator()(const unique_ptr<NGHolder> &holder) const {
         const CompileContext &cc = build.cc;
         const ReportManager &rm = build.rm;
 
-        NGHolder &h = *holder;
+        const NGHolder &h = *holder;
         assert(h.kind == NFA_OUTFIX);
 
         // Build NFA.
@@ -1657,7 +1657,7 @@ public:
         return n;
     }
 
-    bytecode_ptr<NFA> operator()(UNUSED MpvProto &mpv) const {
+    bytecode_ptr<NFA> operator()(UNUSED const MpvProto &mpv) const {
         // MPV construction handled separately.
         assert(mpv.puffettes.empty());
         return nullptr;
@@ -2728,7 +2728,7 @@ void buildLeftInfoTable(const RoseBuildImpl &tbi, build_context &bc,
 }
 
 static
-RoseProgram makeLiteralProgram(const RoseBuildImpl &build, build_context &bc,
+RoseProgram makeLiteralProgram(const RoseBuildImpl &build, const build_context &bc,
                                ProgramBuild &prog_build, u32 lit_id,
                                const vector<vector<RoseEdge>> &lit_edge_map,
                                bool is_anchored_replay_program) {
@@ -2973,7 +2973,7 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
                                             pfrag.lit_ids, lit_edge_map);
         if (pfrag.included_frag_id != INVALID_FRAG_ID &&
             !lit_prog.empty()) {
-            auto &cfrag = fragments[pfrag.included_frag_id];
+            const auto &cfrag = fragments[pfrag.included_frag_id];
             assert(pfrag.s.length() >= cfrag.s.length() &&
                    !pfrag.s.any_nocase() >= !cfrag.s.any_nocase());
             u32 child_offset = cfrag.lit_program_offset;
@@ -2992,7 +2992,7 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
                                                     pfrag.lit_ids);
         if (pfrag.included_delay_frag_id != INVALID_FRAG_ID &&
             !rebuild_prog.empty()) {
-            auto &cfrag = fragments[pfrag.included_delay_frag_id];
+            const auto &cfrag = fragments[pfrag.included_delay_frag_id];
             assert(pfrag.s.length() >= cfrag.s.length() &&
                    !pfrag.s.any_nocase() >= !cfrag.s.any_nocase());
             u32 child_offset = cfrag.delay_program_offset;
@@ -3011,7 +3011,7 @@ void updateLitProtoProgramOffset(vector<LitFragment> &fragments,
     auto &proto = *litProto.hwlmProto;
     for (auto &lit : proto.lits) {
         auto fragId = lit.id;
-        auto &frag = fragments[fragId];
+        const auto &frag = fragments[fragId];
         if (delay) {
             DEBUG_PRINTF("delay_program_offset:%u\n",
                          frag.delay_program_offset);

--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -2992,6 +2992,7 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
                                                     pfrag.lit_ids);
         if (pfrag.included_delay_frag_id != INVALID_FRAG_ID &&
             !rebuild_prog.empty()) {
+            const auto &cfrag = fragments[pfrag.included_frag_id];
             /** assert(pfrag.s.length() >= cfrag.s.length() && **/
             assert(pfrag.s.length() == cfrag.s.length() &&
                    !pfrag.s.any_nocase() >= !cfrag.s.any_nocase());

--- a/src/rose/rose_build_exclusive.cpp
+++ b/src/rose/rose_build_exclusive.cpp
@@ -118,7 +118,7 @@ bool addPrefixLiterals(NGHolder &h, unordered_set<u32> &tailId,
 
     for (auto v : adjacent_vertices_range(start, h)) {
         if (v != h.startDs) {
-            for (auto &t : tails) {
+            for (const auto &t : tails) {
                 add_edge(t, v, h);
             }
         }
@@ -126,7 +126,7 @@ bool addPrefixLiterals(NGHolder &h, unordered_set<u32> &tailId,
 
     clear_out_edges(start, h);
     add_edge(h.start, h.start, h);
-    for (auto &t : heads) {
+    for (const auto &t : heads) {
         add_edge(start, t, h);
     }
 

--- a/src/rose/rose_build_groups.cpp
+++ b/src/rose/rose_build_groups.cpp
@@ -275,7 +275,7 @@ void assignGroupsToLiterals(RoseBuildImpl &build) {
     // Second pass: the other literals.
     for (u32 id = 0; id < literals.size(); id++) {
         const rose_literal_id &lit = literals.at(id);
-        rose_literal_info &info = literal_info[id];
+        const rose_literal_info &info = literal_info[id];
 
         if (!requires_group_assignment(lit, info)) {
             continue;

--- a/src/rose/rose_build_merge.cpp
+++ b/src/rose/rose_build_merge.cpp
@@ -1338,7 +1338,7 @@ void chunk(vector<T> in, vector<vector<T>> *out, size_t chunk_size) {
 }
 
 static
-insertion_ordered_map<left_id, vector<RoseVertex>> get_eng_verts(RoseGraph &g) {
+insertion_ordered_map<left_id, vector<RoseVertex>> get_eng_verts(const RoseGraph &g) {
     insertion_ordered_map<left_id, vector<RoseVertex>> eng_verts;
     for (auto v : vertices_range(g)) {
         const auto &left = g[v].left;
@@ -1924,7 +1924,7 @@ void mergeSmallLeftfixes(RoseBuildImpl &tbi) {
         }
 
         assert(left.graph());
-        NGHolder &h = *left.graph();
+        const NGHolder &h = *left.graph();
 
         /* Ensure that kind on the graph is correct */
         assert(h.kind == (tbi.isRootSuccessor(v) ? NFA_PREFIX : NFA_INFIX));
@@ -2024,7 +2024,7 @@ void mergeCastleLeftfixes(RoseBuildImpl &build) {
         return;
     }
 
-    RoseGraph &g = build.g;
+    const RoseGraph &g = build.g;
 
     insertion_ordered_map<left_id, vector<RoseVertex>> eng_verts;
 
@@ -2306,7 +2306,7 @@ void mergeOutfixInfo(OutfixInfo &winner, const OutfixInfo &victim) {
 }
 
 static
-map<NGHolder *, NGHolder *> chunkedNfaMerge(RoseBuildImpl &build,
+map<NGHolder *, NGHolder *> chunkedNfaMerge(const RoseBuildImpl &build,
                                             const vector<NGHolder *> &nfas) {
     map<NGHolder *, NGHolder *> merged;
 

--- a/src/rose/rose_build_role_aliasing.cpp
+++ b/src/rose/rose_build_role_aliasing.cpp
@@ -1352,8 +1352,8 @@ bool attemptRoseMerge(RoseBuildImpl &build, bool preds_same, RoseVertex a,
     assert(a != b);
 
     RoseGraph &g = build.g;
-    LeftEngInfo &a_left = g[a].left;
-    LeftEngInfo &b_left = g[b].left;
+    const LeftEngInfo &a_left = g[a].left;
+    const LeftEngInfo &b_left = g[b].left;
 
     // Trivial case.
     if (a_left == b_left) {
@@ -1601,7 +1601,7 @@ void diamondMergePass(CandidateSet &candidates, RoseBuildImpl &build,
                       vector<RoseVertex> *dead, bool mergeRoses,
                       RoseAliasingInfo &rai) {
     DEBUG_PRINTF("begin\n");
-    RoseGraph &g = build.g;
+    const RoseGraph &g = build.g;
 
     if (candidates.empty()) {
         return;
@@ -1972,7 +1972,7 @@ bool hasNoDiamondSiblings(const RoseGraph &g, RoseVertex v) {
  * merge.
  */
 static
-void filterDiamondCandidates(RoseGraph &g, CandidateSet &candidates) {
+void filterDiamondCandidates(const RoseGraph &g, CandidateSet &candidates) {
     DEBUG_PRINTF("%zu candidates enter\n", candidates.size());
 
     vector<RoseVertex> dead;

--- a/src/som/slot_manager.cpp
+++ b/src/som/slot_manager.cpp
@@ -187,7 +187,7 @@ u32 SomSlotManager::getInitialResetSomSlot(const NGHolder &prefix,
             find_if(reset.entries.begin(), reset.entries.end(),
                     has_prefix_func) != reset.entries.end();
 
-        for (auto &e : reset.entries) {
+        for (const auto &e : reset.entries) {
             u32 temp = 0;
             /* we don't need to test against sentinels which are identical to
              * our current one as races don't matter and we know it clears

--- a/src/util/clique.cpp
+++ b/src/util/clique.cpp
@@ -79,7 +79,7 @@ vector<u32> findCliqueGroup(CliqueGraph &cg) {
 
         // Choose a vertex from the graph
         u32 id = g[0];
-        CliqueVertex &n = vertexMap.at(id);
+        const CliqueVertex &n = vertexMap.at(id);
         clique.emplace_back(id);
         // Corresponding vertex in the original graph
         set<u32> subgraphId(g.begin(), g.end());

--- a/tools/hsbench/engine_hyperscan.cpp
+++ b/tools/hsbench/engine_hyperscan.cpp
@@ -132,7 +132,7 @@ void EngineHyperscan::scan(const char *data, unsigned int len, unsigned int id,
                            ResultEntry &result, EngineContext &ectx) const {
     assert(data);
 
-    EngineHSContext &ctx = static_cast<EngineHSContext &>(ectx);
+    const EngineHSContext &ctx = static_cast<EngineHSContext &>(ectx);
     ScanHSContext sc(id, result, nullptr);
     auto callback = echo_matches ? onMatchEcho : onMatch;
     hs_error_t rv = hs_scan(db, data, len, 0, ctx.scratch, callback, &sc);
@@ -150,7 +150,7 @@ void EngineHyperscan::scan_vectored(const char *const *data,
     assert(data);
     assert(len);
 
-    EngineHSContext &ctx = static_cast<EngineHSContext &>(ectx);
+    const EngineHSContext &ctx = static_cast<EngineHSContext &>(ectx);
     ScanHSContext sc(streamId, result, nullptr);
     auto callback = echo_matches ? onMatchEcho : onMatch;
     hs_error_t rv =
@@ -198,8 +198,8 @@ void EngineHyperscan::streamScan(EngineStream &stream, const char *data,
                                  ResultEntry &result) const {
     assert(data);
 
-    auto &s = static_cast<EngineHSStream &>(stream);
-    EngineHSContext &ctx = *s.ctx;
+    const auto &s = static_cast<EngineHSStream &>(stream);
+    const EngineHSContext &ctx = *s.ctx;
 
     ScanHSContext sc(id, result, &s);
     auto callback = echo_matches ? onMatchEcho : onMatch;
@@ -215,7 +215,7 @@ void EngineHyperscan::streamScan(EngineStream &stream, const char *data,
 void EngineHyperscan::streamCompressExpand(EngineStream &stream,
                                            vector<char> &temp) const {
     size_t used = 0;
-    auto &s = static_cast<EngineHSStream &>(stream);
+    const auto &s = static_cast<EngineHSStream &>(stream);
     hs_error_t err = hs_compress_stream(s.id, temp.data(), temp.size(),
                                         &used);
     if (err == HS_INSUFFICIENT_SPACE) {

--- a/unit/hyperscan/logical_combination.cpp
+++ b/unit/hyperscan/logical_combination.cpp
@@ -45,8 +45,8 @@ TEST(LogicalCombination, SingleComb1) {
     string data = "abcdefxxfoobarrrghabcxdefxteakettleeeeexxxxijklmxxdef";
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(101 & 102 & 103) | (104 & !105)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION};
-    unsigned ids[] = {101, 102, 103, 104, 105, 1001};
+    const unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION};
+    const unsigned ids[] = {101, 102, 103, 104, 105, 1001};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -92,9 +92,9 @@ TEST(LogicalCombination, SingleCombQuietSub1) {
     string data = "abcdefxxfoobarrrghabcxdefxteakettleeeeexxxxijklmxxdef";
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(101 & 102 & 103) | (104 & !105)"};
-    unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET,
+    const unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET,
                         HS_FLAG_QUIET, 0, HS_FLAG_COMBINATION};
-    unsigned ids[] = {101, 102, 103, 104, 105, 1001};
+    const unsigned ids[] = {101, 102, 103, 104, 105, 1001};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -133,11 +133,11 @@ TEST(LogicalCombination, MultiCombQuietSub1) {
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(101 & 102 & 103) | (104 & !105)",
                           "!101 & 102", "!(!101 | 102)", "101 & !102"};
-    unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET,
+    const unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET,
                         HS_FLAG_QUIET, 0, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION};
-    unsigned ids[] = {101, 102, 103, 104, 105, 1001, 1002, 1003, 1004};
+    const unsigned ids[] = {101, 102, 103, 104, 105, 1001, 1002, 1003, 1004};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 9, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -178,13 +178,13 @@ TEST(LogicalCombination, MultiHighlanderCombQuietSub1) {
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(101 & 102 & 103) | (104 & !105)",
                           "!101 & 102", "!(!101 | 102)", "101 & !102"};
-    unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET,
+    const unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET,
                         HS_FLAG_QUIET, 0,
                         HS_FLAG_COMBINATION | HS_FLAG_SINGLEMATCH,
                         HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION | HS_FLAG_SINGLEMATCH,
                         HS_FLAG_COMBINATION | HS_FLAG_SINGLEMATCH};
-    unsigned ids[] = {101, 102, 103, 104, 105, 1001, 1002, 1003, 1004};
+    const unsigned ids[] = {101, 102, 103, 104, 105, 1001, 1002, 1003, 1004};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 9, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -219,11 +219,11 @@ TEST(LogicalCombination, MultiQuietCombQuietSub1) {
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(101 & 102 & 103) | (104 & !105)",
                           "!101 & 102", "!(!101 | 102)", "101 & !102"};
-    unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET,
+    const unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET,
                         HS_FLAG_QUIET, 0, HS_FLAG_COMBINATION | HS_FLAG_QUIET,
                         HS_FLAG_COMBINATION, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION | HS_FLAG_QUIET};
-    unsigned ids[] = {101, 102, 103, 104, 105, 1001, 1002, 1003, 1004};
+    const unsigned ids[] = {101, 102, 103, 104, 105, 1001, 1002, 1003, 1004};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 9, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -255,8 +255,8 @@ TEST(LogicalCombination, SingleComb2) {
     string data = "abbdefxxfoobarrrghabcxdefxteakettleeeeexxxxijklmxxdef";
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(201 | 202 & 203) & (!204 | 205)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION};
-    unsigned ids[] = {201, 202, 203, 204, 205, 1002};
+    const unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION};
+    const unsigned ids[] = {201, 202, 203, 204, 205, 1002};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -299,9 +299,9 @@ TEST(LogicalCombination, SingleCombQuietSub2) {
     string data = "abbdefxxfoobarrrghabcxdefxteakettleeeeexxxxijklmxxdef";
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(201 | 202 & 203) & (!204 | 205)"};
-    unsigned flags[] = {0, HS_FLAG_QUIET, HS_FLAG_QUIET, 0, HS_FLAG_QUIET,
+    const unsigned flags[] = {0, HS_FLAG_QUIET, HS_FLAG_QUIET, 0, HS_FLAG_QUIET,
                         HS_FLAG_COMBINATION};
-    unsigned ids[] = {201, 202, 203, 204, 205, 1002};
+    const unsigned ids[] = {201, 202, 203, 204, 205, 1002};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -339,8 +339,8 @@ TEST(LogicalCombination, SingleComb3) {
     string data = "abcijklndefxxfoobarrrghabcxdefxteakettleeeeexxxxijklnxxdef";
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "((301 | 302) & 303) & (304 | 305)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION};
-    unsigned ids[] = {301, 302, 303, 304, 305, 1003};
+    const unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION};
+    const unsigned ids[] = {301, 302, 303, 304, 305, 1003};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -387,9 +387,9 @@ TEST(LogicalCombination, SingleCombQuietSub3) {
     string data = "abcijklndefxxfoobarrrghabcxdefxteakettleeeeexxxxijklnxxdef";
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "((301 | 302) & 303) & (304 | 305)"};
-    unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, 0, HS_FLAG_QUIET,
+    const unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, 0, HS_FLAG_QUIET,
                         HS_FLAG_QUIET, HS_FLAG_COMBINATION};
-    unsigned ids[] = {301, 302, 303, 304, 305, 1003};
+    const unsigned ids[] = {301, 302, 303, 304, 305, 1003};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -429,9 +429,9 @@ TEST(LogicalCombination, MultiCombDupSub4) {
                           "ijkl[mMn]", "(201 & 202 & 203) | (204 & !205)",
                           "(201 | 202 & 203) & (!204 | 205)",
                           "((201 | 202) & 203) & (204 | 205)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION,
+    const unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION, HS_FLAG_COMBINATION};
-    unsigned ids[] = {201, 202, 203, 204, 205, 1001, 1002, 1003};
+    const unsigned ids[] = {201, 202, 203, 204, 205, 1001, 1002, 1003};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 8, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -486,10 +486,10 @@ TEST(LogicalCombination, MultiCombQuietDupSub4) {
                           "ijkl[mMn]", "(201 & 202 & 203) | (204 & !205)",
                           "(201 | 202 & 203) & (!204 | 205)",
                           "((201 | 202) & 203) & (204 | 205)"};
-    unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET, 0,
+    const unsigned flags[] = {HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET, 0,
                         HS_FLAG_QUIET, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION, HS_FLAG_COMBINATION};
-    unsigned ids[] = {201, 202, 203, 204, 205, 1001, 1002, 1003};
+    const unsigned ids[] = {201, 202, 203, 204, 205, 1001, 1002, 1003};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 8, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -546,10 +546,10 @@ TEST(LogicalCombination, MultiCombUniSub5) {
                           "(101 & 102 & 103) | (104 & !105)",
                           "(201 | 202 & 203) & (!204 | 205)",
                           "((301 | 302) & 303) & (304 | 305)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    const unsigned flags[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         HS_FLAG_COMBINATION, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION};
-    unsigned ids[] = {101, 102, 103, 104, 105, 201, 202, 203, 204, 205, 301,
+    const unsigned ids[] = {101, 102, 103, 104, 105, 201, 202, 203, 204, 205, 301,
                       302, 303, 304, 305, 1001, 1002, 1003};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 18, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
@@ -636,12 +636,12 @@ TEST(LogicalCombination, MultiCombQuietUniSub5) {
                           "(101 & 102 & 103) | (104 & !105)",
                           "(201 | 202 & 203) & (!204 | 205)",
                           "((301 | 302) & 303) & (304 | 305)"};
-    unsigned flags[] = {0, HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET, 0,
+    const unsigned flags[] = {0, HS_FLAG_QUIET, HS_FLAG_QUIET, HS_FLAG_QUIET, 0,
                         HS_FLAG_QUIET, 0, HS_FLAG_QUIET, 0, HS_FLAG_QUIET,
                         HS_FLAG_QUIET, HS_FLAG_QUIET, 0, HS_FLAG_QUIET, 0,
                         HS_FLAG_COMBINATION, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION};
-    unsigned ids[] = {101, 102, 103, 104, 105, 201, 202, 203, 204, 205, 301,
+    const unsigned ids[] = {101, 102, 103, 104, 105, 201, 202, 203, 204, 205, 301,
                       302, 303, 304, 305, 1001, 1002, 1003};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 18, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
@@ -702,8 +702,8 @@ TEST(LogicalCombination, SingleCombPurelyNegative6) {
     string data = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(!201 | 202 & 203) & (!204 | 205)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION};
-    unsigned ids[] = {201, 202, 203, 204, 205, 1002};
+    const unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION};
+    const unsigned ids[] = {201, 202, 203, 204, 205, 1002};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -734,8 +734,8 @@ TEST(LogicalCombination, SingleCombQuietPurelyNegative6) {
     string data = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
     const char *expr[] = {"abc", "def", "foobar.*gh", "teakettle{4,10}",
                           "ijkl[mMn]", "(!201 | 202 & 203) & (!204 | 205)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION | HS_FLAG_QUIET};
-    unsigned ids[] = {201, 202, 203, 204, 205, 1002};
+    const unsigned flags[] = {0, 0, 0, 0, 0, HS_FLAG_COMBINATION | HS_FLAG_QUIET};
+    const unsigned ids[] = {201, 202, 203, 204, 205, 1002};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -775,10 +775,10 @@ TEST(LogicalCombination, MultiCombPurelyNegativeUniSub6) {
                           "(101 & 102 & 103) | (!104 & !105)",
                           "(!201 | 202 & 203) & (!204 | 205)",
                           "((301 | 302) & 303) & (304 | 305)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    const unsigned flags[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         HS_FLAG_COMBINATION, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION};
-    unsigned ids[] = {101, 102, 103, 104, 105, 201, 202, 203, 204, 205, 301,
+    const unsigned ids[] = {101, 102, 103, 104, 105, 201, 202, 203, 204, 205, 301,
                       302, 303, 304, 305, 1001, 1002, 1003};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 18, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
@@ -822,11 +822,11 @@ TEST(LogicalCombination, MultiCombPurelyNegativeUniSubEOD6) {
                           "(101 & 102 & 103) | (!104 & !105)",
                           "(!201 | 202 & 203) & (!204 | 205)",
                           "((301 | 302) & 303) & (304 | 305)"};
-    unsigned flags[] = {0, 0, 0, 0, 0, 0, HS_FLAG_MULTILINE,
+    const unsigned flags[] = {0, 0, 0, 0, 0, 0, HS_FLAG_MULTILINE,
                         0, 0, 0, 0, 0, 0, 0, 0,
                         HS_FLAG_COMBINATION, HS_FLAG_COMBINATION,
                         HS_FLAG_COMBINATION};
-    unsigned ids[] = {101, 102, 103, 104, 105, 201, 202, 203, 204, 205, 301,
+    const unsigned ids[] = {101, 102, 103, 104, 105, 201, 202, 203, 204, 205, 301,
                       302, 303, 304, 305, 1001, 1002, 1003};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 18, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
@@ -875,8 +875,8 @@ TEST(LogicalCombination, MultiCombStream1) {
                      "z"};
     const char *expr[] = {"abc", "def", "xyz", "zxyz",
                           "101 & 102", "201 & !202"};
-    unsigned flags[] = {0, 0, 0, 0, HS_FLAG_COMBINATION, HS_FLAG_COMBINATION};
-    unsigned ids[] = {101, 102, 201, 202, 1001, 1002};
+    const unsigned flags[] = {0, 0, 0, 0, HS_FLAG_COMBINATION, HS_FLAG_COMBINATION};
+    const unsigned ids[] = {101, 102, 201, 202, 1001, 1002};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 6, HS_MODE_STREAM,
                                       nullptr, &db, &compile_err);
 

--- a/unit/hyperscan/multi.cpp
+++ b/unit/hyperscan/multi.cpp
@@ -44,8 +44,8 @@ TEST(MMAdaptor, norm_cont1) { // UE-901
     CallBackContext c;
     string data = "aooAaooAbarZ";
     const char *expr[] = {"aoo[A-K]", "bar[L-Z]"};
-    unsigned flags[] = {0, 0};
-    unsigned ids[] = {30, 31};
+    const unsigned flags[] = {0, 0};
+    const unsigned ids[] = {30, 31};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 2, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -77,8 +77,8 @@ TEST(MMAdaptor, norm_cont2) {
     CallBackContext c;
     string data = "aooAaooAbarZ                      ";
     const char *expr[] = {"aoo[A-K][^\n]{16}", "bar[L-Z][^\n]{16}"};
-    unsigned flags[] = {0, 0};
-    unsigned ids[] = {30, 31};
+    const unsigned flags[] = {0, 0};
+    const unsigned ids[] = {30, 31};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 2, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -110,8 +110,8 @@ TEST(MMAdaptor, norm_halt1) {
     CallBackContext c;
     string data = "aooAaooAbarZ";
     const char *expr[] = {"aoo[A-K]", "bar[L-Z]"};
-    unsigned flags[] = {0, 0};
-    unsigned ids[] = {30, 31};
+    const unsigned flags[] = {0, 0};
+    const unsigned ids[] = {30, 31};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 2, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -141,8 +141,8 @@ TEST(MMAdaptor, norm_halt2) { // UE-901
     CallBackContext c;
     string data = "aooAaooAbarZ                      ";
     const char *expr[] = {"aoo[A-K][^\n]{16}", "bar[L-Z][^\n]{16}"};
-    unsigned flags[] = {0, 0};
-    unsigned ids[] = {30, 31};
+    const unsigned flags[] = {0, 0};
+    const unsigned ids[] = {30, 31};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 2, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -172,8 +172,8 @@ TEST(MMAdaptor, high_cont1) { // UE-901
     CallBackContext c;
     string data = "aooAaooAbarZ";
     const char *expr[] = {"aoo[A-K]", "bar[L-Z]"};
-    unsigned flags[] = {HS_FLAG_SINGLEMATCH, 0};
-    unsigned ids[] = {30, 31};
+    const unsigned flags[] = {HS_FLAG_SINGLEMATCH, 0};
+    const unsigned ids[] = {30, 31};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 2, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -204,8 +204,8 @@ TEST(MMAdaptor, high_cont2) {
     CallBackContext c;
     string data = "aooAaooAbarZ                      ";
     const char *expr[] = {"aoo[A-K][^\n]{16}", "bar[L-Z][^\n]{16}"};
-    unsigned flags[] = {HS_FLAG_SINGLEMATCH, 0};
-    unsigned ids[] = {30, 31};
+    const unsigned flags[] = {HS_FLAG_SINGLEMATCH, 0};
+    const unsigned ids[] = {30, 31};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 2, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -236,8 +236,8 @@ TEST(MMAdaptor, high_halt1) {
     CallBackContext c;
     string data = "aooAaooAbarZ";
     const char *expr[] = {"aoo[A-K]", "bar[L-Z]"};
-    unsigned flags[] = {HS_FLAG_SINGLEMATCH, 0};
-    unsigned ids[] = {30, 31};
+    const unsigned flags[] = {HS_FLAG_SINGLEMATCH, 0};
+    const unsigned ids[] = {30, 31};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 2, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -267,8 +267,8 @@ TEST(MMAdaptor, high_halt2) {
     CallBackContext c;
     string data = "aooAaooAbarZbarZaooA                      ";
     const char *expr[] = {"aoo[A-K][^\n]{16}", "bar[L-Z][^\n]{16}"};
-    unsigned flags[] = {HS_FLAG_SINGLEMATCH, 0};
-    unsigned ids[] = {30, 31};
+    const unsigned flags[] = {HS_FLAG_SINGLEMATCH, 0};
+    const unsigned ids[] = {30, 31};
     hs_error_t err = hs_compile_multi(expr, flags, ids, 2, HS_MODE_NOSTREAM,
                                       nullptr, &db, &compile_err);
 
@@ -342,7 +342,7 @@ TEST(MMRoseLiteralPath, issue_141) {
     const char *expr[] = {"/odezhda-dlya-bega/",
                           "kurtki-i-vetrovki-dlya-bega",
                           "futbolki-i-mayki-dlya-bega"};
-    unsigned flags[] = {HS_FLAG_DOTALL | HS_FLAG_SINGLEMATCH,
+    const unsigned flags[] = {HS_FLAG_DOTALL | HS_FLAG_SINGLEMATCH,
                         HS_FLAG_DOTALL | HS_FLAG_SINGLEMATCH,
                         HS_FLAG_DOTALL | HS_FLAG_SINGLEMATCH};
     hs_error_t err = hs_compile_multi(expr, flags, nullptr, 3, HS_MODE_BLOCK,

--- a/unit/internal/nfagraph_common.h
+++ b/unit/internal/nfagraph_common.h
@@ -41,7 +41,7 @@ namespace ue2 {
 // Helper function: construct a graph from an expression, flags and context.
 inline
 std::unique_ptr<NGHolder> constructGraphWithCC(const std::string &expr,
-                                               CompileContext &cc,
+                                               const CompileContext &cc,
                                                unsigned flags) {
     ReportManager rm(cc.grey);
     ParsedExpression parsed(0, expr.c_str(), flags, 0);

--- a/unit/internal/state_compress.cpp
+++ b/unit/internal/state_compress.cpp
@@ -152,7 +152,7 @@ TEST(state_compress, m128_1) {
 TEST(state_compress, m128_2) {
     char buf[sizeof(m128)] = { 0 };
 
-    char val_raw[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
+    const char val_raw[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
                          '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
     m128 val;
     memcpy(&val, val_raw, sizeof(val));
@@ -228,7 +228,7 @@ TEST(state_compress, m256_1) {
 TEST(state_compress, m256_2) {
     char buf[sizeof(m256)] = { 0 };
 
-    char val_raw[32] = { '0', '1', '2', '3', '4', '5', '6', '7',
+    const char val_raw[32] = { '0', '1', '2', '3', '4', '5', '6', '7',
                          '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
                          'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
                          'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P' };
@@ -306,7 +306,7 @@ TEST(state_compress, m384_1) {
 TEST(state_compress, m384_2) {
     char buf[sizeof(m384)] = { 0 };
 
-    char val_raw[48] = { '0', '1', '2', '3', '4', '5', '6', '7',
+    const char val_raw[48] = { '0', '1', '2', '3', '4', '5', '6', '7',
                          '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
                          'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
                          'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
@@ -386,7 +386,7 @@ TEST(state_compress, m512_1) {
 TEST(state_compress, m512_2) {
     char buf[sizeof(m512)] = { 0 };
 
-    char val_raw[64] = { '0', '1', '2', '3', '4', '5', '6', '7',
+    const char val_raw[64] = { '0', '1', '2', '3', '4', '5', '6', '7',
                          '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
                          'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
                          'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',

--- a/util/ng_find_matches.cpp
+++ b/util/ng_find_matches.cpp
@@ -861,7 +861,7 @@ bool isUtf8CodePoint(const char c) {
 }
 
 static
-bool canReach(const NGHolder &g, const NFAEdge &e, struct fmstate &state) {
+bool canReach(const NGHolder &g, const NFAEdge &e, const struct fmstate &state) {
     auto flags = g[e].assert_flags;
     if (!flags) {
         return true;


### PR DESCRIPTION
47 [constParameterReference]
48 [constVariableReference]
58 [constVariable]

false positives: 

../src/nfa/goughcompile.cpp:444:72: style: Parameter 'rep' can be declared as re
ference to const [constParameterReference] -> const doesnt work there.

../src/nfa/mcsheng_compile.cpp:537:62: style: Parameter 'accel_escape_info' can
be declared as reference to const [constParameterReference] -> const doesnt work
 there

../src/nfagraph/ng_limex_accel.cpp:466:16: style: Variable 'p' can be declared a
s reference to const [constVariableReference] -> const doesnt work there

../src/rose/rose_build_anchored.cpp:870:37: style: Parameter 'build' can be decl
ared as reference to const [constParameterReference] -> const doesnt work there

