### PR TITLE
Truffle further speed up (10-40%)

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, 2021, VectorCamp PC
+ * Copyright (c) 2023, 2024, Arm Limited
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -34,6 +35,7 @@
 #include <iostream>
 #include <memory>
 
+#include "util/arch.h"
 #include "benchmarks.hpp"
 
 #define MAX_LOOPS 1000000000
@@ -145,11 +147,11 @@ int main(){
                 sizes[i], MAX_LOOPS / sizes[i], matches[m], false, bench,
                 [&](MicroBenchmark &b) {
                     b.chars.set('a');
-                    ue2::shuftiBuildMasks(b.chars, (u8 *)&b.lo, (u8 *)&b.hi);
+                    ue2::shuftiBuildMasks(b.chars, (u8 *)&b.truffle_mask.lo, (u8 *)&b.truffle_mask.hi);
                     memset(b.buf.data(), 'b', b.size);
                 },
                 [&](MicroBenchmark &b) {
-                    return shuftiExec(b.lo, b.hi, b.buf.data(),
+                    return shuftiExec(b.truffle_mask.lo, b.truffle_mask.hi, b.buf.data(),
                                       b.buf.data() + b.size);
                 });
         }
@@ -160,11 +162,11 @@ int main(){
                 sizes[i], MAX_LOOPS / sizes[i], matches[m], true, bench,
                 [&](MicroBenchmark &b) {
                     b.chars.set('a');
-                    ue2::shuftiBuildMasks(b.chars, (u8 *)&b.lo, (u8 *)&b.hi);
+                    ue2::shuftiBuildMasks(b.chars, (u8 *)&b.truffle_mask.lo, (u8 *)&b.truffle_mask.hi);
                     memset(b.buf.data(), 'b', b.size);
                 },
                 [&](MicroBenchmark &b) {
-                    return rshuftiExec(b.lo, b.hi, b.buf.data(),
+                    return rshuftiExec(b.truffle_mask.lo, b.truffle_mask.hi, b.buf.data(),
                                        b.buf.data() + b.size);
                 });
         }
@@ -175,11 +177,11 @@ int main(){
                 sizes[i], MAX_LOOPS / sizes[i], matches[m], false, bench,
                 [&](MicroBenchmark &b) {
                     b.chars.set('a');
-                    ue2::truffleBuildMasks(b.chars, (u8 *)&b.lo, (u8 *)&b.hi);
+                    ue2::truffleBuildMasks(b.chars, (u8 *)&b.truffle_mask.lo, (u8 *)&b.truffle_mask.hi);
                     memset(b.buf.data(), 'b', b.size);
                 },
                 [&](MicroBenchmark &b) {
-                    return truffleExec(b.lo, b.hi, b.buf.data(),
+                    return truffleExec(b.truffle_mask.lo, b.truffle_mask.hi, b.buf.data(),
                                        b.buf.data() + b.size);
                 });
         }
@@ -190,14 +192,45 @@ int main(){
                 sizes[i], MAX_LOOPS / sizes[i], matches[m], true, bench,
                 [&](MicroBenchmark &b) {
                     b.chars.set('a');
-                    ue2::truffleBuildMasks(b.chars, (u8 *)&b.lo, (u8 *)&b.hi);
+                    ue2::truffleBuildMasks(b.chars, (u8 *)&b.truffle_mask.lo, (u8 *)&b.truffle_mask.hi);
                     memset(b.buf.data(), 'b', b.size);
                 },
                 [&](MicroBenchmark &b) {
-                    return rtruffleExec(b.lo, b.hi, b.buf.data(),
+                    return rtruffleExec(b.truffle_mask.lo, b.truffle_mask.hi, b.buf.data(),
                                         b.buf.data() + b.size);
                 });
         }
