### PR TITLE
Fix marked as done cppcheck warnings unreadVariable & others

### DIFF
--- a/src/fdr/fdr_confirm_compile.cpp
+++ b/src/fdr/fdr_confirm_compile.cpp
@@ -294,9 +294,6 @@ setupFullConfs(const vector<hwlmLiteral> &lits,
                const EngineDescription &eng,
                const map<BucketIndex, vector<LiteralIndex>> &bucketToLits,
                bool make_small) {
-    unique_ptr<TeddyEngineDescription> teddyDescr =
-        getTeddyDescription(eng.getID());
-
     BC2CONF bc2Conf;
     u32 totalConfirmSize = 0;
     for (BucketIndex b = 0; b < eng.getNumBuckets(); b++) {

--- a/src/hs_valid_platform.c
+++ b/src/hs_valid_platform.c
@@ -49,6 +49,7 @@ hs_error_t HS_CDECL hs_valid_platform(void) {
     }
 #elif !defined(VS_SIMDE_BACKEND) && (defined(ARCH_ARM32) || defined(ARCH_AARCH64))
    //check_neon returns true for now
+   // cppcheck-suppress knownConditionTrueFalse
    if (check_neon()) {
         return HS_SUCCESS;
     } else {

--- a/src/nfa/dfa_min.cpp
+++ b/src/nfa/dfa_min.cpp
@@ -304,6 +304,7 @@ void minimize_hopcroft(raw_dfa &rdfa, const Grey &grey) {
         DEBUG_PRINTF("dfa is empty\n");
     }
 
+    // cppcheck-suppress unreadVariable
     UNUSED const size_t states_before = rdfa.states.size();
 
     HopcroftInfo info(rdfa);

--- a/src/nfa/gough.c
+++ b/src/nfa/gough.c
@@ -978,7 +978,6 @@ char nfaExecGough16_initCompressedState(const struct NFA *nfa, u64a offset,
 char nfaExecGough8_reportCurrent(const struct NFA *n, struct mq *q) {
     const struct mcclellan *m = (const struct mcclellan *)getImplNfa(n);
     NfaCallback cb = q->cb;
-    void *ctxt = q->context;
     u8 s = *(u8 *)q->state;
     u64a offset = q_cur_offset(q);
     const struct gough_som_info *som = getSomInfo(q->state);
@@ -986,6 +985,7 @@ char nfaExecGough8_reportCurrent(const struct NFA *n, struct mq *q) {
     assert(s);
 
     if (s >= m->accept_limit_8) {
+        void *ctxt = q->context;
         u32 cached_accept_id = 0;
         u16 cached_accept_state = 0;
         u32 cached_accept_som = 0;
@@ -1000,7 +1000,6 @@ char nfaExecGough8_reportCurrent(const struct NFA *n, struct mq *q) {
 char nfaExecGough16_reportCurrent(const struct NFA *n, struct mq *q) {
     const struct mcclellan *m = (const struct mcclellan *)getImplNfa(n);
     NfaCallback cb = q->cb;
-    void *ctxt = q->context;
     u16 s = *(u16 *)q->state;
     const struct mstate_aux *aux = get_aux(m, s);
     u64a offset = q_cur_offset(q);
@@ -1010,6 +1009,7 @@ char nfaExecGough16_reportCurrent(const struct NFA *n, struct mq *q) {
     assert(s);
 
     if (aux->accept) {
+        void *ctxt = q->context;
         u32 cached_accept_id = 0;
         u16 cached_accept_state = 0;
         u32 cached_accept_som = 0;

--- a/src/nfa/goughcompile.cpp
+++ b/src/nfa/goughcompile.cpp
@@ -802,7 +802,7 @@ private:
 
 static
 void prep_joins_for_generation(const GoughGraph &g, GoughVertex v,
-                               map<GoughEdge, edge_join_info> *edge_info) {
+                               map<GoughEdge, edge_join_info> &edge_info) {
     DEBUG_PRINTF("writing out joins for %u\n", g[v].state_id);
     for (const auto &var : g[v].vars) {
         u32 dest_slot = var->slot;
@@ -813,7 +813,7 @@ void prep_joins_for_generation(const GoughGraph &g, GoughVertex v,
             }
 
             for (const GoughEdge &incoming_edge : var_edges.second) {
-                (*edge_info)[incoming_edge].insert(input, dest_slot);
+                edge_info[incoming_edge].insert(input, dest_slot);
                 DEBUG_PRINTF("need %u<-%u\n", dest_slot, input);
             }
         }
@@ -911,7 +911,7 @@ void build_blocks(const GoughGraph &g,
         }
 
         map<GoughEdge, edge_join_info> eji;
-        prep_joins_for_generation(g, t, &eji);
+        prep_joins_for_generation(g, t, eji);
 
         for (auto &m : eji) {
             vector<gough_ins> &block = (*blocks)[gough_edge_id(g, m.first)];

--- a/src/nfa/limex_exceptional.h
+++ b/src/nfa/limex_exceptional.h
@@ -302,8 +302,8 @@ int PE_FN(STATE_ARG, ESTATE_ARG, UNUSED u32 diffmask, STATE_T *succ,
     }
 #else
     // A copy of the estate as an array of GPR-sized chunks.
-    CHUNK_T chunks[sizeof(STATE_T) / sizeof(CHUNK_T)];
-    CHUNK_T emask_chunks[sizeof(STATE_T) / sizeof(CHUNK_T)];
+    CHUNK_T chunks[sizeof(STATE_T) / sizeof(CHUNK_T)];       // cppcheck-suppress duplicateExpression
+    CHUNK_T emask_chunks[sizeof(STATE_T) / sizeof(CHUNK_T)]; // cppcheck-suppress duplicateExpression
 #ifdef ESTATE_ON_STACK
     memcpy(chunks, &estate, sizeof(STATE_T));
 #else
@@ -311,7 +311,7 @@ int PE_FN(STATE_ARG, ESTATE_ARG, UNUSED u32 diffmask, STATE_T *succ,
 #endif
     memcpy(emask_chunks, &limex->exceptionMask, sizeof(STATE_T));
 
-    u32 base_index[sizeof(STATE_T) / sizeof(CHUNK_T)];
+    u32 base_index[sizeof(STATE_T) / sizeof(CHUNK_T)];       // cppcheck-suppress duplicateExpression
     base_index[0] = 0;
     for (s32 i = 0; i < (s32)ARRAY_LENGTH(base_index) - 1; i++) {
         base_index[i + 1] = base_index[i] + POPCOUNT_FN(emask_chunks[i]);

--- a/src/nfa/mcclellancompile.cpp
+++ b/src/nfa/mcclellancompile.cpp
@@ -1379,7 +1379,6 @@ void generate_symbol_chain(dfa_info &info, vector<symbol_t> &chain_tail) {
 
         for (size_t j = 0; j < width; j++) {
             dstate_id_t curr_id = state_chain[j];
-            dstate_id_t next_id = state_chain[j + 1];
 
             // The last state of the chain doesn't belong to a wide state.
             info.extra[curr_id].wideState = true;
@@ -1388,6 +1387,7 @@ void generate_symbol_chain(dfa_info &info, vector<symbol_t> &chain_tail) {
             if (j == width - 1) {
                 symbol_chain.emplace_back(chain_tail[i]);
             } else {
+                dstate_id_t next_id = state_chain[j + 1];
                 for (symbol_t sym = 0; sym < info.impl_alpha_size; sym++) {
                     if (rdfa.states[curr_id].next[sym] == next_id) {
                         symbol_chain.emplace_back(sym);

--- a/src/nfa/mcsheng_compile.cpp
+++ b/src/nfa/mcsheng_compile.cpp
@@ -1018,12 +1018,16 @@ bytecode_ptr<NFA> mcshengCompile16(dfa_info &info, dstate_id_t sheng_end,
 
     // Sherman optimization
     if (info.impl_alpha_size > 16) {
+#ifdef DEBUG
         u16 total_daddy = 0;
+#endif // DEBUG
         for (u32 i = 0; i < info.size(); i++) {
             find_better_daddy(info, i,
                               is_cyclic_near(info.raw, info.raw.start_anchored),
                               grey);
+#ifdef DEBUG
             total_daddy += info.extra[i].daddytaken;
+#endif // DEBUG
         }
 
         DEBUG_PRINTF("daddy %hu/%zu states=%zu alpha=%hu\n", total_daddy,
@@ -1172,12 +1176,16 @@ bytecode_ptr<NFA> mcsheng64Compile16(dfa_info&info, dstate_id_t sheng_end,
 
     // Sherman optimization
     if (info.impl_alpha_size > 16) {
+#ifdef DEBUG
         u16 total_daddy = 0;
+#endif // DEBUG
         for (u32 i = 0; i < info.size(); i++) {
             find_better_daddy(info, i,
                               is_cyclic_near(info.raw, info.raw.start_anchored),
                               grey);
+#ifdef DEBUG
             total_daddy += info.extra[i].daddytaken;
+#endif // DEBUG
         }
 
         DEBUG_PRINTF("daddy %hu/%zu states=%zu alpha=%hu\n", total_daddy,
@@ -1430,11 +1438,9 @@ bytecode_ptr<NFA> mcshengCompile(raw_dfa &raw, const CompileContext &cc,
 
     map<dstate_id_t, AccelScheme> accel_escape_info
         = info.strat.getAccelInfo(cc.grey);
-    auto old_states = info.states;
     dstate_id_t sheng_end = find_sheng_states(info, accel_escape_info, MAX_SHENG_STATES);
 
     if (sheng_end <= DEAD_STATE + 1) {
-        info.states = old_states;
         return bytecode_ptr<NFA>(nullptr);
     }
 
@@ -1447,7 +1453,6 @@ bytecode_ptr<NFA> mcshengCompile(raw_dfa &raw, const CompileContext &cc,
     }
 
     if (!nfa) {
-        info.states = old_states;
         return nfa;
     }
 

--- a/src/nfa/nfa_api_queue.h
+++ b/src/nfa/nfa_api_queue.h
@@ -251,6 +251,10 @@ void q_skip_forward_to(struct mq *q, s64a min_loc) {
 // Dump the contents of the given queue.
 static never_inline UNUSED
 void debugQueue(const struct mq *q) {
+    if (q == nullptr) {
+       DEBUG_PRINTF("q=NULL!\n");
+       return;
+    }
     DEBUG_PRINTF("q=%p, nfa=%p\n", q, q->nfa);
     DEBUG_PRINTF("q offset=%llu, buf={%p, len=%zu}, history={%p, len=%zu}\n",
                  q->offset, q->buffer, q->length, q->history, q->hlength);

--- a/src/nfa/sheng.c
+++ b/src/nfa/sheng.c
@@ -814,7 +814,6 @@ char nfaExecSheng_testEOD(const struct NFA *nfa, const char *state,
 char nfaExecSheng_reportCurrent(const struct NFA *n, struct mq *q) {
     const struct sheng *sh = (const struct sheng *)getImplNfa(n);
     NfaCallback cb = q->cb;
-    void *ctxt = q->context;
     u8 s = *(u8 *)q->state;
     const struct sstate_aux *aux = get_aux(sh, s);
     u64a offset = q_cur_offset(q);
@@ -823,6 +822,7 @@ char nfaExecSheng_reportCurrent(const struct NFA *n, struct mq *q) {
     assert(q_cur_type(q) == MQE_START);
 
     if (aux->accept) {
+        void *ctxt = q->context;
         if (sh->flags & SHENG_FLAG_SINGLE_REPORT) {
             fireSingleReport(cb, ctxt, sh->report, offset);
         } else {

--- a/src/nfa/shengcompile.cpp
+++ b/src/nfa/shengcompile.cpp
@@ -800,7 +800,7 @@ bytecode_ptr<NFA> sheng64Compile(raw_dfa &raw, const CompileContext &cc,
     old_states = info.states;
     auto nfa = shengCompile_int<sheng64>(raw, cc, accel_states, strat, info);
     if (!nfa) {
-        info.states = old_states;
+        info.states = old_states;  // cppcheck-suppress unreadVariable
     }
     return nfa;
 }

--- a/src/nfagraph/ng_repeat.cpp
+++ b/src/nfagraph/ng_repeat.cpp
@@ -854,9 +854,7 @@ void replaceSubgraphWithLazySpecial(NGHolder &g, ReachSubgraph &rsi,
     assert(rsi.repeatMax >= rsi.repeatMin);
 
     DEBUG_PRINTF("entry\n");
-
-    const unordered_set<NFAVertex> involved(rsi.vertices.begin(),
-                                            rsi.vertices.end());
+ 
     vector<NFAVertex> g_succs;
     getSuccessors(g, rsi, &g_succs);
 

--- a/src/nfagraph/ng_som.cpp
+++ b/src/nfagraph/ng_som.cpp
@@ -3125,7 +3125,7 @@ sombe_rv doSomWithHaig(NG &ng, NGHolder &g, const ExpressionInfo &expr,
 
     // try a redundancy pass.
     if (addSomRedundancy(g, depths)) {
-        depths = getDistancesFromSOM(g);
+        depths = getDistancesFromSOM(g); // cppcheck-suppress unreadVariable
     }
 
     auto regions = assignRegions(g);

--- a/src/parser/ucp_table.cpp
+++ b/src/parser/ucp_table.cpp
@@ -34,14 +34,6 @@ using namespace std;
 
 namespace ue2 {
 
-#define UCP_FN(cat)                                                     \
-CodePointSet getUcp##cat(void) {                                        \
-    CodePointSet rv;                                                    \
-    for (u32 i = 0; i < ARRAY_LENGTH(ucp_##cat##_def); i += 2) {        \
-        rv.setRange(ucp_##cat##_def[i], ucp_##cat##_def[i + 1]);        \
-    }                                                                   \
-    return rv;                                                          \
-}
 
 struct unicase {
     unichar base;

--- a/src/parser/ucp_table.h
+++ b/src/parser/ucp_table.h
@@ -36,6 +36,15 @@
 
 namespace ue2 {
 
+#define UCP_FN(cat)                                                     \
+CodePointSet getUcp##cat(void) {                                        \
+    CodePointSet rv;                                                    \
+    for (u32 i = 0; i < ARRAY_LENGTH(ucp_##cat##_def); i += 2) {        \
+        rv.setRange(ucp_##cat##_def[i], ucp_##cat##_def[i + 1]);        \
+    }                                                                   \
+    return rv;                                                          \
+}
+
 class CodePointSet;
 void make_caseless(CodePointSet *cps);
 bool flip_case(unichar *c);

--- a/src/rose/match.c
+++ b/src/rose/match.c
@@ -267,7 +267,8 @@ hwlmcb_rv_t playDelaySlot(const struct RoseEngine *t,
     const u32 *programs = getByOffset(t, t->delayProgramOffset);
 
     for (u32 it = fatbit_iterate(vicSlot, delay_count, MMB_INVALID);
-         it != MMB_INVALID; it = fatbit_iterate(vicSlot, delay_count, it)) {
+        it != MMB_INVALID; it = fatbit_iterate(vicSlot, delay_count, it)) {
+        // cppcheck-suppress unreadVariable
         UNUSED rose_group old_groups = tctxt->groups;
 
         DEBUG_PRINTF("DELAYED MATCH id=%u offset=%llu\n", it, offset);

--- a/src/rose/rose_build_add.cpp
+++ b/src/rose/rose_build_add.cpp
@@ -1039,9 +1039,9 @@ bool canImplementGraph(NGHolder &h, bool prefilter, const ReportManager &rm,
 
     if (prefilter && cc.grey.prefilterReductions) {
         // If we're prefiltering, we can have another go with a reduced graph.
-        UNUSED size_t numBefore = num_vertices(h);
+        UNUSED size_t numBefore = num_vertices(h); // cppcheck-suppress unreadVariable
         prefilterReductions(h, cc);
-        UNUSED size_t numAfter = num_vertices(h);
+        UNUSED size_t numAfter = num_vertices(h);  // cppcheck-suppress unreadVariable
         DEBUG_PRINTF("reduced from %zu to %zu vertices\n", numBefore, numAfter);
 
         if (isImplementableNFA(h, &rm, cc)) {

--- a/src/rose/rose_build_add_mask.cpp
+++ b/src/rose/rose_build_add_mask.cpp
@@ -392,8 +392,9 @@ bool validateTransientMask(const vector<CharReach> &mask, bool anchored,
            none_of(begin(lits), end(lits), mixed_sensitivity));
 
     // Build the HWLM literal mask.
-    vector<u8> msk, lcmp;
+    vector<u8> msk;
     if (grey.roseHamsterMasks) {
+        vector<u8> lcmp;
         buildLiteralMask(mask, msk, lcmp, delay);
     }
 

--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -1901,8 +1901,8 @@ void findExclusiveSuffixes(RoseBuildImpl &tbi, build_context &bc,
 
         // We may have already built this NFA.
         if (contains(suffixes, s)) {
-            u32 id = suffixes[s];
             if (!tbi.isInETable(v)) {
+                u32 id = suffixes[s];
                 vertex_map[id].emplace_back(v);
             }
             continue;
@@ -2233,10 +2233,10 @@ vector<u32> buildSuffixEkeyLists(const RoseBuildImpl &build, build_context &bc,
 
     for (const auto &e : bc.suffixes) {
         const suffix_id &s = e.first;
-        u32 qi = e.second;
         set<u32> ekeys = reportsToEkeys(all_reports(s), build.rm);
 
         if (!ekeys.empty()) {
+            u32 qi = e.second;
             qi_to_ekeys[qi] = {ekeys.begin(), ekeys.end()};
         }
     }
@@ -2987,7 +2987,7 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
             const auto &cfrag = fragments[pfrag.included_frag_id];
             /** assert(pfrag.s.length() >= cfrag.s.length() && **/
             assert(pfrag.s.length() == cfrag.s.length() &&
-                   !pfrag.s.any_nocase() >= !cfrag.s.any_nocase());
+                   !pfrag.s.any_nocase() != !cfrag.s.any_nocase());
             u32 child_offset = cfrag.delay_program_offset;
             DEBUG_PRINTF("child %u offset %u\n", cfrag.fragment_id,
                          child_offset);

--- a/src/rose/rose_build_long_lit.cpp
+++ b/src/rose/rose_build_long_lit.cpp
@@ -98,8 +98,7 @@ void addToBloomFilter(vector<u8> &bloom, const u8 *substr, bool nocase) {
 
     const auto hash_functions = { bloomHash_1, bloomHash_2, bloomHash_3 };
     for (const auto &hash_func : hash_functions) {
-        u32 hash = hash_func(substr, nocase);
-        u32 key = hash & key_mask;
+        u32 key = hash_func(substr, nocase) & key_mask;
         DEBUG_PRINTF("set key %u (of %zu)\n", key, bloom.size() * 8);
         bloom[key / 8] |= 1U << (key % 8);
     }
@@ -193,10 +192,8 @@ vector<RoseLongLitHashEntry> buildHashTable(
     }
 
     for (const auto &m : hashToLitOffPairs) {
-        u32 hash = m.first;
+        u32 bucket = m.first % numEntries;
         const LitOffsetVector &d = m.second;
-
-        u32 bucket = hash % numEntries;
 
         // Placement via linear probing.
         for (const auto &lit_offset : d) {

--- a/src/rose/rose_build_misc.cpp
+++ b/src/rose/rose_build_misc.cpp
@@ -861,7 +861,6 @@ u32 roseQuality(const RoseResources &res, const RoseEngine *t) {
     }
 
     if (eod_prefix) {
-        always_run++;
         DEBUG_PRINTF("eod prefixes are slow");
         return 0;
     }

--- a/src/stream_compress_impl.h
+++ b/src/stream_compress_impl.h
@@ -142,6 +142,7 @@ size_t JOIN(sc_, FN_SUFFIX)(const struct RoseEngine *rose,
     COPY(stream_body + so->groups, so->groups_size);
 
     /* copy the real bits of history */
+    // cppcheck-suppress unreadVariable
     UNUSED u32 hend = so->history + rose->historyRequired;
     COPY(stream_body + hend - history, history);
 

--- a/src/util/multibit_build.cpp
+++ b/src/util/multibit_build.cpp
@@ -256,7 +256,7 @@ void mmbBuildInitRangePlan(u32 total_bits, u32 begin, u32 end,
     /* handle the multilevel case */
     s32 ks = mmbit_keyshift(total_bits);
     u32 level = 0;
-    assert(sizeof(MMB_TYPE) == sizeof(u64a));
+    assert(sizeof(MMB_TYPE) == sizeof(u64a)); // cppcheck-suppress duplicateExpression
 
     if (begin == end) {
         add_scatter(&out->p_u64a, 0, 0);

--- a/unit/internal/multi_bit_compress.cpp
+++ b/unit/internal/multi_bit_compress.cpp
@@ -401,7 +401,6 @@ TEST_P(MultiBitCompTest, CompCompressDecompressDense) {
 
 TEST(MultiBitComp, CompIntegration1) {
     // 256 + 1 --> smallest 2-level mmbit
-    //u32 total_size = mmbit_size(257);
     mmbit_holder ba(257);
 
     //-------------------- 1 -----------------------//
@@ -516,7 +515,6 @@ TEST(MultiBitComp, CompIntegration1) {
 
 TEST(MultiBitComp, CompIntegration2) {
     // 64^2 + 1 --> smallest 3-level mmbit
-    //u32 total_size = mmbit_size(4097);
     mmbit_holder ba(4097);
 
     //-------------------- 1 -----------------------//
@@ -645,7 +643,6 @@ TEST(MultiBitComp, CompIntegration2) {
 
 TEST(MultiBitComp, CompIntegration3) {
     // 64^3 + 1 --> smallest 4-level mmbit
-    //u32 total_size = mmbit_size(262145);
     mmbit_holder ba(262145);
 
     //-------------------- 1 -----------------------//

--- a/unit/internal/state_compress.cpp
+++ b/unit/internal/state_compress.cpp
@@ -180,7 +180,7 @@ TEST(state_compress, m128_2) {
             loadcompressed128(&val_out, &buf, &mask, 0);
             EXPECT_TRUE(!diff128(and128(val, mask), val_out));
 
-            mask_raw[j] = 0x7f;
+            mask_raw[j] = 0x7f; // cppcheck-suppress unreadVariable
         }
     }
 }
@@ -258,7 +258,7 @@ TEST(state_compress, m256_2) {
             loadcompressed256(&val_out, &buf, &mask, 0);
             EXPECT_TRUE(!diff256(and256(val, mask), val_out));
 
-            mask_raw[j] = 0x7f;
+            mask_raw[j] = 0x7f; // cppcheck-suppress unreadVariable
         }
     }
 }
@@ -338,7 +338,7 @@ TEST(state_compress, m384_2) {
             loadcompressed384(&val_out, &buf, &mask, 0);
             EXPECT_TRUE(!diff384(and384(val, mask), val_out));
 
-            mask_raw[j] = 0x7f;
+            mask_raw[j] = 0x7f; // cppcheck-suppress unreadVariable
         }
     }
 }
@@ -419,7 +419,7 @@ TEST(state_compress, m512_2) {
             loadcompressed512(&val_out, &buf, &mask, 0);
             EXPECT_TRUE(!diff512(and512(val, mask), val_out));
 
-            mask_raw[j] = 0x7f;
+            mask_raw[j] = 0x7f; // cppcheck-suppress unreadVariable
         }
     }
 }

--- a/util/cross_compile.cpp
+++ b/util/cross_compile.cpp
@@ -55,7 +55,6 @@ unique_ptr<hs_platform_info> xcompileReadMode(const char *s) {
     assert(!err);
 
     string str(s);
-    //string mode = str.substr(0, str.find(":"));
     string opt = str.substr(str.find(":")+1, str.npos);
     bool found_mode = false;
 

--- a/util/ng_corpus_generator.cpp
+++ b/util/ng_corpus_generator.cpp
@@ -221,7 +221,7 @@ class CorpusGeneratorImpl : public CorpusGenerator {
 public:
     CorpusGeneratorImpl(const NGHolder &graph_in, const ExpressionInfo &expr_in,
                         CorpusProperties &props);
-    ~CorpusGeneratorImpl() = default;
+    virtual ~CorpusGeneratorImpl() = default;
 
     void generateCorpus(vector<string> &data) override;
 


### PR DESCRIPTION
Fix various cppcheck warnings:
duplicateExpression
knownConditionTrueFalse
variableScope
unknownMacro
missingOverride
unreadVariable
nullPointerRedundantCheck