+#ifdef HAVE_SVE
+        if(svcntb() >= 32) {
+            for (size_t i = 0; i < std::size(sizes); i++) {
+                MicroBenchmark bench("Truffle32", sizes[i]);
+                run_benchmarks(sizes[i], MAX_LOOPS / sizes[i], matches[m], false, bench,
+                    [&](MicroBenchmark &b) {
+                        b.chars.set('a');
+                        ue2::truffleBuildMasks32(b.chars, (u8 *)&(b.truffle_mask));
+                        memset(b.buf.data(), 'b', b.size);
+                    },
+                    [&](MicroBenchmark &b) {
+                        return truffleExec32(b.truffle_mask, b.buf.data(), b.buf.data() + b.size);
+                    }
+                );
+            }
+
+            for (size_t i = 0; i < std::size(sizes); i++) {
+                MicroBenchmark bench("Reverse Truffle32", sizes[i]);
+                run_benchmarks(sizes[i], MAX_LOOPS / sizes[i], matches[m], true, bench,
+                    [&](MicroBenchmark &b) {
+                        b.chars.set('a');
+                        ue2::truffleBuildMasks32(b.chars, (u8 *)&(b.truffle_mask));
+                        memset(b.buf.data(), 'b', b.size);
+                    },
+                    [&](MicroBenchmark &b) {
+                        return rtruffleExec32(b.truffle_mask, b.buf.data(), b.buf.data() + b.size);
+                    }
+                );
+            }
+        }
+#endif
 
         for (size_t i = 0; i < std::size(sizes); i++) {
             MicroBenchmark bench("Vermicelli", sizes[i]);
@@ -205,7 +238,7 @@ int main(){
                 sizes[i], MAX_LOOPS / sizes[i], matches[m], false, bench,
                 [&](MicroBenchmark &b) {
                     b.chars.set('a');
-                    ue2::truffleBuildMasks(b.chars, (u8 *)&b.lo, (u8 *)&b.hi);
+                    ue2::truffleBuildMasks(b.chars, (u8 *)&b.truffle_mask.lo, (u8 *)&b.truffle_mask.hi);
                     memset(b.buf.data(), 'b', b.size);
                 },
                 [&](MicroBenchmark &b) {
@@ -220,7 +253,7 @@ int main(){
                 sizes[i], MAX_LOOPS / sizes[i], matches[m], true, bench,
                 [&](MicroBenchmark &b) {
                     b.chars.set('a');
-                    ue2::truffleBuildMasks(b.chars, (u8 *)&b.lo, (u8 *)&b.hi);
+                    ue2::truffleBuildMasks(b.chars, (u8 *)&b.truffle_mask.lo, (u8 *)&b.truffle_mask.hi);
                     memset(b.buf.data(), 'b', b.size);
                 },
                 [&](MicroBenchmark &b) {

--- a/benchmarks/benchmarks.hpp
+++ b/benchmarks/benchmarks.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, 2021, VectorCamp PC
+ * Copyright (c) 2024, Arm Limited
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -44,7 +45,7 @@ public:
     size_t size;
 
     // Shufti/Truffle
-    m128 lo, hi;
+    m256 truffle_mask;
     ue2::CharReach chars;
     std::vector<u8> buf;
 

--- a/src/hwlm/hwlm.c
+++ b/src/hwlm/hwlm.c
@@ -73,7 +73,12 @@ const u8 *run_hwlm_accel(const union AccelAux *aux, const u8 *ptr,
         return shuftiExec(aux->shufti.lo, aux->shufti.hi, ptr, end);
     case ACCEL_TRUFFLE:
         DEBUG_PRINTF("truffle\n");
-        return truffleExec(aux->truffle.mask1, aux->truffle.mask2, ptr, end);
+        return truffleExec(aux->truffle.mask.lo, aux->truffle.mask.hi, ptr, end);
+#ifdef HAVE_SVE
+    case ACCEL_TRUFFLE_WIDE:
+        DEBUG_PRINTF("truffle wide\n");
+        return truffleExec32(aux->truffle.mask, ptr, end);
+#endif // HAVE_SVE
     default:
         /* no acceleration, fall through and return current ptr */
         DEBUG_PRINTF("no accel; %u\n", (int)aux->accel_type);

--- a/src/nfa/accel.c
+++ b/src/nfa/accel.c
@@ -142,7 +142,16 @@ const u8 *run_accel(const union AccelAux *accel, const u8 *c, const u8 *c_end) {
             return c;
         }
 
-        rv = truffleExec(accel->truffle.mask1, accel->truffle.mask2, c, c_end);
+        rv = truffleExec(accel->truffle.mask.lo, accel->truffle.mask.hi, c, c_end);
+        break;
+
+    case ACCEL_TRUFFLE_WIDE:
+        DEBUG_PRINTF("accel Truffle Wide %p %p\n", c, c_end);
+        if (c + 15 >= c_end) {
+            return c;
+        }
+
+        rv = truffleExec32(accel->truffle.mask, c, c_end);
         break;
 
     case ACCEL_DSHUFTI:

--- a/src/nfa/accel.h
+++ b/src/nfa/accel.h
@@ -66,6 +66,7 @@ enum AccelType {
     ACCEL_VERM16,
     ACCEL_DVERM16,
     ACCEL_DVERM16_MASKED,
+    ACCEL_TRUFFLE_WIDE,
 };
 
 /** \brief Structure for accel framework. */
@@ -136,8 +137,7 @@ union AccelAux {
     struct {
         u8 accel_type;
         u8 offset;
-        m128 mask1;
-        m128 mask2;
+        m256 mask;
     } truffle;
 };
 

--- a/src/nfa/accel_dfa_build_strat.cpp
+++ b/src/nfa/accel_dfa_build_strat.cpp
@@ -569,9 +569,20 @@ accel_dfa_build_strat::buildAccel(UNUSED dstate_id_t this_idx,
     }
 
     assert(!info.cr.none());
+#if defined(HAVE_SVE)
+    if(svcntb() >= 32) {
+        accel->accel_type = ACCEL_TRUFFLE_WIDE;
+        truffleBuildMasks32(info.cr, (u8 *)&accel->truffle.mask);
+    } else {
+        accel->accel_type = ACCEL_TRUFFLE;
+        truffleBuildMasks(info.cr, (u8 *)&accel->truffle.mask.lo,
+                        (u8 *)&accel->truffle.mask.hi);
+    }
+#else
     accel->accel_type = ACCEL_TRUFFLE;
-    truffleBuildMasks(info.cr, (u8 *)&accel->truffle.mask1,
-                      (u8 *)&accel->truffle.mask2);
+    truffleBuildMasks(info.cr, (u8 *)&accel->truffle.mask.lo,
+                      (u8 *)&accel->truffle.mask.hi);
+#endif
     DEBUG_PRINTF("state %hu is truffle\n", this_idx);
 }
 

--- a/src/nfa/accel_dump.cpp
+++ b/src/nfa/accel_dump.cpp
@@ -93,6 +93,8 @@ const char *accelName(u8 accel_type) {
         return "double-shufti";
     case ACCEL_TRUFFLE:
         return "truffle";
+    case ACCEL_TRUFFLE_WIDE:
+        return "truffle wide";
     case ACCEL_RED_TAPE:
         return "red tape";
     default:
@@ -179,6 +181,13 @@ void dumpTruffleCharReach(FILE *f, const u8 *hiset, const u8 *hiclear) {
 }
 
 static
+void dumpTruffleCharReach32(FILE *f, const u8 *mask) {
+    CharReach cr = truffle2cr32(mask);
+    fprintf(f, "count %zu class %s\n", cr.count(),
+            describeClass(cr).c_str());
+}
+
+static
 void dumpTruffleMasks(FILE *f, const u8 *hiset, const u8 *hiclear) {
     fprintf(f, "lo %s\n", dumpMask(hiset, 128).c_str());
     fprintf(f, "hi %s\n", dumpMask(hiclear, 128).c_str());
@@ -231,10 +240,17 @@ void dumpAccelInfo(FILE *f, const AccelAux &accel) {
         break;
     case ACCEL_TRUFFLE: {
         fprintf(f, "\n");
-        dumpTruffleMasks(f, (const u8 *)&accel.truffle.mask1,
-                         (const u8 *)&accel.truffle.mask2);
-        dumpTruffleCharReach(f, (const u8 *)&accel.truffle.mask1,
-                             (const u8 *)&accel.truffle.mask2);
+        dumpTruffleMasks(f, (const u8 *)&accel.truffle.mask.lo,
+                         (const u8 *)&accel.truffle.mask.hi);
+        dumpTruffleCharReach(f, (const u8 *)&accel.truffle.mask.lo,
+                             (const u8 *)&accel.truffle.mask.hi);
+        break;
+    }
+    case ACCEL_TRUFFLE_WIDE: {
+        fprintf(f, "\n");
+        dumpTruffleMasks(f, (const u8 *)&accel.truffle.mask.lo,
+                         (const u8 *)&accel.truffle.mask.hi);
+        dumpTruffleCharReach32(f, (const u8 *)&accel.truffle.mask);
         break;
     }
     default:

--- a/src/nfa/accelcompile.cpp
+++ b/src/nfa/accelcompile.cpp
@@ -96,10 +96,15 @@ void buildAccelSingle(const AccelInfo &info, AccelAux *aux) {
 
     if (outs <= ACCEL_MAX_STOP_CHAR) {
         DEBUG_PRINTF("building Truffle for %zu chars\n", outs);
-        aux->accel_type = ACCEL_TRUFFLE;
         aux->truffle.offset = offset;
-        truffleBuildMasks(info.single_stops, (u8 *)&aux->truffle.mask1,
-                          (u8 *)&aux->truffle.mask2);
+        if(svcntb() >= 32) {
+            aux->accel_type = ACCEL_TRUFFLE_WIDE;
+            truffleBuildMasks32(info.single_stops, (u8 *)&aux->truffle.mask);
+        } else {
+            aux->accel_type = ACCEL_TRUFFLE;
+            truffleBuildMasks(info.single_stops, (u8 *)&aux->truffle.mask.lo,
+                            (u8 *)&aux->truffle.mask.hi);
+        }
         return;
     }
 

--- a/src/nfa/arm/truffle.hpp
+++ b/src/nfa/arm/truffle.hpp
@@ -172,9 +172,17 @@ svuint8_t blockSingleMaskSVE(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_ma
     return svand_x(svptrue_b8(), svorr_x(svptrue_b8(), byte_select_low, byte_select_high), bit_select);
 }
 
+#ifdef __ARM_NEON_SVE_BRIDGE
+#include <arm_neon_sve_bridge.h> // Available from Clang 14 and gcc 14
+static really_inline
+svuint8_t blockSingleMask(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_highset, svuint8_t chars) {
+    return svset_neonq(svundef_u8(), blockSingleMaskNEON(svget_neonq(shuf_mask_lo_highclear), svget_neonq(shuf_mask_lo_highset), svget_neonq(chars)));
+}
+#else
 static really_inline
 svuint8_t blockSingleMask(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_highset, svuint8_t chars) {
     return blockSingleMaskSVE(shuf_mask_lo_highclear, shuf_mask_lo_highset, chars);
 }
+#endif /* __ARM_NEON_SVE_BRIDGE */
 
 #endif //HAVE_SVE

--- a/src/nfa/mcclellandump.cpp
+++ b/src/nfa/mcclellandump.cpp
@@ -181,6 +181,9 @@ void dumpAccelText(FILE *f, const union AccelAux *accel) {
     case ACCEL_TRUFFLE:
         fprintf(f, ":M");
         break;
+    case ACCEL_TRUFFLE_WIDE:
+        fprintf(f, ":M");
+        break;
     default:
         fprintf(f, ":??");
         break;
@@ -200,6 +203,7 @@ void dumpAccelDot(FILE *f, u16 i, const union AccelAux *accel) {
     case ACCEL_SHUFTI:
     case ACCEL_DSHUFTI:
     case ACCEL_TRUFFLE:
+    case ACCEL_TRUFFLE_WIDE:
         fprintf(f, "%u [ color = darkgreen style=diagonals ];\n", i);
         break;
     default:

--- a/src/nfa/mcsheng_dump.cpp
+++ b/src/nfa/mcsheng_dump.cpp
@@ -306,6 +306,7 @@ void dumpAccelDot(FILE *f, u16 i, const union AccelAux *accel) {
     case ACCEL_SHUFTI:
     case ACCEL_DSHUFTI:
     case ACCEL_TRUFFLE:
+    case ACCEL_TRUFFLE_WIDE:
         fprintf(f, "%u [ color = darkgreen style=diagonals ];\n", i);
         break;
     default:

--- a/src/nfa/truffle.cpp
+++ b/src/nfa/truffle.cpp
@@ -39,14 +39,24 @@
 
 #include "truffle_simd.hpp"
 #ifdef HAVE_SVE
+const u8 *truffleExec32(m256 mask, const u8 *buf,
+                      const u8 *buf_end) {
+    return truffleExecSVE<32>(mask, buf, buf_end);
+}
+
+const u8 *rtruffleExec32(m256 mask, const u8 *buf,
+                       const u8 *buf_end) {
+    return rtruffleExecSVE<32>(mask, buf, buf_end);
+}
+
 const u8 *truffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
                       const u8 *buf_end) {
-    return truffleExecSVE(mask_lo, mask_hi, buf, buf_end);
+    return truffleExecSVE<16>({mask_lo, mask_hi}, buf, buf_end);
 }
 
 const u8 *rtruffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
                        const u8 *buf_end) {
-    return rtruffleExecSVE(mask_lo, mask_hi, buf, buf_end);
+    return rtruffleExecSVE<16>({mask_lo, mask_hi}, buf, buf_end);
 }
 #else
 const u8 *truffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,

--- a/src/nfa/truffle.h
+++ b/src/nfa/truffle.h
@@ -42,6 +42,14 @@ extern "C"
 {
 #endif
 
+#ifdef HAVE_SVE
+const u8 *truffleExec32(m256 mask, const u8 *buf,
+                      const u8 *buf_end);
+
+const u8 *rtruffleExec32(m256 mask, const u8 *buf,
+                       const u8 *buf_end);
+#endif
+
 const u8 *truffleExec(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset,
                       const u8 *buf, const u8 *buf_end);
 

--- a/src/nfa/truffle_simd.hpp
+++ b/src/nfa/truffle_simd.hpp
@@ -45,6 +45,9 @@
 #ifdef HAVE_SVE
 static really_inline
 svuint8_t blockSingleMask(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_highset, svuint8_t chars);
+
+static really_inline
+svuint8_t blockSingleMask32(svuint8_t shuf_mask_32, svuint8_t chars);
 #else
 template <uint16_t S>
 static really_inline
@@ -64,19 +67,33 @@ const SuperVector<S> blockSingleMask(SuperVector<S> shuf_mask_lo_highclear, Supe
 #endif
 
 #ifdef HAVE_SVE
-
-const u8 *truffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset,
+template <char min_vector_size>
+static really_inline
+const u8 *truffleExecSVE(m256 shuf_mask_32,
                       const u8 *buf, const u8 *buf_end);
 
-const u8 *rtruffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset,
+
+template <char min_vector_size>
+static really_inline
+const u8 *rtruffleExecSVE(m256 shuf_mask_32,
                        const u8 *buf, const u8 *buf_end);
 
+template <char min_vector_size>
 static really_inline
-const u8 *scanBlock(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_highset, svuint8_t chars, const u8 *buf, bool forward) {
+const u8 *scanBlock(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_highset,
+                    svuint8_t chars, const u8 *buf, bool forward)
+{
 
     const size_t vector_size_int_8 = svcntb();
 
-    const svuint8_t result_mask = blockSingleMask(shuf_mask_lo_highclear, shuf_mask_lo_highset, chars);
+    svuint8_t result_mask;
+    if(min_vector_size < 32) {
+        result_mask = blockSingleMask(shuf_mask_lo_highclear, shuf_mask_lo_highset, chars);
+    } else {
+        svuint8_t shuf_mask_wide = shuf_mask_lo_highclear;
+        (void) shuf_mask_lo_highset;
+        result_mask = blockSingleMask32(shuf_mask_wide, chars);
+    }
     uint64_t index;
     if (forward) {
         index = first_non_zero(vector_size_int_8, result_mask);
@@ -84,25 +101,35 @@ const u8 *scanBlock(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_hig
         index = last_non_zero(vector_size_int_8, result_mask);
     }
 
-    if(index < vector_size_int_8) {
+    if (index < vector_size_int_8) {
         return buf+index;
     } else {
         return NULL;
     }
 }
 
-really_inline
-const u8 *truffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset, const u8 *buf, const u8 *buf_end) {
+template <char min_vector_size>
+static really_inline
+const u8 *truffleExecSVE(m256 shuf_mask_32, const u8 *buf, const u8 *buf_end) {
     const int vect_size_int8 = svcntb();
-    // Activate only 16 lanes to read the m128 buffers
-    const svbool_t lane_pred_16 = svwhilelt_b8(0, 16);
     assert(buf && buf_end);
     assert(buf < buf_end);
     DEBUG_PRINTF("truffle %p len %zu\n", buf, buf_end - buf);
     DEBUG_PRINTF("b %s\n", buf);
 
-    svuint8_t wide_shuf_mask_lo_highclear = svld1(lane_pred_16, (uint8_t*) &shuf_mask_lo_highclear);
-    svuint8_t wide_shuf_mask_lo_highset = svld1(lane_pred_16, (uint8_t*) &shuf_mask_lo_highset);
+    svuint8_t wide_shuf_mask_32;
+    svuint8_t wide_shuf_mask_lo_highclear ;
+    svuint8_t wide_shuf_mask_lo_highset; 
+    if (min_vector_size < 32) {
+        m128 shuf_mask_lo_highclear = shuf_mask_32.lo;
+        m128 shuf_mask_lo_highset = shuf_mask_32.hi;
+        const svbool_t lane_pred_16 = svwhilelt_b8(0, 16);
+        wide_shuf_mask_lo_highclear = svld1(lane_pred_16, (uint8_t*) &shuf_mask_lo_highclear);
+        wide_shuf_mask_lo_highset = svld1(lane_pred_16, (uint8_t*) &shuf_mask_lo_highset);
+    } else {
+        const svbool_t lane_pred_32 = svwhilelt_b8(0, 32);
+        wide_shuf_mask_32 = svld1(lane_pred_32, (uint8_t*) &shuf_mask_32);
+    }
 
     const u8 *work_buffer = buf;
     const u8 *ret_val;
@@ -118,16 +145,24 @@ const u8 *truffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset,
         if (!ISALIGNED_N(work_buffer, vect_size_int8)) {
             svuint8_t chars = svld1(svptrue_b8(), work_buffer);
             const u8 *alligned_buffer = ROUNDUP_PTR(work_buffer, vect_size_int8);
-            ret_val = scanBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, work_buffer, true);
+            if (min_vector_size < 32) {
+                ret_val = scanBlock<min_vector_size>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, work_buffer, true);
+            } else {
+                ret_val = scanBlock<min_vector_size>(wide_shuf_mask_32, svundef_u8(), chars, work_buffer, true);
+            }
             if (ret_val && ret_val < alligned_buffer) return ret_val;
             work_buffer = alligned_buffer;
         }
 
-        while(work_buffer + vect_size_int8 <= buf_end) {
+        while (work_buffer + vect_size_int8 <= buf_end) {
             __builtin_prefetch(work_buffer + 16*64);
             DEBUG_PRINTF("work_buffer %p \n", work_buffer);
             svuint8_t chars = svld1(svptrue_b8(), work_buffer);
-            ret_val = scanBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, work_buffer, true);
+            if (min_vector_size < 32) {
+                ret_val = scanBlock<min_vector_size>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, work_buffer, true);
+            } else {
+                ret_val = scanBlock<min_vector_size>(wide_shuf_mask_32, svundef_u8(), chars, work_buffer, true);
+            }
             if (ret_val) return ret_val;
             work_buffer += vect_size_int8;
         }
@@ -147,7 +182,11 @@ const u8 *truffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset,
             chars = svld1(svptrue_b8(), buf_end - vect_size_int8);
             end_buf = buf_end - vect_size_int8;
         }
-        ret_val = scanBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, end_buf, true);
+        if (min_vector_size < 32) {
+            ret_val = scanBlock<min_vector_size>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, end_buf, true);
+        } else {
+            ret_val = scanBlock<min_vector_size>(wide_shuf_mask_32, svundef_u8(), chars, end_buf, true);
+        }
         DEBUG_PRINTF("ret_val %p \n", ret_val);
         if (ret_val && ret_val < buf_end) return ret_val;
     }
@@ -155,18 +194,28 @@ const u8 *truffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset,
     return buf_end;
 }
 
-really_inline
-const u8 *rtruffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset, const u8 *buf, const u8 *buf_end){
+template <char min_vector_size>
+static really_inline
+const u8 *rtruffleExecSVE(m256 shuf_mask_32, const u8 *buf, const u8 *buf_end){
     const int vect_size_int8 = svcntb();
-    // Activate only 16 lanes to read the m128 buffers
-    const svbool_t lane_pred_16 = svwhilelt_b8(0, 16);
     assert(buf && buf_end);
     assert(buf < buf_end);
     DEBUG_PRINTF("truffle %p len %zu\n", buf, buf_end - buf);
     DEBUG_PRINTF("b %s\n", buf);
 
-    svuint8_t wide_shuf_mask_lo_highclear = svld1(lane_pred_16, (uint8_t*) &shuf_mask_lo_highclear);
-    svuint8_t wide_shuf_mask_lo_highset = svld1(lane_pred_16, (uint8_t*) &shuf_mask_lo_highset);
+    svuint8_t wide_shuf_mask_32;
+    svuint8_t wide_shuf_mask_lo_highclear ;
+    svuint8_t wide_shuf_mask_lo_highset; 
+    if (min_vector_size < 32) {
+        m128 shuf_mask_lo_highclear = shuf_mask_32.lo;
+        m128 shuf_mask_lo_highset = shuf_mask_32.hi;
+        const svbool_t lane_pred_16 = svwhilelt_b8(0, 16);
+        wide_shuf_mask_lo_highclear = svld1(lane_pred_16, (uint8_t*) &shuf_mask_lo_highclear);
+        wide_shuf_mask_lo_highset = svld1(lane_pred_16, (uint8_t*) &shuf_mask_lo_highset);
+    } else {
+        const svbool_t lane_pred_32 = svwhilelt_b8(0, 32);
+        wide_shuf_mask_32 = svld1(lane_pred_32, (uint8_t*) &shuf_mask_32);
+    }
 
     const u8 *work_buffer = buf_end;
     const u8 *ret_val;
@@ -182,7 +231,11 @@ const u8 *rtruffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset
         if (!ISALIGNED_N(work_buffer, vect_size_int8)) {
             svuint8_t chars = svld1(svptrue_b8(), work_buffer - vect_size_int8);
             const u8 *alligned_buffer = ROUNDDOWN_PTR(work_buffer, vect_size_int8);
-            ret_val = scanBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, work_buffer - vect_size_int8, false);
+            if (min_vector_size < 32) {
+                ret_val = scanBlock<min_vector_size>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, work_buffer - vect_size_int8, false);
+            } else {
+                ret_val = scanBlock<min_vector_size>(wide_shuf_mask_32, svundef_u8(),chars, work_buffer - vect_size_int8, false);
+            }
             DEBUG_PRINTF("ret_val %p \n", ret_val);
             if (ret_val >= alligned_buffer) return ret_val;
             work_buffer = alligned_buffer;
@@ -195,7 +248,11 @@ const u8 *rtruffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset
 
             work_buffer -= vect_size_int8;
             svuint8_t chars = svld1(svptrue_b8(), work_buffer);
-            ret_val = scanBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, work_buffer, false);
+            if (min_vector_size < 32) {
+                ret_val = scanBlock<min_vector_size>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, work_buffer, false);
+            } else {
+                ret_val = scanBlock<min_vector_size>(wide_shuf_mask_32, svundef_u8(), chars, work_buffer, false);
+            }
             if (ret_val) return ret_val;
         }
     }
@@ -211,7 +268,11 @@ const u8 *rtruffleExecSVE(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset
         } else {
             chars = svld1(svptrue_b8(), buf);
         }
-        ret_val = scanBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, buf, false);
+        if (min_vector_size < 32) {
+            ret_val = scanBlock<min_vector_size>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, buf, false);
+        } else {
+            ret_val = scanBlock<min_vector_size>(wide_shuf_mask_32, svundef_u8(), chars, buf, false);
+        }
         DEBUG_PRINTF("ret_val %p \n", ret_val);
         if (ret_val && ret_val < buf_end) return ret_val;
     }
@@ -253,7 +314,7 @@ const u8 *truffleExecReal(const m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_
             d = dup;
         }
 
-        while(d + S <= buf_end) {
+        while (d + S <= buf_end) {
             __builtin_prefetch(d + 16*64);
             DEBUG_PRINTF("d %p \n", d);
             SuperVector<S> chars = SuperVector<S>::load(d);

--- a/src/nfa/trufflecompile.cpp
+++ b/src/nfa/trufflecompile.cpp
@@ -93,4 +93,33 @@ CharReach truffle2cr(const u8 *highclear, const u8 *highset) {
     return cr;
 }
 
+void truffleBuildMasks32(const CharReach &cr, u8 *shuf_mask) {
+    memset(shuf_mask, 0, 2*sizeof(m128));
+
+    for (size_t v = cr.find_first(); v != CharReach::npos;
+         v = cr.find_next(v)) {
+        DEBUG_PRINTF("adding 0x%02x to shuf_mask\n", (u8)v);
+        u8 *change_mask = shuf_mask;
+        u8 low_nibble = v & 0x1f;
+        u8 bits_567 = (v & 0xe0) >> 5;
+        change_mask[low_nibble] |= 1 << bits_567;
+    }
+}
+
+/*
+ * Reconstruct the charclass that the truffle masks represent
+ */
+CharReach truffle2cr32(const u8 *shuf_mask) {
+    CharReach cr;
+    for (u8 i = 0; i < 32; i++) {
+        u32 bits_567 = shuf_mask[i];
+        while (bits_567) {
+            u32 pos = findAndClearLSB_32(&bits_567);
+            assert(pos < 8);
+            cr.set(pos << 5 | i);
+        }
+    }
+    return cr;
+}
+
 } // namespc

--- a/src/nfa/trufflecompile.h
+++ b/src/nfa/trufflecompile.h
@@ -37,6 +37,9 @@ namespace ue2 {
 void truffleBuildMasks(const CharReach &cr, u8 *mask1, u8 *mask2);
 CharReach truffle2cr(const u8 *lo_in, const u8 *hi_in);
 
+void truffleBuildMasks32(const CharReach &cr, u8 *mask);
+CharReach truffle2cr32(const u8 *mask);
+
 }
 
 #endif /* TRUFFLECOMPILE_H */

--- a/src/rose/rose_build_lit_accel.cpp
+++ b/src/rose/rose_build_lit_accel.cpp
@@ -462,10 +462,16 @@ void findForwardAccelScheme(const vector<AccelString> &lits,
         return;
     }
 
-    truffleBuildMasks(cr, (u8 *)&aux->truffle.mask1, (u8 *)&aux->truffle.mask2);
+    if(svcntb() >= 32) {
+        aux->truffle.accel_type = ACCEL_TRUFFLE_WIDE;
+        truffleBuildMasks32(cr, (u8 *)&aux->truffle.mask);
+    } else {
+        aux->truffle.accel_type = ACCEL_TRUFFLE;
+        truffleBuildMasks(cr, (u8 *)&aux->truffle.mask.lo,
+                        (u8 *)&aux->truffle.mask.hi);
+    }
     DEBUG_PRINTF("built truffle for %s (%zu chars, offset %u)\n",
                  describeClass(cr).c_str(), cr.count(), min_offset);
-    aux->truffle.accel_type = ACCEL_TRUFFLE;
     aux->truffle.offset = verify_u8(min_offset);
 }
 

--- a/src/util/arch/arm/simd_types.h
+++ b/src/util/arch/arm/simd_types.h
@@ -34,5 +34,9 @@
 typedef int32x4_t m128;
 #endif
 
+#if !defined(m256) && defined(m128)
+typedef struct ALIGN_AVX_DIRECTIVE {m128 lo; m128 hi;} m256;
+#endif
+
 #endif /* SIMD_TYPES_ARM_H */
 

--- a/src/util/supervector/arch/arm/types.hpp
+++ b/src/util/supervector/arch/arm/types.hpp
@@ -31,3 +31,6 @@
 typedef int32x4_t m128;
 #endif
 
+#if !defined(m256) && defined(m128)
+typedef struct ALIGN_AVX_DIRECTIVE {m128 lo; m128 hi;} m256;
+#endif

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -107,6 +107,7 @@ set(unit_internal_SOURCES
     internal/shufti.cpp
     internal/state_compress.cpp
     internal/truffle.cpp
+    internal/truffle32.cpp
     internal/unaligned.cpp
     internal/unicode_set.cpp
     internal/uniform_ops.cpp

--- a/unit/internal/sheng.cpp
+++ b/unit/internal/sheng.cpp
@@ -290,19 +290,26 @@ struct NFA *get_expected_nfa_header(u8 type, unsigned int length, unsigned int n
 }
 
 struct NFA *get_expected_nfa16_header() {
-    return get_expected_nfa_header(SHENG_NFA, 4736, 8);
+    return get_expected_nfa_header(SHENG_NFA, 4736, 8); /* size recorded in 04/2024 */
 }
 
 #if defined(HAVE_AVX512VBMI) || defined(HAVE_SVE)
 struct NFA *get_expected_nfa32_header() {
-    return get_expected_nfa_header(SHENG_NFA_32, 17216, 18);
+    return get_expected_nfa_header(SHENG_NFA_32, 17216, 18); /* size recorded in 04/2024 */
 }
 #endif /* defined(HAVE_AVX512VBMI) || defined(HAVE_SVE) */
 
 void test_nfa_equal(const NFA& l, const NFA& r)
 {
+    /**
+     * The length is meant to be a sanity test: it's not 0 (we compiled something) and that it roughly fit the
+     * expected size for a given sheng implementation (we don't feed compiled sheng32 into sheng16).
+     * Changes in other nfa algorithms may affect the sheng length, so we accept small variations.
+     */
+    int relative_difference = std::abs((float)(l.length) - r.length) / ((l.length + r.length) / 2);
+    EXPECT_LE(relative_difference, 0.1); /* same +-10% */
+
     EXPECT_EQ(l.flags, r.flags);
-    EXPECT_EQ(l.length, r.length);
     EXPECT_EQ(l.type, r.type);
     EXPECT_EQ(l.rAccelType, r.rAccelType);
     EXPECT_EQ(l.rAccelOffset, r.rAccelOffset);

--- a/unit/internal/truffle32.cpp
+++ b/unit/internal/truffle32.cpp
@@ -1,0 +1,652 @@
+/*
+ * Copyright (c) 2015-2017, Intel Corporation
+ * Copyright (c) 2024, Arm Limited
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "gtest/gtest.h"
+#include "nfa/truffle.h"
+#include "nfa/trufflecompile.h"
+#include "util/charreach.h"
+#include "util/simd_utils.h"
+
+#include "util/arch.h"
+#ifdef HAVE_SVE
+using namespace ue2;
+
+#define SKIP_IF_NARROW_SVE() \
+    if(svcntb() < 32) {\
+        std::cout << "[  SKIPPED ] System does not support 256b+ vectors" << std::endl;\
+        return;\
+    }
+
+TEST(Truffle32, CompileDot) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+    memset(&mask, 0, sizeof(mask));
+
+    CharReach chars;
+
+    chars.setall();
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    CharReach out = truffle2cr32((u8 *)&mask);
+
+    ASSERT_EQ(out, chars);
+
+}
+
+TEST(Truffle32, CompileChars) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    // test one char at a time
+    for (u32 c = 0; c < 256; ++c) {
+        mask = zeroes256();
+        chars.clear();
+        chars.set((u8)c);
+        truffleBuildMasks32(chars, (u8 *)&mask);
+        CharReach out = truffle2cr32((u8 *)&mask);
+        ASSERT_EQ(out, chars);
+    }
+
+    // set all chars up to dot
+    for (u32 c = 0; c < 256; ++c) {
+        mask = zeroes256();
+        chars.set((u8)c);
+        truffleBuildMasks32(chars, (u8 *)&mask);
+        CharReach out = truffle2cr32((u8 *)&mask);
+        ASSERT_EQ(out, chars);
+    }
+
+    // unset all chars from dot
+    for (u32 c = 0; c < 256; ++c) {
+        mask = zeroes256();
+        chars.clear((u8)c);
+        truffleBuildMasks32(chars, (u8 *)&mask);
+        CharReach out = truffle2cr32((u8 *)&mask);
+        ASSERT_EQ(out, chars);
+    }
+
+}
+
+TEST(Truffle32, ExecNoMatch1) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+    memset(&mask, 0, sizeof(mask));
+
+    CharReach chars;
+
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\xff";
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = truffleExec32(mask, (u8 *)t1 + i, (u8 *)t1 + strlen(t1));
+
+        ASSERT_EQ((size_t)t1 + strlen(t1), (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecNoMatch2) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    chars.set('a');
+    chars.set('B');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = truffleExec32(mask, (u8 *)t1 + i, (u8 *)t1 + strlen(t1));
+
+        ASSERT_EQ((size_t)t1 + strlen(t1), (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecNoMatch3) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    chars.set('V'); /* V = 0x56, e = 0x65 */
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = truffleExec32(mask, (u8 *)t1 + i, (u8 *)t1 + strlen(t1));
+
+        ASSERT_EQ((size_t)t1 + strlen(t1), (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecMiniMatch0) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "a";
+
+    const u8 *rv = truffleExec32(mask, (u8 *)t1, (u8 *)t1 + strlen(t1));
+
+    ASSERT_EQ((size_t)t1, (size_t)rv);
+}
+
+TEST(Truffle32, ExecMiniMatch1) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "bbbbbbbabbb";
+
+    const u8 *rv = truffleExec32(mask, (u8 *)t1, (u8 *)t1 + strlen(t1));
+
+    ASSERT_EQ((size_t)t1 + 7, (size_t)rv);
+}
+
+TEST(Truffle32, ExecMiniMatch2) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set(0);
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "bbbbbbb\0bbb";
+
+    const u8 *rv = truffleExec32(mask, (u8 *)t1, (u8 *)t1 + 11);
+
+    ASSERT_EQ((size_t)t1 + 7, (size_t)rv);
+}
+
+TEST(Truffle32, ExecMiniMatch3) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "\0\0\0\0\0\0\0a\0\0\0";
+
+    const u8 *rv = truffleExec32(mask, (u8 *)t1, (u8 *)t1 + 11);
+
+    ASSERT_EQ((size_t)t1 + 7, (size_t)rv);
+}
+
+TEST(Truffle32, ExecMatchBig) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    std::array<u8, 400> t1;
+    t1.fill('b');
+    t1[120] = 'a';
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = truffleExec32(mask, (u8 *)t1.data() + i, (u8 *)t1.data() + 399);
+
+        ASSERT_LE(((size_t)t1.data() + 120) & ~0xf, (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecMatch1) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbbbbbbbbbbbbbbabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbabbbbbbbbbbbb";
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = truffleExec32(mask, (u8 *)t1 + i, (u8 *)t1 + strlen(t1));
+
+        ASSERT_EQ((size_t)t1 + 17, (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecMatch2) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbabbbbbbbbbbbb";
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = truffleExec32(mask, (u8 *)t1 + i, (u8 *)t1 + strlen(t1));
+
+        ASSERT_EQ((size_t)t1 + 17, (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecMatch3) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    chars.set('a');
+    chars.set('B');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbbbbbbbbbbbbbbBaaaaaaaaaaaaaaabbbbbbbbbbbbbbbabbbbbbbbbbbb";
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = truffleExec32(mask, (u8 *)t1 + i, (u8 *)t1 + strlen(t1));
+
+        ASSERT_EQ((size_t)t1 + 17, (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecMatch4) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    chars.set('a');
+    chars.set('C');
+    chars.set('A');
+    chars.set('c');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbbbbbbbbbbbbbbAaaaaaaaaaaaaaaabbbbbbbbbbbbbbbabbbbbbbbbbbb";
+    char t2[] = "bbbbbbbbbbbbbbbbbCaaaaaaaaaaaaaaabbbbbbbbbbbbbbbabbbbbbbbbbbb";
+    char t3[] = "bbbbbbbbbbbbbbbbbcaaaaaaaaaaaaaaabbbbbbbbbbbbbbbabbbbbbbbbbbb";
+    char t4[] = "bbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbabbbbbbbbbbbb";
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = truffleExec32(mask, (u8 *)t1 + i, (u8 *)t1 + strlen(t1));
+
+        ASSERT_EQ((size_t)t1 + 17, (size_t)rv);
+
+        rv = truffleExec32(mask, (u8 *)t2 + i, (u8 *)t2 + strlen(t1));
+
+        ASSERT_EQ((size_t)t2 + 17, (size_t)rv);
+
+        rv = truffleExec32(mask, (u8 *)t3 + i, (u8 *)t3 + strlen(t3));
+
+        ASSERT_EQ((size_t)t3 + 17, (size_t)rv);
+
+        rv = truffleExec32(mask, (u8 *)t4 + i, (u8 *)t4 + strlen(t4));
+
+        ASSERT_EQ((size_t)t4 + 17, (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecMatch5) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    for (size_t i = 0; i < 31; i++) {
+        t1[48 - i] = 'a';
+        const u8 *rv = truffleExec32(mask, (u8 *)t1, (u8 *)t1 + strlen(t1));
+
+        ASSERT_EQ((size_t)&t1[48 - i], (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecMatch6) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    // [0-Z] - includes some graph chars
+    chars.setRange('0', 'Z');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    std::array<u8, 128> t1;
+    t1.fill('*'); // it's full of stars!
+
+    for (u8 c = '0'; c <= 'Z'; c++) {
+        t1[17] = c;
+        const u8 *rv = truffleExec32(mask, (u8 *)t1.data(), (u8 *)t1.data() + 128);
+
+        ASSERT_EQ((size_t)t1.data() + 17, (size_t)rv);
+    }
+}
+
+TEST(Truffle32, ExecMatch7) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    // hi bits
+    chars.setRange(127, 255);
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    std::array<u8, 128> t1;
+    t1.fill('*'); // it's full of stars!
+
+    for (unsigned int c = 127; c <= 255; c++) {
+        t1[40] = (u8)c;
+        const u8 *rv = truffleExec32(mask, (u8 *)t1.data(), (u8 *)t1.data() + 128);
+
+        ASSERT_EQ((size_t)t1.data() + 40, (size_t)rv);
+    }
+}
+
+TEST(ReverseTruffle32, ExecNoMatch1) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t[] = " bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    char *t1 = t + 1;
+    size_t len = strlen(t1);
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len - i);
+        ASSERT_EQ((const u8 *)t, rv);
+    }
+}
+
+TEST(ReverseTruffle32, ExecNoMatch2) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+
+    chars.set('a');
+    chars.set('B');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t[] = " bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    char *t1 = t + 1;
+    size_t len = strlen(t1);
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len - i);
+        ASSERT_EQ((const u8 *)t, rv);
+    }
+}
+
+TEST(ReverseTruffle32, ExecNoMatch3) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('V'); /* V = 0x56, e = 0x65 */
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t[] = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    char *t1 = t + 1;
+    size_t len = strlen(t1);
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len - i);
+        ASSERT_EQ((const u8 *)t, rv);
+    }
+}
+
+TEST(ReverseTruffle32, ExecMiniMatch0) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "a";
+
+    const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + strlen(t1));
+
+    ASSERT_EQ((size_t)t1, (size_t)rv);
+}
+
+TEST(ReverseTruffle32, ExecMiniMatch1) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbbbbabbbb";
+    size_t len = strlen(t1);
+
+    const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len);
+    ASSERT_NE((const u8 *)t1 - 1, rv); // not found
+    EXPECT_EQ('a', (char)*rv);
+    ASSERT_EQ((const u8 *)t1 + 7, rv);
+}
+
+TEST(ReverseTruffle32, ExecMiniMatch2) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "babbbbbabbbb";
+    size_t len = strlen(t1);
+
+    const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len);
+    ASSERT_NE((const u8 *)t1 - 1, rv); // not found
+    EXPECT_EQ('a', (char)*rv);
+    ASSERT_EQ((const u8 *)t1 + 7, rv);
+}
+
+
+TEST(ReverseTruffle32, ExecMatch1) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbbbabbbbbbbbbbabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    size_t len = strlen(t1);
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len - i);
+        ASSERT_NE((const u8 *)t1 - 1, rv); // not found
+        EXPECT_EQ('a', (char)*rv);
+        ASSERT_EQ((const u8 *)t1 + 17, rv);
+    }
+}
+
+TEST(ReverseTruffle32, ExecMatch2) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbabbbbbbbbbbbbaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    size_t len = strlen(t1);
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len - i);
+        ASSERT_NE((const u8 *)t1 - 1, rv); // not found
+        EXPECT_EQ('a', (char)*rv);
+        ASSERT_EQ((const u8 *)t1 + 32, rv);
+    }
+}
+
+TEST(ReverseTruffle32, ExecMatch3) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+    chars.set('B');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaBbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    size_t len = strlen(t1);
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len - i);
+        ASSERT_NE((const u8 *)t1 - 1, rv); // not found
+        EXPECT_EQ('B', (char)*rv);
+        ASSERT_EQ((const u8 *)t1 + 32, rv);
+    }
+
+    // check that we match the 'a' bytes as well.
+    ASSERT_EQ('B', t1[32]);
+    t1[32] = 'b';
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len - i);
+        ASSERT_NE((const u8 *)t1 - 1, rv); // not found
+        EXPECT_EQ('a', (char)*rv);
+        ASSERT_EQ((const u8 *)t1 + 31, rv);
+    }
+}
+
+TEST(ReverseTruffle32, ExecMatch4) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+    chars.set('C');
+    chars.set('A');
+    chars.set('c');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    /*          0123456789012345678901234567890 */
+    char t1[] = "bbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaAbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    char t2[] = "bbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaCbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    char t3[] = "bbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaacbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    char t4[] = "bbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    size_t len = strlen(t1);
+
+    for (size_t i = 0; i < 16; i++) {
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len - i);
+        EXPECT_EQ('A', (char)*rv);
+        ASSERT_EQ((const u8 *)t1 + 32, rv);
+
+        rv = rtruffleExec32(mask, (u8 *)t2, (u8 *)t2 + len - i);
+        EXPECT_EQ('C', (char)*rv);
+        ASSERT_EQ((const u8 *)t2 + 32, rv);
+
+        rv = rtruffleExec32(mask, (u8 *)t3, (u8 *)t3 + len - i);
+        EXPECT_EQ('c', (char)*rv);
+        ASSERT_EQ((const u8 *)t3 + 32, rv);
+
+        rv = rtruffleExec32(mask, (u8 *)t4, (u8 *)t4 + len - i);
+        EXPECT_EQ('a', (char)*rv);
+        ASSERT_EQ((const u8 *)t4 + 32, rv);
+    }
+}
+
+TEST(ReverseTruffle32, ExecMatch5) {
+    SKIP_IF_NARROW_SVE()
+    m256 mask;
+
+    CharReach chars;
+    chars.set('a');
+
+    truffleBuildMasks32(chars, (u8 *)&mask);
+
+    char t1[] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    size_t len = strlen(t1);
+
+    for (size_t i = 0; i < len; i++) {
+        t1[i] = 'a';
+        const u8 *rv = rtruffleExec32(mask, (u8 *)t1, (u8 *)t1 + len);
+
+        ASSERT_EQ((const u8 *)t1 + i, rv);
+    }
+}
+#endif


### PR DESCRIPTION
Those three commits enable three different optimizations to truffle:
- Make the neon path explicit instead of using the supervector (~10% speedup over generic neon path)
- Enable hybrid neon/SVE path. This enable the explicit neon code for the comparison while using the SVE code for returning the match index. (~10% speedup over regular SVE)
- Optimization for wide SVE (256+ bit wide) by simplifying the algorithm. It have its own code path but provide ~40% speedup compared to the normal SVE path over the same wide machine (graviton 3), making truffle the fastest nfa algorithm in the microbenchmark.