### PR TITLE
Wip cppcheck271 useStlAlgorithm part2

### DIFF
--- a/examples/patbench.cc
+++ b/examples/patbench.cc
@@ -360,9 +360,6 @@ public:
         size_t sum = 0;
         auto packs = [](size_t z, const string &packet) { return z + packet.size(); };
         sum += std::accumulate(packets.begin(), packets.end(), 0, packs);
-        // for (const auto &packet : packets) {
-        //     sum += packet.size();
-        // }
         return sum;
     }
 

--- a/examples/patbench.cc
+++ b/examples/patbench.cc
@@ -459,10 +459,8 @@ public:
         // dynamic storage.)
         vector<const char *> cstrPatterns;
         cstrPatterns.reserve(patterns.size());
-        for (const auto &pattern : patterns) {
-            // cppcheck-suppress useStlAlgorithm
-            cstrPatterns.push_back(pattern.c_str());
-        }
+        auto pstr = [](const string &pattern) { return pattern.c_str(); };
+        std::transform(patterns.begin(), patterns.end(), std::back_inserter(cstrPatterns), pstr);
 
         Clock clock;
         clock.start();

--- a/examples/patbench.cc
+++ b/examples/patbench.cc
@@ -358,9 +358,11 @@ public:
     // Return the number of bytes scanned
     size_t bytes() const {
         size_t sum = 0;
-        for (const auto &packet : packets) {
-            sum += packet.size();
-        }
+        auto packs = [](size_t z, const string &packet) { return z + packet.size(); };
+        sum += std::accumulate(packets.begin(), packets.end(), 0, packs);
+        // for (const auto &packet : packets) {
+        //     sum += packet.size();
+        // }
         return sum;
     }
 
@@ -461,6 +463,7 @@ public:
         vector<const char *> cstrPatterns;
         cstrPatterns.reserve(patterns.size());
         for (const auto &pattern : patterns) {
+            // cppcheck-suppress useStlAlgorithm
             cstrPatterns.push_back(pattern.c_str());
         }
 

--- a/examples/pcapscan.cc
+++ b/examples/pcapscan.cc
@@ -55,6 +55,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <numeric>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -250,9 +251,8 @@ public:
     // Return the number of bytes scanned
     size_t bytes() const {
         size_t sum = 0;
-        for (const auto &packet : packets) {
-            sum += packet.size();
-        }
+        auto packs = [](size_t z, const string &packet) { return z + packet.size(); };
+        sum += std::accumulate(packets.begin(), packets.end(), 0, packs);
         return sum;
     }
 
@@ -433,6 +433,7 @@ static void databasesFromFile(const char *filename,
     // storage.)
     vector<const char*> cstrPatterns;
     for (const auto &pattern : patterns) {
+        // cppcheck-suppress useStlAlgorithm
         cstrPatterns.push_back(pattern.c_str());
     }
 

--- a/src/compiler/asserts.cpp
+++ b/src/compiler/asserts.cpp
@@ -251,6 +251,7 @@ void checkForMultilineStart(ReportManager &rm, NGHolder &g,
 
 static
 bool hasAssertVertices(const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(g)) {
         int flags = g[v].assert_flags;
         if (flags & WORDBOUNDARY_FLAGS) {

--- a/src/fdr/fdr_compile.cpp
+++ b/src/fdr/fdr_compile.cpp
@@ -135,10 +135,10 @@ void FDRCompiler::createInitialState(FDR *fdr) {
         // Find the minimum length for the literals in this bucket.
         const vector<LiteralIndex> &bucket_lits = bucketToLits[b];
         u32 min_len = ~0U;
-        for (const LiteralIndex &lit_idx : bucket_lits) {
-            // cppcheck-suppress useStlAlgorithm
-            min_len = min(min_len, verify_u32(lits[lit_idx].s.length()));
-        }
+        auto mlit = [lits=lits](const LiteralIndex &m, const LiteralIndex &n) {
+            return verify_u32(lits[m].s.length()) < verify_u32(lits[n].s.length()); };
+        auto minel = std::min_element(bucket_lits.begin(), bucket_lits.end(), mlit);
+        min_len = min(min_len, verify_u32(lits[*minel].s.length()));
 
         DEBUG_PRINTF("bucket %u has min_len=%u\n", b, min_len);
         assert(min_len);

--- a/src/fdr/fdr_compile.cpp
+++ b/src/fdr/fdr_compile.cpp
@@ -135,10 +135,10 @@ void FDRCompiler::createInitialState(FDR *fdr) {
         // Find the minimum length for the literals in this bucket.
         const vector<LiteralIndex> &bucket_lits = bucketToLits[b];
         u32 min_len = ~0U;
-        auto mlit = [lits=lits](const LiteralIndex &m, const LiteralIndex &n) {
-            return verify_u32(lits[m].s.length()) < verify_u32(lits[n].s.length()); };
-        auto minel = std::min_element(bucket_lits.begin(), bucket_lits.end(), mlit);
-        min_len = min(min_len, verify_u32(lits[*minel].s.length()));
+        for (const LiteralIndex &lit_idx : bucket_lits) {		
+            // cppcheck-suppress useStlAlgorithm		
+            min_len = min(min_len, verify_u32(lits[lit_idx].s.length()));		
+        }
 
         DEBUG_PRINTF("bucket %u has min_len=%u\n", b, min_len);
         assert(min_len);

--- a/src/fdr/fdr_compile.cpp
+++ b/src/fdr/fdr_compile.cpp
@@ -136,6 +136,7 @@ void FDRCompiler::createInitialState(FDR *fdr) {
         const vector<LiteralIndex> &bucket_lits = bucketToLits[b];
         u32 min_len = ~0U;
         for (const LiteralIndex &lit_idx : bucket_lits) {
+            // cppcheck-suppress useStlAlgorithm
             min_len = min(min_len, verify_u32(lits[lit_idx].s.length()));
         }
 

--- a/src/fdr/fdr_confirm_compile.cpp
+++ b/src/fdr/fdr_confirm_compile.cpp
@@ -303,6 +303,7 @@ setupFullConfs(const vector<hwlmLiteral> &lits,
         if (contains(bucketToLits, b)) {
             vector<hwlmLiteral> vl;
             for (const LiteralIndex &lit_idx : bucketToLits.at(b)) {
+                // cppcheck-suppress useStlAlgorithm
                 vl.emplace_back(lits[lit_idx]);
             }
 

--- a/src/fdr/teddy_engine_description.cpp
+++ b/src/fdr/teddy_engine_description.cpp
@@ -71,6 +71,7 @@ void getTeddyDescriptions(vector<TeddyEngineDescription> *out) {
     };
     out->clear();
     for (const auto &def : defns) {
+        // cppcheck-suppress useStlAlgorithm
         out->emplace_back(def);
     }
 }
@@ -123,6 +124,7 @@ bool isAllowed(const vector<hwlmLiteral> &vl, const TeddyEngineDescription &eng,
         u32 n_small_lits = 0;
         for (const auto &lit : vl) {
             if (lit.s.length() < eng.numMasks) {
+                // cppcheck-suppress useStlAlgorithm
                 n_small_lits++;
             }
         }
@@ -204,6 +206,7 @@ unique_ptr<TeddyEngineDescription> getTeddyDescription(u32 engineID) {
     getTeddyDescriptions(&descs);
 
     for (const auto &desc : descs) {
+        // cppcheck-suppress useStlAlgorithm
         if (desc.getID() == engineID) {
             return std::make_unique<TeddyEngineDescription>(desc);
         }

--- a/src/nfa/accel_dfa_build_strat.cpp
+++ b/src/nfa/accel_dfa_build_strat.cpp
@@ -182,6 +182,7 @@ vector<vector<CharReach>> generate_paths(const raw_dfa &rdfa,
     vector<vector<CharReach>> rv;
     rv.reserve(paths.size());
     for (auto &p : paths) {
+        // cppcheck-suppress useStlAlgorithm
         rv.emplace_back(vector<CharReach>(std::make_move_iterator(p.reach.begin()),
                                        std::make_move_iterator(p.reach.end())));
     }

--- a/src/nfa/castlecompile.cpp
+++ b/src/nfa/castlecompile.cpp
@@ -672,6 +672,7 @@ set<ReportID> all_reports(const CastleProto &proto) {
 depth findMinWidth(const CastleProto &proto) {
     depth min_width(depth::infinity());
     for (const PureRepeat &pr : proto.repeats | map_values) {
+        // cppcheck-suppress useStlAlgorithm
         min_width = min(min_width, pr.bounds.min);
     }
     return min_width;
@@ -680,6 +681,7 @@ depth findMinWidth(const CastleProto &proto) {
 depth findMaxWidth(const CastleProto &proto) {
     depth max_width(0);
     for (const PureRepeat &pr : proto.repeats | map_values) {
+        // cppcheck-suppress useStlAlgorithm
         max_width = max(max_width, pr.bounds.max);
     }
     return max_width;
@@ -746,6 +748,7 @@ u32 CastleProto::merge(const PureRepeat &pr) {
 
     // First, see if this repeat is already in this castle.
     for (const auto &m : repeats) {
+        // cppcheck-suppress useStlAlgorithm
         if (m.second == pr) {
             DEBUG_PRINTF("repeat already present, with top %u\n", m.first);
             return m.first;
@@ -970,6 +973,7 @@ void addToHolder(NGHolder &g, u32 top, const PureRepeat &pr) {
 static
 bool hasZeroMinBound(const CastleProto &proto) {
     const depth zero(0);
+    // cppcheck-suppress useStlAlgorithm
     for (const PureRepeat &pr : proto.repeats | map_values) {
         if (pr.bounds.min == zero) {
             return true;

--- a/src/nfa/dfa_min.cpp
+++ b/src/nfa/dfa_min.cpp
@@ -263,6 +263,7 @@ void mapping_new_states(const HopcroftInfo &info,
     new_states.reserve(num_partitions);
 
     for (const auto &m : ordering) {
+        // cppcheck-suppress useStlAlgorithm    
         new_states.emplace_back(rdfa.states[m.first]);
     }
     rdfa.states = std::move(new_states);

--- a/src/nfa/goughcompile.cpp
+++ b/src/nfa/goughcompile.cpp
@@ -650,6 +650,7 @@ void GoughSSAVarJoin::generate(UNUSED vector<gough_ins> *out) const {
 
 GoughSSAVar *GoughSSAVarJoin::get_input(const GoughEdge &prev) const {
     for (const auto &var_edge : input_map) {
+        // cppcheck-suppress useStlAlgorithm
         if (contains(var_edge.second, prev)) {
             return var_edge.first;
         }
@@ -992,6 +993,7 @@ void copy_in_blocks(raw_som_dfa &raw, u8 alphaShift, const GoughGraph &cfg,
 }
 
 bool find_normal_self_loop(GoughVertex v, const GoughGraph &g, GoughEdge *out) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : out_edges_range(v, g)) {
         if (target(e, g) != v) {
             continue;

--- a/src/nfa/goughcompile_accel.cpp
+++ b/src/nfa/goughcompile_accel.cpp
@@ -146,6 +146,7 @@ bool verify_neighbour(const GoughGraph &g, GoughVertex u,
                       const map<gough_edge_id, vector<gough_ins> > &blocks,
                       const set<GoughVertex> &succs,
                       const vector<gough_ins> &block_sl) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : out_edges_range(u, g)) {
         if (!g[e].reach.any()) { /* ignore top edges */
             continue;
@@ -172,6 +173,7 @@ static
 bool verify_neighbour_no_block(const GoughGraph &g, GoughVertex u,
                         const map<gough_edge_id, vector<gough_ins> > &blocks,
                         const set<GoughVertex> &succs) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : out_edges_range(u, g)) {
         if (!g[e].reach.any()) { /* ignore top edges */
             continue;
@@ -229,6 +231,7 @@ bool allow_two_byte_accel(const GoughGraph &g,
             succs.insert(target(e, g));
         }
 
+        // cppcheck-suppress useStlAlgorithm
         for (auto w : adjacent_vertices_range(v, g)) {
             if (w != v && !verify_neighbour(g, w, blocks, succs, block_sl)) {
                 return false;
@@ -249,6 +252,7 @@ bool allow_two_byte_accel(const GoughGraph &g,
             }
             succs.insert(target(e, g));
 
+            // cppcheck-suppress useStlAlgorithm
             for (auto w : adjacent_vertices_range(v, g)) {
                 if (w != v && !verify_neighbour_no_block(g, w, blocks, succs)) {
                     return false;

--- a/src/nfa/goughcompile_reg.cpp
+++ b/src/nfa/goughcompile_reg.cpp
@@ -50,6 +50,7 @@ namespace ue2 {
 
 template<typename VarP, typename VarQ>
 void emplace_back_all_raw(vector<VarP> *out, const vector<VarQ> &in) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &var : in) {
         out->emplace_back(var.get());
     }
@@ -380,6 +381,7 @@ template<typename VarP>
 void add_to_dom_ordering(const vector<VarP> &vars,
                          vector<GoughSSAVar *> *out) {
     for (const auto &var : vars) {
+        // cppcheck-suppress useStlAlgorithm
         out->emplace_back(var.get());
     }
 }

--- a/src/nfa/limex_compile.cpp
+++ b/src/nfa/limex_compile.cpp
@@ -482,6 +482,7 @@ bool allow_wide_accel(NFAVertex v, const NGHolder &g, NFAVertex sds_or_proxy) {
 static
 bool allow_wide_accel(const vector<NFAVertex> &vv, const NGHolder &g,
                       NFAVertex sds_or_proxy) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vv) {
         if (allow_wide_accel(v, g, sds_or_proxy)) {
             return true;
@@ -623,6 +624,7 @@ void fillAccelInfo(build_info &bi) {
 
     vector<NFAVertex> astates;
     for (const auto &m : accel_map) {
+        // cppcheck-suppress useStlAlgorithm
         astates.emplace_back(m.first);
     }
 
@@ -799,12 +801,14 @@ u32 getEffectiveAccelStates(const build_info &args,
             continue;
         }
         for (const auto &s_mask : args.squashMap | map_values) {
+            // cppcheck-suppress useStlAlgorithm
             if (!s_mask.test(state_id)) {
                 may_turn_off |= 1U << accel_id;
                 break;
             }
         }
         for (const auto &s_mask : args.reportSquashMap | map_values) {
+            // cppcheck-suppress useStlAlgorithm
             if (!s_mask.test(state_id)) {
                 may_turn_off |= 1U << accel_id;
                 break;

--- a/src/nfa/mcclellancompile.cpp
+++ b/src/nfa/mcclellancompile.cpp
@@ -55,6 +55,7 @@
 #include <cstring>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <queue>
 #include <set>
 #include <vector>
@@ -529,10 +530,15 @@ size_t calcWideRegionSize(const dfa_info &info) {
     size_t rv = info.wide_symbol_chain.size() * sizeof(u32) + 4;
 
     // wide info body
-    for (const auto &chain : info.wide_symbol_chain) {
-        rv += ROUNDUP_N(chain.size(), 2) +
-              (info.impl_alpha_size + 1) * sizeof(u16) + 2;
-    }
+    auto chainz = [info=info](size_t z, const vector<symbol_t> &chain) {
+        return z + (size_t)(ROUNDUP_N(chain.size(), 2) +   
+               (info.impl_alpha_size + 1) * sizeof(u16) + 2);
+    };
+    rv += std::accumulate(info.wide_symbol_chain.begin(), info.wide_symbol_chain.end(), 0, chainz);
+    // for (const auto &chain : info.wide_symbol_chain) {
+    //     rv += ROUNDUP_N(chain.size(), 2) +
+    //           (info.impl_alpha_size + 1) * sizeof(u16) + 2;
+    // }
 
     return ROUNDUP_16(rv);
 }

--- a/src/nfa/mcclellancompile.cpp
+++ b/src/nfa/mcclellancompile.cpp
@@ -535,10 +535,6 @@ size_t calcWideRegionSize(const dfa_info &info) {
                (info.impl_alpha_size + 1) * sizeof(u16) + 2);
     };
     rv += std::accumulate(info.wide_symbol_chain.begin(), info.wide_symbol_chain.end(), 0, chainz);
-    // for (const auto &chain : info.wide_symbol_chain) {
-    //     rv += ROUNDUP_N(chain.size(), 2) +
-    //           (info.impl_alpha_size + 1) * sizeof(u16) + 2;
-    // }
 
     return ROUNDUP_16(rv);
 }

--- a/src/nfa/mcclellancompile_util.cpp
+++ b/src/nfa/mcclellancompile_util.cpp
@@ -265,6 +265,7 @@ bool can_die_early(const raw_dfa &raw, dstate_id_t s,
     }
 
     for (const auto &next : raw.states[s].next) {
+        // cppcheck-suppress useStlAlgorithm
         if (can_die_early(raw, next, visited, age_limit - 1)) {
             return true;
         }

--- a/src/nfa/shufticompile.cpp
+++ b/src/nfa/shufticompile.cpp
@@ -182,6 +182,7 @@ bool shuftiBuildDoubleMasks(const CharReach &onechar,
         }
         nibble_masks.clear();
         for (const auto &e : new_masks) {
+            // cppcheck-suppress useStlAlgorithm
             nibble_masks.emplace_back(e.second);
         }
     }

--- a/src/nfa/tamaramacompile.cpp
+++ b/src/nfa/tamaramacompile.cpp
@@ -42,6 +42,8 @@
 #include "util/container.h"
 #include "util/verify_types.h"
 
+#include <numeric>
+
 using namespace std;
 
 namespace ue2 {
@@ -127,9 +129,14 @@ buildTamarama(const TamaInfo &tamaInfo, const u32 queue,
         sizeof(u32) * subSize + 64; // offsets to subengines in bytecode and
                                     // padding for subengines
 
-    for (const auto &sub : tamaInfo.subengines) {
-        total_size += ROUNDUP_CL(sub->length);
-    }
+
+    auto subl = [](size_t z, NFA *sub) {
+        return z + (size_t)(ROUNDUP_CL(sub->length));
+    };
+    total_size += std::accumulate(tamaInfo.subengines.begin(), tamaInfo.subengines.end(), 0, subl);
+    // for (const auto &sub : tamaInfo.subengines) {
+    //     total_size += ROUNDUP_CL(sub->length);
+    // }
 
     // use subSize as a sentinel value for no active subengines,
     // so add one to subSize here

--- a/src/nfagraph/ng_anchored_dots.cpp
+++ b/src/nfagraph/ng_anchored_dots.cpp
@@ -137,6 +137,7 @@ NFAVertex findReformable(const NGHolder &g, const set<NFAVertex> &starts,
 static
 bool isStartNode(NFAVertex v, NFAVertex start, const NGHolder &g,
                  bool selfLoopIsAcceptable) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (selfLoopIsAcceptable && u == v) {
             continue;
@@ -307,6 +308,7 @@ void reformUnanchoredRepeatsComponent(NGHolder &g,
             }
 
             for (auto v : otherV) {
+                // cppcheck-suppress useStlAlgorithm
                 if (!edge(dotV, v, g).second) {
                     return;
                 }
@@ -441,6 +443,7 @@ bool gatherParticipants(const NGHolder &g,
 
     /* All the non chained v connected to start must be in succ as well
      * TODO: remember why (and document). */
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : adjacent_vertices_range(start, g)) {
         if (is_special(u, g)) {
             continue;

--- a/src/nfagraph/ng_calc_components.cpp
+++ b/src/nfagraph/ng_calc_components.cpp
@@ -77,17 +77,20 @@ static constexpr u32 MAX_TAIL_SHELL_DEPTH = 3;
  * classes.
  */
 bool isAlternationOfClasses(const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(g)) {
         if (is_special(v, g)) {
             continue;
         }
         // Vertex must have in edges from starts only.
+        // cppcheck-suppress useStlAlgorithm
         for (auto u : inv_adjacent_vertices_range(v, g)) {
             if (!is_any_start(u, g)) {
                 return false;
             }
         }
         // Vertex must have out edges to accepts only.
+        // cppcheck-suppress useStlAlgorithm
         for (auto w : adjacent_vertices_range(v, g)) {
             if (!is_any_accept(w, g)) {
                 return false;

--- a/src/nfagraph/ng_depth.cpp
+++ b/src/nfagraph/ng_depth.cpp
@@ -157,6 +157,7 @@ vector<bool> findLoopReachable(const Graph &g,
 
     for (auto v : reverse(topoOrder)) {
         for (const auto &e : in_edges_range(v, g)) {
+            // cppcheck-suppress useStlAlgorithm
             if (deadNodes[g[source(e, g)].index]) {
                 deadNodes[g[v].index] = true;
                 break;

--- a/src/nfagraph/ng_edge_redundancy.cpp
+++ b/src/nfagraph/ng_edge_redundancy.cpp
@@ -63,6 +63,7 @@ bool checkVerticesFwd(const NGHolder &g, const set<NFAVertex> &sad,
     for (auto u : sad) {
         bool ok = false;
         for (auto v : adjacent_vertices_range(u, g)) {
+            // cppcheck-suppress useStlAlgorithm
             if (contains(happy, v)) {
                 ok = true;
                 break;
@@ -85,6 +86,7 @@ bool checkVerticesRev(const NGHolder &g, const set<NFAVertex> &sad,
     for (auto v : sad) {
         bool ok = false;
         for (auto u : inv_adjacent_vertices_range(v, g)) {
+            // cppcheck-suppress useStlAlgorithm
             if (contains(happy, u)) {
                 ok = true;
                 break;

--- a/src/nfagraph/ng_equivalence.cpp
+++ b/src/nfagraph/ng_equivalence.cpp
@@ -197,6 +197,7 @@ bool outIsIrreducible(NFAVertex &v, const NGHolder &g) {
     unsigned nonSpecialVertices = 0;
     for (auto w : adjacent_vertices_range(v, g)) {
         if (!is_special(w, g) && w != v) {
+            // cppcheck-suppress useStlAlgorithm
             nonSpecialVertices++;
         }
     }
@@ -208,6 +209,7 @@ bool inIsIrreducible(NFAVertex &v, const NGHolder &g) {
     unsigned nonSpecialVertices = 0;
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (!is_special(u, g) && u != v) {
+            // cppcheck-suppress useStlAlgorithm
             nonSpecialVertices++;
         }
     }

--- a/src/nfagraph/ng_expr_info.cpp
+++ b/src/nfagraph/ng_expr_info.cpp
@@ -131,6 +131,7 @@ void checkVertex(const ReportManager &rm, const NGHolder &g, NFAVertex v,
 
 static
 bool hasOffsetAdjust(const ReportManager &rm, const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &report_id : all_reports(g)) {
         if (rm.getReport(report_id).offsetAdjust) {
             return true;

--- a/src/nfagraph/ng_extparam.cpp
+++ b/src/nfagraph/ng_extparam.cpp
@@ -75,6 +75,7 @@ bool hasSameBounds(const Container &reports, const ReportManager &rm) {
     assert(!reports.empty());
 
     const auto &first = rm.getReport(*reports.begin());
+    // cppcheck-suppress useStlAlgorithm
     for (auto id : reports) {
         const auto &report = rm.getReport(id);
         if (report.minOffset != first.minOffset ||
@@ -225,6 +226,7 @@ void updateReportBounds(ReportManager &rm, NGHolder &g,
 
 static
 bool hasVirtualStarts(const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(g.start, g)) {
         if (g[v].assert_flags & POS_FLAG_VIRTUAL_START) {
             return true;
@@ -439,6 +441,7 @@ bool hasOffsetAdjust(const ReportManager &rm, NGHolder &g,
     }
 
     int offsetAdjust = rm.getReport(*reports.begin()).offsetAdjust;
+    // cppcheck-suppress useStlAlgorithm
     for (auto report : reports) {
         const Report &ir = rm.getReport(report);
         if (ir.offsetAdjust != offsetAdjust) {

--- a/src/nfagraph/ng_fuzzy.cpp
+++ b/src/nfagraph/ng_fuzzy.cpp
@@ -673,6 +673,7 @@ void validate_fuzzy_compile(const NGHolder &g, u32 edit_distance, bool hamming,
     }
     // graph isn't fuzzable if there are edge assertions anywhere in the graph
     for (auto e : edges_range(g)) {
+        // cppcheck-suppress useStlAlgorithm
         if (g[e].assert_flags) {
             throw CompileError("Zero-width assertions are disallowed for "
                                "approximate matching.");

--- a/src/nfagraph/ng_haig.cpp
+++ b/src/nfagraph/ng_haig.cpp
@@ -453,6 +453,7 @@ void haig_do_preds(const NGHolder &g, const stateset &nfa_states,
         DEBUG_PRINTF("d vertex %zu\n", g[v].index);
         vector<u32> &out_map = preds[slot_id];
         for (auto u : inv_adjacent_vertices_range(v, g)) {
+            // cppcheck-suppress useStlAlgorithm
             out_map.emplace_back(g[u].index);
         }
 

--- a/src/nfagraph/ng_is_equal.cpp
+++ b/src/nfagraph/ng_is_equal.cpp
@@ -172,9 +172,11 @@ bool is_equal_i(const NGHolder &a, const NGHolder &b,
     vector<pair<u32, flat_set<u32>>> top_b;
 
     for (const auto &e : out_edges_range(a.start, a)) {
+        // cppcheck-suppress useStlAlgorithm
         top_a.emplace_back(a[target(e, a)].index, a[e].tops);
     }
     for (const auto &e : out_edges_range(b.start, b)) {
+        // cppcheck-suppress useStlAlgorithm
         top_b.emplace_back(b[target(e, b)].index, b[e].tops);
     }
 

--- a/src/nfagraph/ng_literal_analysis.cpp
+++ b/src/nfagraph/ng_literal_analysis.cpp
@@ -46,6 +46,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <numeric>
 #include <queue>
 
 #include <boost/graph/boykov_kolmogorov_max_flow.hpp>
@@ -359,6 +360,7 @@ u64a litUniqueness(const string &s) {
 static
 u64a litCountBits(const ue2_literal &lit) {
     u64a n = 0;
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &c : lit) {
         n += c.nocase ? 7 : 8;
     }
@@ -670,10 +672,11 @@ u64a scoreSet(const set<ue2_literal> &s) {
     }
 
     u64a score = 1ULL;
-
-    for (const auto &lit : s) {
-        score += calculateScore(lit);
-    }
+    auto cscore = [](u64a z, const ue2_literal &lit) { return z + calculateScore(lit); };
+    score += std::accumulate(s.begin(), s.end(), 0, cscore);
+    // for (const auto &lit : s) {
+    //     score += calculateScore(lit);
+    // }
 
     return score;
 }

--- a/src/nfagraph/ng_literal_analysis.cpp
+++ b/src/nfagraph/ng_literal_analysis.cpp
@@ -674,9 +674,6 @@ u64a scoreSet(const set<ue2_literal> &s) {
     u64a score = 1ULL;
     auto cscore = [](u64a z, const ue2_literal &lit) { return z + calculateScore(lit); };
     score += std::accumulate(s.begin(), s.end(), 0, cscore);
-    // for (const auto &lit : s) {
-    //     score += calculateScore(lit);
-    // }
 
     return score;
 }

--- a/src/nfagraph/ng_misc_opt.cpp
+++ b/src/nfagraph/ng_misc_opt.cpp
@@ -154,6 +154,7 @@ void predCRIntersection(const NGHolder &g, NFAVertex v, CharReach &add) {
     add.setall();
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (u != v) {
+            // cppcheck-suppress useStlAlgorithm
             add &= g[u].char_reach;
         }
     }
@@ -165,6 +166,7 @@ void succCRIntersection(const NGHolder &g, NFAVertex v, CharReach &add) {
     add.setall();
     for (auto u : adjacent_vertices_range(v, g)) {
         if (u != v) {
+            // cppcheck-suppress useStlAlgorithm
             add &= g[u].char_reach;
         }
     }
@@ -195,6 +197,7 @@ set<NFAVertex> findSustainSet(const NGHolder &g, NFAVertex p,
             CharReach sus_cr;
             for (auto v : adjacent_vertices_range(u, g)) {
                 if (contains(cand, v)) {
+                    // cppcheck-suppress useStlAlgorithm
                     sus_cr |= g[v].char_reach;
                 }
             }
@@ -227,6 +230,7 @@ set<NFAVertex> findSustainSet_rev(const NGHolder &g, NFAVertex p,
             CharReach sus_cr;
             for (auto v : inv_adjacent_vertices_range(u, g)) {
                 if (contains(cand, v)) {
+                    // cppcheck-suppress useStlAlgorithm
                     sus_cr |= g[v].char_reach;
                 }
             }
@@ -282,6 +286,7 @@ bool enlargeCyclicVertex(NGHolder &g, som_type som, NFAVertex v) {
             CharReach sustain_cr;
             for (auto pv : adjacent_vertices_range(pp, g)) {
                 if (contains(sustain, pv)) {
+                    // cppcheck-suppress useStlAlgorithm
                     sustain_cr |= g[pv].char_reach;
                 }
             }
@@ -332,6 +337,7 @@ bool enlargeCyclicVertex_rev(NGHolder &g, NFAVertex v) {
             CharReach sustain_cr;
             for (auto pv : inv_adjacent_vertices_range(pp, g)) {
                 if (contains(sustain, pv)) {
+                    // cppcheck-suppress useStlAlgorithm
                     sustain_cr |= g[pv].char_reach;
                 }
             }

--- a/src/nfagraph/ng_prune.cpp
+++ b/src/nfagraph/ng_prune.cpp
@@ -251,12 +251,14 @@ bool hasOnlySelfLoopAndExhaustibleAccepts(const NGHolder &g,
         return false;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto w : adjacent_vertices_range(v, g)) {
         if (w != v && w != g.accept) {
             return false;
         }
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &report_id : g[v].reports) {
         if (!isSimpleExhaustible(rm.getReport(report_id))) {
             return false;

--- a/src/nfagraph/ng_puff.cpp
+++ b/src/nfagraph/ng_puff.cpp
@@ -154,6 +154,7 @@ static
 bool triggerResetsPuff(const NGHolder &g, NFAVertex head) {
     const CharReach puff_escapes = ~g[head].char_reach;
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(head, g)) {
         if (!g[u].char_reach.isSubsetOf(puff_escapes)) {
             DEBUG_PRINTF("no reset on trigger %zu %zu\n", g[u].index,
@@ -187,6 +188,7 @@ bool triggerFloodsPuff(const NGHolder &g, NFAVertex head) {
         DEBUG_PRINTF("temp new head = %zu\n", g[head].index);
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto s : inv_adjacent_vertices_range(head, g)) {
         DEBUG_PRINTF("s = %zu\n", g[s].index);
         if (!puff_cr.isSubsetOf(g[s].char_reach)) {
@@ -224,6 +226,7 @@ u32 allowedSquashDistance(const CharReach &cr, u32 min_width, const NGHolder &g,
 
     /* TODO: inspect further back in the pattern */
     for (auto u : inv_adjacent_vertices_range(pv, g)) {
+        // cppcheck-suppress useStlAlgorithm
         accept_cr |= g[u].char_reach;
     }
 
@@ -367,6 +370,7 @@ bool doComponent(RoseBuild &rose, ReportManager &rm, NGHolder &g, NFAVertex a,
 
     if (!nodes.empty() && proper_in_degree(nodes.back(), g) != 1) {
         for (auto u : inv_adjacent_vertices_range(nodes.back(), g)) {
+            // cppcheck-suppress useStlAlgorithm
             if (is_special(u, g)) {
                 DEBUG_PRINTF("pop\n");
                 a = nodes.back();
@@ -453,6 +457,7 @@ bool doComponent(RoseBuild &rose, ReportManager &rm, NGHolder &g, NFAVertex a,
     const auto &reports = g[nodes[0]].reports;
     assert(!reports.empty());
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto report : reports) {
         const Report &ir = rm.getReport(report);
         const bool highlander = ir.ekey != INVALID_EKEY;
@@ -499,6 +504,7 @@ bool splitOffPuffs(RoseBuild &rose, ReportManager &rm, NGHolder &g,
 
     for (auto v : inv_adjacent_vertices_range(g.accept, g)) {
         if (doComponent(rose, rm, g, v, dead, cc, prefilter)) {
+            // cppcheck-suppress useStlAlgorithm
             count++;
         }
     }

--- a/src/nfagraph/ng_redundancy.cpp
+++ b/src/nfagraph/ng_redundancy.cpp
@@ -682,6 +682,7 @@ bool forwardPathReachSubset(const NFAEdge &e, const NFAVertex &dom,
 
 static
 bool allOutsSpecial(NFAVertex v, const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto w : adjacent_vertices_range(v, g)) {
         if (!is_special(w, g)) {
             return false;
@@ -692,6 +693,7 @@ bool allOutsSpecial(NFAVertex v, const NGHolder &g) {
 
 static
 bool allInsSpecial(NFAVertex v, const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (!is_special(u, g)) {
             return false;
@@ -704,6 +706,7 @@ bool allInsSpecial(NFAVertex v, const NGHolder &g) {
  * just a chain of vertices with no other edges. */
 static
 bool isIrreducible(const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(g)) {
         // skip specials
         if (is_special(v, g)) {

--- a/src/nfagraph/ng_region.cpp
+++ b/src/nfagraph/ng_region.cpp
@@ -153,6 +153,7 @@ bool exitValid(UNUSED const AcyclicGraph &g, const vector<exit_info> &exits,
     }
 
     for (auto it = begin(exits) + 1; it != end(exits); ++it) {
+        // cppcheck-suppress useStlAlgorithm
         if (it->open != enters) {
             return false;
         }

--- a/src/nfagraph/ng_region.h
+++ b/src/nfagraph/ng_region.h
@@ -141,12 +141,14 @@ bool isRegionExit(const Graph &g, NFAVertex v,
 template <class Graph>
 bool isSingletonRegion(const Graph &g, NFAVertex v,
                        const std::unordered_map<NFAVertex, u32> &region_map) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : in_edges_range(v, g)) {
         auto u = source(e, g);
         if (u != v && inSameRegion(g, v, u, region_map)) {
             return false;
         }
 
+        // cppcheck-suppress useStlAlgorithm
         for (auto w : ue2::adjacent_vertices_range(u, g)) {
             if (w != v && inSameRegion(g, v, w, region_map)) {
                 return false;
@@ -154,11 +156,13 @@ bool isSingletonRegion(const Graph &g, NFAVertex v,
         }
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto w : adjacent_vertices_range(v, g)) {
         if (w != v && inSameRegion(g, v, w, region_map)) {
             return false;
         }
 
+        // cppcheck-suppress useStlAlgorithm
         for (const auto &e : in_edges_range(w, g)) {
             auto u = source(e, g);
             if (u != v && inSameRegion(g, v, u, region_map)) {
@@ -201,7 +205,7 @@ bool isOptionalRegion(const Graph &g, NFAVertex v,
         DEBUG_PRINTF("  searching from u=%zu\n", g[u].index);
 
         assert(inEarlierRegion(g, v, u, region_map));
-
+        // cppcheck-suppress useStlAlgorithm
         for (auto w : adjacent_vertices_range(u, g)) {
             DEBUG_PRINTF("    searching to w=%zu\n", g[w].index);
             if (inLaterRegion(g, v, w, region_map)) {

--- a/src/nfagraph/ng_region_redundancy.cpp
+++ b/src/nfagraph/ng_region_redundancy.cpp
@@ -62,6 +62,7 @@ bool regionHasUnexpectedAccept(const NGHolder &g, const u32 region,
                        const flat_set<ReportID> &expected_reports,
                        const unordered_map<NFAVertex, u32> &region_map) {
     /* TODO: only check vertices connected to accept/acceptEOD */
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(g)) {
         if (region != region_map.at(v)) {
             continue;
@@ -71,7 +72,7 @@ bool regionHasUnexpectedAccept(const NGHolder &g, const u32 region,
             return true; /* encountering an actual special in the region is
                           * possible but definitely unexpected */
         }
-
+        // cppcheck-suppress useStlAlgorithm
         for (auto w : adjacent_vertices_range(v, g)) {
             if (is_any_accept(w, g) && g[v].reports != expected_reports) {
                 return true;
@@ -200,6 +201,7 @@ map<u32, RegionInfo> buildRegionInfoMap(const NGHolder &g,
 
 static
 bool hasNoStartAnchoring(const NGHolder &h) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(h.start, h)) {
         if (!edge(h.startDs, v, h).second) {
             return false;

--- a/src/nfagraph/ng_repeat.cpp
+++ b/src/nfagraph/ng_repeat.cpp
@@ -260,6 +260,7 @@ bool vertexIsBad(const NGHolder &g, NFAVertex v,
     // We must drop any vertex that is the target of a back-edge within
     // our subgraph. The tail set contains all vertices that are after v in a
     // topo ordering.
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (contains(tail, u)) {
             DEBUG_PRINTF("back-edge (%zu,%zu) in subgraph found\n",
@@ -343,6 +344,7 @@ static
 void findFirstReports(const NGHolder &g, const ReachSubgraph &rsi,
                       flat_set<ReportID> &reports) {
     for (auto v : rsi.vertices) {
+        // cppcheck-suppress useStlAlgorithm
         if (is_match_vertex(v, g)) {
             reports = g[v].reports;
             return;
@@ -620,6 +622,7 @@ bool processSubgraph(const NGHolder &g, ReachSubgraph &rsi,
 static
 bool allPredsInSubgraph(NFAVertex v, const NGHolder &g,
                         const unordered_set<NFAVertex> &involved) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (!contains(involved, u)) {
             return false;
@@ -688,6 +691,7 @@ u32 isCloseToAccept(const NGHolder &g, NFAVertex v) {
     }
 
     for (auto w : adjacent_vertices_range(v, g)) {
+        // cppcheck-suppress useStlAlgorithm
         if (is_any_accept(w, g)) {
             return 1;
         }
@@ -702,6 +706,7 @@ u32 unpeelAmount(const NGHolder &g, const ReachSubgraph &rsi) {
     u32 rv = 0;
 
     for (auto v : adjacent_vertices_range(last, g)) {
+        // cppcheck-suppress useStlAlgorithm
         rv = max(rv, isCloseToAccept(g, v));
     }
 
@@ -995,6 +1000,7 @@ bool peelSubgraph(const NGHolder &g, const Grey &grey, ReachSubgraph &rsi,
 
     // If vertices in the middle are involved in other repeats, it's a definite
     // no-no.
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : rsi.vertices) {
         if (contains(created, v)) {
             DEBUG_PRINTF("vertex %zu is in another repeat\n", g[v].index);
@@ -1075,7 +1081,9 @@ bool hasSkipEdges(const NGHolder &g, const ReachSubgraph &rsi) {
     const NFAVertex last = rsi.vertices.back();
 
     // All of the preds of first must have edges to all the successors of last.
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(first, g)) {
+        // cppcheck-suppress useStlAlgorithm
         for (auto v : adjacent_vertices_range(last, g)) {
             if (!edge(u, v, g).second) {
                 return false;
@@ -1114,6 +1122,7 @@ bool entered_at_fixed_offset(NFAVertex v, const NGHolder &g,
     }
     DEBUG_PRINTF("first is at least %s from start\n", first.str().c_str());
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         const depth &u_max_depth = depths.at(u).fromStart.max;
         DEBUG_PRINTF("pred %zu max depth %s from start\n", g[u].index,
@@ -1204,6 +1213,7 @@ static
 CharReach predReach(const NGHolder &g, NFAVertex v) {
     CharReach cr;
     for (auto u : inv_adjacent_vertices_range(v, g)) {
+        // cppcheck-suppress useStlAlgorithm
         cr |= g[u].char_reach;
     }
     return cr;
@@ -1431,6 +1441,7 @@ struct StrawWalker {
      * inf max bound). */
     bool isBoundedRepeatCyclic(NFAVertex v) const {
         for (const auto &r : repeats) {
+            // cppcheck-suppress useStlAlgorithm
             if (r.repeatMax.is_finite() && r.cyclic == v) {
                 return true;
             }
@@ -1580,6 +1591,7 @@ bool hasCyclicSupersetExitPath(const NGHolder &g, const ReachSubgraph &rsi,
 static
 bool leadsOnlyToAccept(const NGHolder &g, const ReachSubgraph &rsi) {
     const NFAVertex u = rsi.vertices.back();
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(u, g)) {
         if (v != g.accept) {
             return false;
@@ -1593,6 +1605,7 @@ static
 bool allSimpleHighlander(const ReportManager &rm,
                          const flat_set<ReportID> &reports) {
     assert(!reports.empty());
+    // cppcheck-suppress useStlAlgorithm
     for (auto report : reports) {
         if (!isSimpleExhaustible(rm.getReport(report))) {
             return false;
@@ -1909,6 +1922,7 @@ bool improveLeadingRepeat(NGHolder &g, BoundedRepeatData &rd,
         DEBUG_PRINTF("startDs has other successors\n");
         return false;
     }
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &v : straw) {
         if (proper_out_degree(v, g) != 1) {
             DEBUG_PRINTF("branch between startDs and repeat, from vertex %zu\n",

--- a/src/nfagraph/ng_reports.cpp
+++ b/src/nfagraph/ng_reports.cpp
@@ -56,6 +56,7 @@ set<ReportID> all_reports(const NGHolder &g) {
 
 /** True if *all* reports in the graph are exhaustible. */
 bool can_exhaust(const NGHolder &g, const ReportManager &rm) {
+    // cppcheck-suppress useStlAlgorithm
     for (ReportID report_id : all_reports(g)) {
         if (rm.getReport(report_id).ekey == INVALID_EKEY) {
             return false;

--- a/src/nfagraph/ng_restructuring.cpp
+++ b/src/nfagraph/ng_restructuring.cpp
@@ -210,6 +210,7 @@ u32 countStates(const unordered_map<NFAVertex, u32> &state_ids) {
     u32 max_state = 0;
     for (const auto &m : state_ids) {
         if (m.second != NO_STATE) {
+            // cppcheck-suppress useStlAlgorithm
             max_state = max(m.second, max_state);
         }
     }

--- a/src/nfagraph/ng_sep.cpp
+++ b/src/nfagraph/ng_sep.cpp
@@ -56,6 +56,7 @@ namespace ue2 {
 
 static
 bool checkFromVertex(const NGHolder &g, NFAVertex start) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(start, g)) {
         if (v == g.startDs) {
             continue;

--- a/src/nfagraph/ng_small_literal_set.cpp
+++ b/src/nfagraph/ng_small_literal_set.cpp
@@ -103,6 +103,7 @@ bool checkLongMixedSensitivityLiterals(
         const map<sls_literal, flat_set<ReportID>> &literals) {
     const size_t len = MAX_MASK2_WIDTH;
 
+    // cppcheck-suppress useStlAlgorithm
     for (const sls_literal &lit : literals | map_keys) {
         if (mixed_sensitivity(lit.s) && lit.s.length() > len) {
             return false;
@@ -202,6 +203,7 @@ size_t min_period(const map<sls_literal, flat_set<ReportID>> &literals) {
     size_t rv = SIZE_MAX;
 
     for (const sls_literal &lit : literals | map_keys) {
+        // cppcheck-suppress useStlAlgorithm
         rv = min(rv, minStringPeriod(lit.s));
     }
     DEBUG_PRINTF("min period %zu\n", rv);

--- a/src/nfagraph/ng_som.cpp
+++ b/src/nfagraph/ng_som.cpp
@@ -545,6 +545,7 @@ bool finalRegion(const NGHolder &g,
                  const unordered_map<NFAVertex, u32> &regions,
                  NFAVertex v) {
     u32 region = regions.at(v);
+    // cppcheck-suppress useStlAlgorithm
     for (auto w : adjacent_vertices_range(v, g)) {
         if (w != g.accept && w != g.acceptEod && regions.at(w) != region) {
             return false;
@@ -2331,6 +2332,7 @@ bool splitOffLeadingLiterals(const NGHolder &g, set<ue2_literal> *lit_out,
     assert(!terms.empty());
     set<NFAVertex> adj_term1;
     insert(&adj_term1, adjacent_vertices(*terms.begin(), g));
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : terms) {
         DEBUG_PRINTF("term %zu\n", g[v].index);
         set<NFAVertex> temp;

--- a/src/nfagraph/ng_som_add_redundancy.cpp
+++ b/src/nfagraph/ng_som_add_redundancy.cpp
@@ -86,6 +86,7 @@ const DepthMinMax &getDepth(NFAVertex v, const NGHolder &g,
 static
 bool hasFloatingPred(NFAVertex v, const NGHolder &g,
                      const vector<DepthMinMax> &depths) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         const DepthMinMax &d = getDepth(u, g, depths);
         if (d.min != d.max) {

--- a/src/nfagraph/ng_som_util.cpp
+++ b/src/nfagraph/ng_som_util.cpp
@@ -151,6 +151,7 @@ bool firstMatchIsFirst(const NGHolder &p) {
     /* run the prefix the main graph */
     states = execute_graph(p, p, states);
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : states) {
         /* need to check if this vertex may represent an infix match - ie
          * it does not have an edge to accept. */
@@ -252,6 +253,7 @@ bool somMayGoBackwards(NFAVertex u, const NGHolder &g,
             continue;
         }
         for (auto v : adjacent_vertices_range(t, g)) {
+            // cppcheck-suppress useStlAlgorithm
             if (contains(u_succ, v)) {
                 /* due to virtual starts being aliased with normal starts in the
                  * copy of the graph, we may have already added the edges. */

--- a/src/nfagraph/ng_squash.cpp
+++ b/src/nfagraph/ng_squash.cpp
@@ -280,10 +280,8 @@ void findDerivedSquashers(const NGHolder &g, const vector<NFAVertex> &vByIndex,
                           const unordered_map<NFAVertex, u32> &region_map,
                           smgb_cache &cache) {
     deque<NFAVertex> remaining;
-    for (const auto &m : *squash) {
-        // cppcheck-suppress useStlAlgorithm
-        remaining.emplace_back(m.first);
-    }
+    auto mfirst = [](const pair<NFAVertex, NFAStateSet> &m) { return m.first; };
+    std::transform(squash->begin(), squash->end(), std::back_inserter(remaining), mfirst);
 
     while (!remaining.empty()) {
         NFAVertex v = remaining.back();

--- a/src/nfagraph/ng_squash.cpp
+++ b/src/nfagraph/ng_squash.cpp
@@ -281,6 +281,7 @@ void findDerivedSquashers(const NGHolder &g, const vector<NFAVertex> &vByIndex,
                           smgb_cache &cache) {
     deque<NFAVertex> remaining;
     for (const auto &m : *squash) {
+        // cppcheck-suppress useStlAlgorithm
         remaining.emplace_back(m.first);
     }
 

--- a/src/nfagraph/ng_util.cpp
+++ b/src/nfagraph/ng_util.cpp
@@ -177,6 +177,7 @@ bool isVacuous(const NGHolder &h) {
 }
 
 bool isAnchored(const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(g.startDs, g)) {
         if (v != g.startDs) {
             return false;
@@ -186,6 +187,7 @@ bool isAnchored(const NGHolder &g) {
 }
 
 bool isFloating(const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(g.start, g)) {
         if (v != g.startDs && !edge(g.startDs, v, g).second) {
             return false;
@@ -228,6 +230,7 @@ bool hasBigCycles(const NGHolder &g) {
     boost::depth_first_search(g, backEdgeVisitor, make_small_color_map(g),
                               g.start);
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : dead) {
         if (source(e, g) != target(e, g)) {
             return true;
@@ -259,6 +262,7 @@ bool can_match_at_eod(const NGHolder &h) {
         return true;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto e : in_edges_range(h.accept, h)) {
         if (h[e].assert_flags) {
             DEBUG_PRINTF("edge to accept has assert flags %d\n",

--- a/src/nfagraph/ng_violet.cpp
+++ b/src/nfagraph/ng_violet.cpp
@@ -89,9 +89,11 @@ bool createsAnchoredLHS(const NGHolder &g, const vector<NFAVertex> &vv,
                         const Grey &grey, depth max_depth = depth::infinity()) {
     max_depth = min(max_depth, depth(grey.maxAnchoredRegion));
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vv) {
         /* avoid issues of self loops blowing out depths:
          *     look at preds, add 1 */
+        // cppcheck-suppress useStlAlgorithm
         for (auto u : inv_adjacent_vertices_range(v, g)) {
             if (u == v) {
                 continue;
@@ -116,9 +118,11 @@ bool createsTransientLHS(const NGHolder &g, const vector<NFAVertex> &vv,
                          const Grey &grey) {
     const depth max_depth(grey.maxHistoryAvailable);
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vv) {
         /* avoid issues of self loops blowing out depths:
          *     look at preds, add 1 */
+        // cppcheck-suppress useStlAlgorithm
         for (auto u : inv_adjacent_vertices_range(v, g)) {
             if (u == v) {
                 continue;
@@ -162,6 +166,7 @@ u32 min_len(const set<ue2_literal> &s) {
     u32 rv = ~0U;
 
     for (const auto &lit : s) {
+        // cppcheck-suppress useStlAlgorithm
         rv = min(rv, (u32)lit.length());
     }
 
@@ -173,6 +178,7 @@ u32 min_period(const set<ue2_literal> &s) {
     u32 rv = ~0U;
 
     for (const auto &lit : s) {
+        // cppcheck-suppress useStlAlgorithm
         rv = min(rv, (u32)minStringPeriod(lit));
     }
     DEBUG_PRINTF("min period %u\n", rv);
@@ -394,6 +400,7 @@ void getSimpleRoseLiterals(const NGHolder &g, bool seeking_anchored,
 
     lits->reserve(lit_info.size());
     for (auto &m : lit_info) {
+        // cppcheck-suppress useStlAlgorithm
         lits->emplace_back(std::move(m.second));
     }
     DEBUG_PRINTF("%zu candidate literal sets\n", lits->size());
@@ -1196,6 +1203,7 @@ bool checkValidNetflowLits(NGHolder &h, const vector<u64a> &scores,
 
         for (const auto &lit : cut.second) {
             if (lit.length() == 2) {
+                // cppcheck-suppress useStlAlgorithm
                 len_2_count++;
             }
         }
@@ -1807,6 +1815,7 @@ void removeRedundantLiterals(RoseInGraph &g, const CompileContext &cc) {
 static
 RoseInVertex getStart(RoseInGraph &vg) {
     for (RoseInVertex v : vertices_range(vg)) {
+        // cppcheck-suppress useStlAlgorithm
         if (vg[v].type == RIV_START || vg[v].type == RIV_ANCHORED_START) {
             return v;
         }
@@ -1822,6 +1831,7 @@ RoseInVertex getStart(RoseInGraph &vg) {
 static
 RoseInVertex getPrimaryAccept(RoseInGraph &vg) {
     for (RoseInVertex v : vertices_range(vg)) {
+        // cppcheck-suppress useStlAlgorithm
         if (vg[v].type == RIV_ACCEPT && vg[v].reports.empty()) {
             return v;
         }
@@ -2833,6 +2843,7 @@ bool doEarlyDfa(RoseBuild &rose, RoseInGraph &vg, NGHolder &h,
     DEBUG_PRINTF("trying for dfa\n");
 
     bool single_trigger;
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : edges) {
         if (vg[target(e, vg)].type == RIV_ACCEPT_EOD) {
             /* TODO: support eod prefixes */

--- a/src/parser/ComponentAlternation.cpp
+++ b/src/parser/ComponentAlternation.cpp
@@ -130,6 +130,7 @@ vector<PositionInfo> ComponentAlternation::last() const {
 
 bool ComponentAlternation::empty(void) const {
     // an alternation can be empty if any of its components are empty
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &c : children) {
         if (c->empty()) {
             return true;
@@ -173,6 +174,7 @@ bool ComponentAlternation::checkEmbeddedEndAnchor(bool at_end) const {
 }
 
 bool ComponentAlternation::vacuous_everywhere(void) const {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &c : children) {
         if (c->vacuous_everywhere()) {
             return true;

--- a/src/parser/ComponentRepeat.cpp
+++ b/src/parser/ComponentRepeat.cpp
@@ -113,6 +113,7 @@ static
 void checkPositions(vector<PositionInfo> &v, const GlushkovBuildState &bs) {
     const NFABuilder& builder = bs.getBuilder();
     for (const auto &e : v) {
+        // cppcheck-suppress useStlAlgorithm
         if (builder.isSpecialState(e.pos)) {
             throw ParseError("Embedded anchors not supported.");
         }
@@ -341,6 +342,7 @@ inf_check:
 
 static
 bool hasPositionFlags(const Component &c) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : c.first()) {
         if (e.flags) {
             return true;

--- a/src/parser/ComponentSequence.cpp
+++ b/src/parser/ComponentSequence.cpp
@@ -253,6 +253,7 @@ vector<PositionInfo> ComponentSequence::last() const {
 
 bool ComponentSequence::empty(void) const {
     // a sequence can be empty if all its subcomponents can be empty
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &c : children) {
         if (!c->empty()) {
             return false;
@@ -342,6 +343,7 @@ bool ComponentSequence::checkEmbeddedEndAnchor(bool at_end) const {
 }
 
 bool ComponentSequence::vacuous_everywhere() const {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &c : children) {
         if (!c->vacuous_everywhere()) {
             return false;

--- a/src/parser/buildstate.cpp
+++ b/src/parser/buildstate.cpp
@@ -175,6 +175,7 @@ void checkEmbeddedEndAnchor(const PositionInfo &from,
     }
 
     for (const auto &first : firsts) {
+        // cppcheck-suppress useStlAlgorithm
         if (first.pos != GlushkovBuildStateImpl::POS_EPSILON) {
             /* can make it through the parse tree */
             throw ParseError("Embedded end anchors not supported.");

--- a/src/rose/rose_build_add.cpp
+++ b/src/rose/rose_build_add.cpp
@@ -241,6 +241,7 @@ RoseRoleHistory selectHistory(const RoseBuildImpl &tbi, const RoseBuildData &bd,
 
 static
 bool hasSuccessorLiterals(RoseInVertex iv, const RoseInGraph &ig) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(iv, ig)) {
         if (ig[v].type != RIV_ACCEPT) {
             return true;
@@ -833,6 +834,7 @@ bool suitableForEod(const RoseInGraph &ig, vector<RoseInVertex> topo,
 
         if (ig[v].type == RIV_ACCEPT) {
             DEBUG_PRINTF("[ACCEPT]\n");
+            // cppcheck-suppress useStlAlgorithm
             for (const auto &e : in_edges_range(v, ig)) {
                 if (!ig[e].graph || !can_only_match_at_eod(*ig[e].graph)) {
                     DEBUG_PRINTF("floating accept\n");
@@ -1057,6 +1059,7 @@ static
 bool predsAreDelaySensitive(const RoseInGraph &ig, RoseInVertex v) {
     assert(in_degree(v, ig));
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : in_edges_range(v, ig)) {
         if (ig[e].graph || ig[e].haig) {
             DEBUG_PRINTF("edge graph\n");
@@ -1626,6 +1629,7 @@ bool roseCheckRose(const RoseInGraph &ig, bool prefilter,
         graphs.emplace_back(ig[e].graph.get());
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &g : graphs) {
         if (!canImplementGraph(*g, prefilter, rm, cc)) {
             return false;
@@ -1930,6 +1934,7 @@ bool RoseBuildImpl::addAnchoredAcyclic(const NGHolder &h) {
     flat_set<u32> added_lit_ids;          /* literal ids added for this NFA */
 
     for (auto v : inv_adjacent_vertices_range(h.accept, h)) {
+        // cppcheck-suppress useStlAlgorithm
         if (!prepAcceptForAddAnchoredNFA(*this, h, v, vertexDepths, depthMap,
                                          reportMap, allocated_reports,
                                          added_lit_ids)) {

--- a/src/rose/rose_build_add_mask.cpp
+++ b/src/rose/rose_build_add_mask.cpp
@@ -262,6 +262,7 @@ bool findMaskLiterals(const vector<CharReach> &mask, vector<ue2_literal> *lit,
 
         // Candidates have been expanded in reverse order.
         for (auto &cand : candidates) {
+            // cppcheck-suppress useStlAlgorithm
             cand = reverse_literal(cand);
         }
 
@@ -443,7 +444,9 @@ bool maskIsNeeded(const ue2_literal &lit, const NGHolder &g) {
         curr.swap(next);
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : curr) {
+        // cppcheck-suppress useStlAlgorithm
         for (auto u : inv_adjacent_vertices_range(v, g)) {
             if (u == g.start || u == g.startDs) {
                 DEBUG_PRINTF("literal spans graph from start to accept\n");

--- a/src/rose/rose_build_anchored.cpp
+++ b/src/rose/rose_build_anchored.cpp
@@ -158,9 +158,11 @@ void mergeAnchoredDfas(vector<unique_ptr<raw_dfa>> &dfas,
 
     // Rehome our groups into one vector.
     for (auto &rdfa : small_starts) {
+        // cppcheck-suppress useStlAlgorithm
         dfas.emplace_back(std::move(rdfa));
     }
     for (auto &rdfa : big_starts) {
+        // cppcheck-suppress useStlAlgorithm
         dfas.emplace_back(std::move(rdfa));
     }
 
@@ -784,6 +786,7 @@ vector<unique_ptr<raw_dfa>> getAnchoredDfas(RoseBuildImpl &build,
     // DFAs that already exist as raw_dfas.
     for (auto &anch_dfas : build.anchored_nfas) {
         for (auto &rdfa : anch_dfas.second) {
+            // cppcheck-suppress useStlAlgorithm
             dfas.emplace_back(std::move(rdfa));
         }
     }

--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -208,6 +208,7 @@ u32 countRosePrefixes(const vector<LeftNfaInfo> &roses) {
     u32 num = 0;
     for (const auto &r : roses) {
         if (!r.infix) {
+            // cppcheck-suppress useStlAlgorithm
             num++;
         }
     }
@@ -242,6 +243,7 @@ bool needsCatchup(const RoseBuildImpl &build) {
 
     const RoseGraph &g = build.g;
 
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(g)) {
         if (g[v].suffix) {
             /* TODO: check that they have non-eod reports */
@@ -304,6 +306,7 @@ bool isPureFloating(const RoseResources &resources, const CompileContext &cc) {
 
 static
 bool isSingleOutfix(const RoseBuildImpl &tbi) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(tbi.g)) {
         if (tbi.isAnyStart(v)) {
             continue;
@@ -986,6 +989,7 @@ bool checkSuitableForEager(bool is_prefix, const left_id &left,
         return false;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (RoseVertex s : succs) {
         if (build.isInETable(s)
             || contains(rg[s].literals, build.eod_event_literal_id)) {
@@ -1599,6 +1603,7 @@ void findSuffixTriggers(const RoseBuildImpl &tbi,
 
 static
 bool hasNonSmallBlockOutfix(const vector<OutfixInfo> &outfixes) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &out : outfixes) {
         if (!out.in_sbmatcher) {
             return true;
@@ -1948,6 +1953,7 @@ bool buildSuffixes(const RoseBuildImpl &tbi, build_context &bc,
     // order.
     vector<pair<u32, suffix_id>> ordered;
     for (const auto &e : bc.suffixes) {
+        // cppcheck-suppress useStlAlgorithm
         ordered.emplace_back(e.second, e.first);
     }
     sort(begin(ordered), end(ordered));
@@ -2294,6 +2300,7 @@ u32 buildEodNfaIterator(build_context &bc, const u32 activeQueueCount) {
 
 static
 bool hasMpvTrigger(const set<u32> &reports, const ReportManager &rm) {
+    // cppcheck-suppress useStlAlgorithm
     for (u32 r : reports) {
         if (rm.getReport(r).type == INTERNAL_ROSE_CHAIN) {
             return true;
@@ -2324,6 +2331,7 @@ bool anyEndfixMpvTriggers(const RoseBuildImpl &build) {
     }
 
     /* outfixes */
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &out : build.outfixes) {
         if (hasMpvTrigger(all_reports(out), build.rm)) {
             return true;
@@ -2607,6 +2615,7 @@ unordered_map<RoseVertex, u32> assignStateIndices(const RoseBuildImpl &build) {
         // eagerly-reported EOD vertices.
         bool needs_state_index = false;
         for (const auto &e : out_edges_range(v, g)) {
+            // cppcheck-suppress useStlAlgorithm
             if (!canEagerlyReportAtEod(build, e)) {
                 needs_state_index = true;
                 break;
@@ -2797,6 +2806,7 @@ bool isUsedLiteral(const RoseBuildImpl &build, u32 lit_id) {
         return true;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (const u32 &delayed_id : info.delayed_ids) {
         assert(delayed_id < build.literal_info.size());
         const rose_literal_info &delayed_info = build.literal_info[delayed_id];
@@ -3225,6 +3235,7 @@ pair<u32, u32> buildReportPrograms(const RoseBuildImpl &build,
 static
 bool hasEodAnchoredSuffix(const RoseBuildImpl &build) {
     const RoseGraph &g = build.g;
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(g)) {
         if (g[v].suffix && build.isInETable(v)) {
             DEBUG_PRINTF("vertex %zu is in eod table and has a suffix\n",
@@ -3238,6 +3249,7 @@ bool hasEodAnchoredSuffix(const RoseBuildImpl &build) {
 static
 bool hasEodMatcher(const RoseBuildImpl &build) {
     const RoseGraph &g = build.g;
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(g)) {
         if (build.isInETable(v)) {
             DEBUG_PRINTF("vertex %zu is in eod table\n", g[v].index);

--- a/src/rose/rose_build_castle.cpp
+++ b/src/rose/rose_build_castle.cpp
@@ -130,6 +130,7 @@ vector<rose_literal_id> literals_for_vertex(const RoseBuildImpl &tbi,
     vector<rose_literal_id> rv;
 
     for (const u32 id : tbi.g[v].literals) {
+        // cppcheck-suppress useStlAlgorithm
         rv.emplace_back(tbi.literals.at(id));
     }
 

--- a/src/rose/rose_build_compile.cpp
+++ b/src/rose/rose_build_compile.cpp
@@ -96,6 +96,7 @@ bool limited_explosion(const ue2_literal &s) {
 
     for (const auto &e : s) {
         if (e.nocase) {
+            // cppcheck-suppress useStlAlgorithm
             nc_count++;
         }
     }
@@ -268,6 +269,7 @@ bool RoseBuildImpl::isPseudoStarOrFirstOnly(const RoseEdge &e) const {
 }
 
 bool RoseBuildImpl::hasOnlyPseudoStarInEdges(RoseVertex v) const {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : in_edges_range(v, g)) {
         if (!isPseudoStar(e)) {
             return false;
@@ -413,6 +415,7 @@ bool RoseBuildImpl::isDirectReport(u32 id) const {
         }
 
         // Use the program to handle cases that aren't external reports.
+        // cppcheck-suppress useStlAlgorithm
         for (const ReportID &rid : g[v].reports) {
             if (!isExternalReport(rm.getReport(rid))) {
                 return false;
@@ -451,6 +454,7 @@ bool RoseBuildImpl::isDirectReport(u32 id) const {
  * larger than avoiding running an eod table over the last N bytes. */
 static
 bool checkFloatingKillableByPrefixes(const RoseBuildImpl &tbi) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : vertices_range(tbi.g)) {
         if (!tbi.isRootSuccessor(v)) {
             continue;
@@ -699,6 +703,7 @@ bool suitableForAnchored(const RoseBuildImpl &tbi, const rose_literal_id &l_id,
             return false;
         }
 
+        // cppcheck-suppress useStlAlgorithm
         for (auto w : adjacent_vertices_range(v, g)) {
             if (!g[w].eod_accept) {
                 DEBUG_PRINTF("non eod accept literal\n");
@@ -771,6 +776,7 @@ bool RoseBuildImpl::isDelayed(u32 id) const {
 }
 
 bool RoseBuildImpl::hasDelayedLiteral(RoseVertex v) const {
+    // cppcheck-suppress useStlAlgorithm
     for (u32 lit_id : g[v].literals) {
         if (literals.at(lit_id).delay) {
             return true;
@@ -781,6 +787,7 @@ bool RoseBuildImpl::hasDelayedLiteral(RoseVertex v) const {
 }
 
 bool RoseBuildImpl::hasDelayPred(RoseVertex v) const {
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (hasDelayedLiteral(u)) {
             return true;
@@ -791,6 +798,7 @@ bool RoseBuildImpl::hasDelayPred(RoseVertex v) const {
 }
 
 bool RoseBuildImpl::hasAnchoredTablePred(RoseVertex v) const {
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (isAnchored(u)) {
             return true;
@@ -956,6 +964,7 @@ bool reduceTopTriggerLoad(RoseBuildImpl &build, NGHolder &h, RoseVertex u) {
     u32 new_top = ~0U;
     /* check if there is already a top with the right the successor set */
     for (const auto &elem : h_top_info) {
+        // cppcheck-suppress useStlAlgorithm
         if (elem.second == edges_to_trigger) {
             new_top = elem.first;
             break;
@@ -1497,6 +1506,7 @@ bool extractSEPLiterals(const raw_dfa &rdfa,
 
         CharReach cr;
         for (const auto &sym : symbols) {
+            // cppcheck-suppress useStlAlgorithm
             cr |= reach[sym];
         }
 
@@ -1522,6 +1532,7 @@ bool extractSEPLiterals(const OutfixInfo &outfix, const ReportManager &rm,
         return false;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &report_id : all_reports(outfix)) {
         const auto &report = rm.getReport(report_id);
         if (!isSimpleExhaustible(report)) {
@@ -1556,6 +1567,7 @@ void addAnchoredSmallBlockLiterals(RoseBuildImpl &tbi) {
     // literals are direct reports (i.e. leaf nodes in the Rose graph).
     for (const set<u32> &lits : tbi.anchored_simple | map_values) {
         for (u32 lit_id : lits) {
+            // cppcheck-suppress useStlAlgorithm
             if (!tbi.isDirectReport(lit_id)) {
                 DEBUG_PRINTF("not all anchored lits are direct reports\n");
                 return;

--- a/src/rose/rose_build_dedupe.cpp
+++ b/src/rose/rose_build_dedupe.cpp
@@ -307,6 +307,7 @@ bool RoseDedupeAuxImpl::requiresDedupeSupport(
 
     /* literals */
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &m : lits) {
         if (m.second > 1) {
             DEBUG_PRINTF("lit %u used by >1 reporting roles\n", m.first);

--- a/src/rose/rose_build_exclusive.cpp
+++ b/src/rose/rose_build_exclusive.cpp
@@ -54,6 +54,7 @@ CharReach getReachability(const NGHolder &h) {
     CharReach cr;
     for (const auto &v : vertices_range(h)) {
         if (!is_special(v, h)) {
+            // cppcheck-suppress useStlAlgorithm
             cr |= h[v].char_reach;
         }
     }
@@ -140,6 +141,7 @@ bool isSuffix(const vector<vector<CharReach>> &triggers1,
               const vector<vector<CharReach>> &triggers2) {
     // literal suffix test
     for (const auto &lit1 : triggers1) {
+        // cppcheck-suppress useStlAlgorithm
         for (const auto &lit2 : triggers2) {
             const size_t len = min(lit1.size(), lit2.size());
             if (equal(lit1.rbegin(), lit1.rbegin() + len,
@@ -240,6 +242,7 @@ bool isExclusive(const NGHolder &h,
             // Check if only literal states are on
             for (const auto &s : activeStates) {
                 if ((!is_any_start(s, h) && h[s].index <= num) ||
+                    // cppcheck-suppress useStlAlgorithm
                     contains(tailId, h[s].index)) {
                     skipList[id2].insert(id1);
                     return false;

--- a/src/rose/rose_build_groups.cpp
+++ b/src/rose/rose_build_groups.cpp
@@ -84,6 +84,7 @@ bool eligibleForAlwaysOnGroup(const RoseBuildImpl &build, u32 id) {
         return true;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (u32 delayed_id : build.literal_info[id].delayed_ids) {
         if (any_of_in(build.literal_info[delayed_id].vertices, eligble)) {
             return true;
@@ -130,6 +131,7 @@ rose_group calcLocalGroup(const RoseVertex v, const RoseGraph &g,
         for (auto w : adjacent_vertices_range(u, g)) {
             if (!small_literal_count || g[v].left == g[w].left) {
                 for (u32 lit_id : g[w].literals) {
+                    // cppcheck-suppress useStlAlgorithm
                     local_group |= literal_info[lit_id].group_mask;
                 }
             } else {
@@ -409,6 +411,7 @@ rose_group RoseBuildImpl::getSuccGroups(RoseVertex start) const {
     rose_group initialGroups = 0;
 
     for (auto v : adjacent_vertices_range(start, g)) {
+        // cppcheck-suppress useStlAlgorithm
         initialGroups |= getGroups(v);
     }
 
@@ -536,6 +539,7 @@ bool coversGroup(const RoseBuildImpl &build,
     rose_group groups = lit_info.group_mask;
     while (groups) {
         u32 group_id = findAndClearLSB_64(&groups);
+        // cppcheck-suppress useStlAlgorithm
         for (u32 id : build.group_to_literal.at(group_id)) {
             DEBUG_PRINTF(" checking against friend %u\n", id);
             if (!is_subset_of(build.literal_info[id].vertices,
@@ -611,6 +615,7 @@ bool isGroupSquasher(const RoseBuildImpl &build, const u32 id /* literal id */,
         }
 
         // Out-edges must have inf max bound, + no other shenanigans */
+        // cppcheck-suppress useStlAlgorithm
         for (const auto &e : out_edges_range(v, g)) {
             if (g[e].maxBound != ROSE_BOUND_INF) {
                 return false;
@@ -629,6 +634,7 @@ bool isGroupSquasher(const RoseBuildImpl &build, const u32 id /* literal id */,
     }
 
     // Multiple-vertex case
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : lit_info.vertices) {
         assert(!build.isAnyStart(v));
 
@@ -650,6 +656,7 @@ bool isGroupSquasher(const RoseBuildImpl &build, const u32 id /* literal id */,
 
         // Out-edges must have inf max bound and not directly lead to another
         // vertex with this group, e.g. 'foobar.*foobar'.
+        // cppcheck-suppress useStlAlgorithm
         for (const auto &e : out_edges_range(v, g)) {
             if (g[e].maxBound != ROSE_BOUND_INF) {
                 return false;
@@ -660,6 +667,7 @@ bool isGroupSquasher(const RoseBuildImpl &build, const u32 id /* literal id */,
                 return false; /* is an infix rose trigger */
             }
 
+            // cppcheck-suppress useStlAlgorithm
             for (u32 lit_id : g[t].literals) {
                 if (build.literal_info[lit_id].group_mask &
                     lit_info.group_mask) {
@@ -671,6 +679,7 @@ bool isGroupSquasher(const RoseBuildImpl &build, const u32 id /* literal id */,
         // In-edges must all be dot-stars with no overlap at all, as overlap
         // also causes history to be used.
         /* Different tables are already forbidden by previous checks */
+        // cppcheck-suppress useStlAlgorithm
         for (const auto &e : in_edges_range(v, g)) {
             if (!(g[e].minBound == 0 && g[e].maxBound == ROSE_BOUND_INF)) {
                 return false;

--- a/src/rose/rose_build_lookaround.cpp
+++ b/src/rose/rose_build_lookaround.cpp
@@ -347,6 +347,7 @@ private:
 
 static
 bool isFloodProne(const map<s32, CharReach> &look, const CharReach &flood_cr) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &m : look) {
         const CharReach &look_cr = m.second;
         if (!overlaps(look_cr, flood_cr)) {
@@ -365,6 +366,7 @@ bool isFloodProne(const map<s32, CharReach> &look,
         return false;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (const CharReach &flood_cr : flood_reach) {
         if (isFloodProne(look, flood_cr)) {
             return true;
@@ -748,6 +750,7 @@ bool getTransientPrefixReach(const NGHolder &g, ReportID report, u32 lag,
             assert(!is_special(v, g));
 
             for (auto u : inv_adjacent_vertices_range(v, g)) {
+                // cppcheck-suppress useStlAlgorithm
                 if (u == g.start || u == g.startDs) {
                     curr[idx] = g.startDs;
                     break;

--- a/src/rose/rose_build_matchers.cpp
+++ b/src/rose/rose_build_matchers.cpp
@@ -490,6 +490,7 @@ bool isNoRunsVertex(const RoseBuildImpl &build, RoseVertex u) {
         return false;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &oe : out_edges_range(u, g)) {
         RoseVertex v = target(oe, g);
         if (g[oe].maxBound != ROSE_BOUND_INF) {
@@ -532,6 +533,7 @@ bool isNoRunsLiteral(const RoseBuildImpl &build, const u32 id,
     }
 
     // Undelayed vertices.
+    // cppcheck-suppress useStlAlgorithm
     for (RoseVertex v : info.vertices) {
         if (!isNoRunsVertex(build, v)) {
             return false;
@@ -543,6 +545,7 @@ bool isNoRunsLiteral(const RoseBuildImpl &build, const u32 id,
         assert(d < build.literal_info.size());
         const rose_literal_info &delayed_info = build.literal_info.at(d);
         assert(delayed_info.undelayed_id == id);
+        // cppcheck-suppress useStlAlgorithm
         for (RoseVertex v : delayed_info.vertices) {
             if (!isNoRunsVertex(build, v)) {
                 return false;

--- a/src/rose/rose_build_merge.cpp
+++ b/src/rose/rose_build_merge.cpp
@@ -582,6 +582,7 @@ bool compatibleLiteralsForMerge(
     }
 
     // We don't handle delayed cases yet.
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &ue : ulits) {
         const rose_literal_id &ul = *ue.first;
         if (ul.delay) {
@@ -589,6 +590,7 @@ bool compatibleLiteralsForMerge(
         }
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &ve : vlits) {
         const rose_literal_id &vl = *ve.first;
         if (vl.delay) {
@@ -601,10 +603,12 @@ bool compatibleLiteralsForMerge(
        checked its status at offset X and X > Y). If we can not establish that
        the literals used for triggering will satisfy this property, then it is
        not safe to merge the engine. */
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &ue : ulits) {
         const rose_literal_id &ul = *ue.first;
         u32 ulag = ue.second;
 
+        // cppcheck-suppress useStlAlgorithm
         for (const auto &ve : vlits) {
             const rose_literal_id &vl = *ve.first;
             u32 vlag = ve.second;
@@ -743,6 +747,7 @@ bool mergeableRoseVertices(const RoseBuildImpl &tbi, RoseVertex u,
     vector<pair<const rose_literal_id *, u32>> ulits;
     ulits.reserve(tbi.g[u].literals.size());
     for (u32 id : tbi.g[u].literals) {
+        // cppcheck-suppress useStlAlgorithm
         ulits.emplace_back(&tbi.literals.at(id), ulag);
     }
 
@@ -750,6 +755,7 @@ bool mergeableRoseVertices(const RoseBuildImpl &tbi, RoseVertex u,
     vector<pair<const rose_literal_id *, u32>> vlits;
     vlits.reserve(tbi.g[v].literals.size());
     for (u32 id : tbi.g[v].literals) {
+        // cppcheck-suppress useStlAlgorithm
         vlits.emplace_back(&tbi.literals.at(id), vlag);
     }
 
@@ -820,6 +826,7 @@ bool checkPredDelays(const RoseBuildImpl &build, const VertexCont &v1,
     vector<const rose_literal_id *> pred_rose_lits;
     pred_rose_lits.reserve(pred_lits.size());
     for (const auto &p : pred_lits) {
+        // cppcheck-suppress useStlAlgorithm
         pred_rose_lits.emplace_back(&build.literals.at(p));
     }
 
@@ -885,6 +892,7 @@ bool mergeableRoseVertices(const RoseBuildImpl &tbi,
 
         u32 ulag = tbi.g[a].left.lag;
         for (u32 id : tbi.g[a].literals) {
+            // cppcheck-suppress useStlAlgorithm
             ulits.emplace_back(&tbi.literals.at(id), ulag);
         }
     }
@@ -897,6 +905,7 @@ bool mergeableRoseVertices(const RoseBuildImpl &tbi,
 
         u32 vlag = tbi.g[a].left.lag;
         for (u32 id : tbi.g[a].literals) {
+            // cppcheck-suppress useStlAlgorithm
             vlits.emplace_back(&tbi.literals.at(id), vlag);
         }
     }
@@ -1050,6 +1059,7 @@ bool checkVerticesOkForLeftfixMerge(const RoseBuildImpl &build,
     for (auto a : targets_1) {
         u32 ulag = build.g[a].left.lag;
         for (u32 id : build.g[a].literals) {
+            // cppcheck-suppress useStlAlgorithm
             ulits.emplace_back(&build.literals.at(id), ulag);
         }
     }
@@ -1058,6 +1068,7 @@ bool checkVerticesOkForLeftfixMerge(const RoseBuildImpl &build,
     for (auto a : targets_2) {
         u32 vlag = build.g[a].left.lag;
         for (u32 id : build.g[a].literals) {
+            // cppcheck-suppress useStlAlgorithm
             vlits.emplace_back(&build.literals.at(id), vlag);
         }
     }

--- a/src/rose/rose_build_misc.cpp
+++ b/src/rose/rose_build_misc.cpp
@@ -106,6 +106,7 @@ bool RoseVertexProps::fixedOffset(void) const {
 }
 
 bool RoseBuildImpl::isRootSuccessor(const RoseVertex &v) const {
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (isAnyStart(u)) {
             return true;
@@ -115,6 +116,7 @@ bool RoseBuildImpl::isRootSuccessor(const RoseVertex &v) const {
 }
 
 bool RoseBuildImpl::isNonRootSuccessor(const RoseVertex &v) const {
+    // cppcheck-suppress useStlAlgorithm
     for (auto u : inv_adjacent_vertices_range(v, g)) {
         if (!isAnyStart(u)) {
             return true;
@@ -124,6 +126,7 @@ bool RoseBuildImpl::isNonRootSuccessor(const RoseVertex &v) const {
 }
 
 bool hasAnchHistorySucc(const RoseGraph &g, RoseVertex v) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : out_edges_range(v, g)) {
         if (g[e].history == ROSE_ROLE_HISTORY_ANCH) {
             return true;
@@ -134,6 +137,7 @@ bool hasAnchHistorySucc(const RoseGraph &g, RoseVertex v) {
 }
 
 bool hasLastByteHistorySucc(const RoseGraph &g, RoseVertex v) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : out_edges_range(v, g)) {
         if (g[e].history == ROSE_ROLE_HISTORY_LAST_BYTE) {
             return true;
@@ -183,6 +187,7 @@ bool RoseBuildImpl::hasLiteralInTable(RoseVertex v,
 /* Indicates that the floating table (if it exists) will be only run
    conditionally based on matches from the anchored table. */
 bool RoseBuildImpl::hasNoFloatingRoots() const {
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(root, g)) {
         if (isFloating(v)) {
             DEBUG_PRINTF("direct floating root %zu\n", g[v].index);
@@ -191,6 +196,7 @@ bool RoseBuildImpl::hasNoFloatingRoots() const {
     }
 
     /* need to check if the anchored_root has any literals which are too deep */
+    // cppcheck-suppress useStlAlgorithm
     for (auto v : adjacent_vertices_range(anchored_root, g)) {
         if (isFloating(v)) {
             DEBUG_PRINTF("indirect floating root %zu\n", g[v].index);
@@ -208,6 +214,7 @@ size_t RoseBuildImpl::maxLiteralLen(RoseVertex v) const {
     size_t maxlen = 0;
 
     for (const auto &lit_id : lit_ids) {
+        // cppcheck-suppress useStlAlgorithm
         maxlen = max(maxlen, literals.at(lit_id).elength());
     }
 
@@ -221,6 +228,7 @@ size_t RoseBuildImpl::minLiteralLen(RoseVertex v) const {
     size_t minlen = ROSE_BOUND_INF;
 
     for (const auto &lit_id : lit_ids) {
+        // cppcheck-suppress useStlAlgorithm
         minlen = min(minlen, literals.at(lit_id).elength());
     }
 
@@ -880,6 +888,7 @@ u32 findMinOffset(const RoseBuildImpl &build, u32 lit_id) {
 
     u32 min_offset = UINT32_MAX;
     for (const auto &v : lit_vertices) {
+        // cppcheck-suppress useStlAlgorithm
         min_offset = min(min_offset, build.g[v].min_offset);
     }
 
@@ -892,6 +901,7 @@ u32 findMaxOffset(const RoseBuildImpl &build, u32 lit_id) {
 
     u32 max_offset = 0;
     for (const auto &v : lit_vertices) {
+        // cppcheck-suppress useStlAlgorithm
         max_offset = max(max_offset, build.g[v].max_offset);
     }
 

--- a/src/rose/rose_build_program.cpp
+++ b/src/rose/rose_build_program.cpp
@@ -292,6 +292,7 @@ void stripCheckHandledInstruction(RoseProgram &prog) {
 /** Returns true if the program may read the interpreter's work_done flag */
 static
 bool reads_work_done_flag(const RoseProgram &prog) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &ri : prog) {
         if (dynamic_cast<const RoseInstrSquashGroups *>(ri.get())) {
             return true;
@@ -914,6 +915,7 @@ void makeRoleGroups(const RoseGraph &g, ProgramBuild &prog_build,
     assert(in_degree(v, g) > 0);
     rose_group already_on = ~rose_group{0};
     for (const auto &u : inv_adjacent_vertices_range(v, g)) {
+        // cppcheck-suppress useStlAlgorithm
         already_on &= prog_build.vertex_group_map.at(u);
     }
 
@@ -2020,6 +2022,7 @@ bool onlyAtEod(const RoseBuildImpl &tbi, RoseVertex v) {
         return false;
     }
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e : out_edges_range(v, g)) {
         RoseVertex w = target(e, g);
         if (!g[w].eod_accept) {

--- a/src/rose/rose_build_role_aliasing.cpp
+++ b/src/rose/rose_build_role_aliasing.cpp
@@ -258,6 +258,7 @@ bool samePredecessors(RoseVertex a, RoseVertex b, const RoseGraph &g) {
             return false;
         }
 
+        // cppcheck-suppress useStlAlgorithm
         for (const auto &e_a : in_edges_range(a, g)) {
             RoseEdge e = edge(source(e_a, g), b, g);
             if (!e || g[e].rose_top != g[e_a].rose_top) {
@@ -273,6 +274,7 @@ bool samePredecessors(RoseVertex a, RoseVertex b, const RoseGraph &g) {
 static
 bool hasCommonSuccWithBadBounds(RoseVertex a, RoseVertex b,
                                 const RoseGraph &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e_a : out_edges_range(a, g)) {
         if (RoseEdge e = edge(b, target(e_a, g), g)) {
             if (g[e_a].maxBound < g[e].minBound
@@ -292,6 +294,7 @@ bool hasCommonSuccWithBadBounds(RoseVertex a, RoseVertex b,
 static
 bool hasCommonPredWithBadBounds(RoseVertex a, RoseVertex b,
                                 const RoseGraph &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e_a : in_edges_range(a, g)) {
         if (RoseEdge e = edge(source(e_a, g), b, g)) {
             if (g[e_a].maxBound < g[e].minBound
@@ -328,8 +331,10 @@ bool canMergeLiterals(RoseVertex a, RoseVertex b, const RoseBuildImpl &build) {
     }
 
     // Otherwise, all the literals involved must have the same length.
+    // cppcheck-suppress useStlAlgorithm
     for (u32 a_id : lits_a) {
         const rose_literal_id &la = build.literals.at(a_id);
+        // cppcheck-suppress useStlAlgorithm
         for (u32 b_id : lits_b) {
             const rose_literal_id &lb = build.literals.at(b_id);
 
@@ -699,6 +704,7 @@ bool hasCommonPredWithDiffRoses(RoseVertex a, RoseVertex b,
 
     const bool equal_roses = hasEqualLeftfixes(a, b, g);
 
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &e_a : in_edges_range(a, g)) {
         if (RoseEdge e = edge(source(e_a, g), b, g)) {
             DEBUG_PRINTF("common pred, e_r=%d r_t %u,%u\n",
@@ -723,6 +729,7 @@ void pruneReportIfUnused(const RoseBuildImpl &build, shared_ptr<NGHolder> h,
     DEBUG_PRINTF("trying to prune %u from %p (v %zu)\n", report, h.get(),
                  verts.size());
     for (RoseVertex v : verts) {
+        // cppcheck-suppress useStlAlgorithm
         if (build.g[v].left.graph == h &&
             build.g[v].left.leftfix_report == report) {
             DEBUG_PRINTF("report %u still in use\n", report);
@@ -1942,6 +1949,7 @@ bool hasNoDiamondSiblings(const RoseGraph &g, RoseVertex v) {
     if (has_successor(v, g)) {
         bool only_succ = true;
         for (const auto &w : adjacent_vertices_range(v, g)) {
+            // cppcheck-suppress useStlAlgorithm
             if (in_degree(w, g) > 1) {
                 only_succ = false;
                 break;
@@ -1958,6 +1966,7 @@ bool hasNoDiamondSiblings(const RoseGraph &g, RoseVertex v) {
 
     bool only_pred = true;
     for (const auto &u : inv_adjacent_vertices_range(v, g)) {
+        // cppcheck-suppress useStlAlgorithm
         if (out_degree(u, g) > 1) {
             only_pred = false;
             break;

--- a/src/rose/rose_build_width.cpp
+++ b/src/rose/rose_build_width.cpp
@@ -44,6 +44,7 @@ namespace ue2 {
 
 static
 bool is_end_anchored(const RoseGraph &g, RoseVertex v) {
+    // cppcheck-suppress useStlAlgorithm
     for (auto w : adjacent_vertices_range(v, g)) {
         if (g[w].eod_accept) {
             return true;

--- a/src/smallwrite/smallwrite_build.cpp
+++ b/src/smallwrite/smallwrite_build.cpp
@@ -241,6 +241,7 @@ bool mergeDfas(vector<unique_ptr<raw_dfa>> &dfas, const ReportManager &rm,
     vector<const raw_dfa *> dfa_ptrs;
     dfa_ptrs.reserve(dfas.size());
     for (auto &d : dfas) {
+        // cppcheck-suppress useStlAlgorithm
         dfa_ptrs.emplace_back(d.get());
     }
 
@@ -331,6 +332,7 @@ bool add_to_trie(const ue2_literal &literal, ReportID report, LitTrie &trie) {
     for (const auto &c : literal) {
         auto next = LitTrie::null_vertex();
         for (auto v : adjacent_vertices_range(u, trie)) {
+            // cppcheck-suppress useStlAlgorithm
             if (trie[v].c == (u8)c.c) {
                 next = v;
                 break;
@@ -409,6 +411,7 @@ struct ACVisitor : public boost::default_bfs_visitor {
         while (u != trie.root) {
             auto f = failure_map.at(u);
             for (auto w : adjacent_vertices_range(f, trie)) {
+                // cppcheck-suppress useStlAlgorithm
                 if (trie[w].c == c) {
                     return w;
                 }

--- a/src/util/bitfield.h
+++ b/src/util/bitfield.h
@@ -200,6 +200,8 @@ public:
 
     /// Are no bits set?
     bool none() const {
+        // cppcheck-suppress useStlAlgorithm
+        // XXX maybe do this one.. 
         for (const auto &e : bits) {
             if (e != 0) {
                 return false;

--- a/src/util/ue2_graph.h
+++ b/src/util/ue2_graph.h
@@ -616,12 +616,14 @@ public:
                                                vertex_descriptor v) const {
         if (in_degree_impl(v) < out_degree_impl(u)) {
             for (const edge_descriptor &e : in_edges_range(v, *this)) {
+                // cppcheck-suppress useStlAlgorithm
                 if (source_impl(e) == u) {
                     return {e, true};
                 }
             }
         } else {
             for (const edge_descriptor &e : out_edges_range(u, *this)) {
+                // cppcheck-suppress useStlAlgorithm
                 if (target_impl(e) == v) {
                     return {e, true};
                 }

--- a/src/util/ue2string.cpp
+++ b/src/util/ue2string.cpp
@@ -134,6 +134,7 @@ string dumpString(const ue2_literal &lit) {
 
 void upperString(string &s) {
     for (auto &c : s) {
+        // cppcheck-suppress useStlAlgorithm
         c = mytoupper(c);
     }
 }
@@ -341,6 +342,7 @@ void make_nocase(ue2_literal *lit) {
     ue2_literal rv;
 
     for (const auto &elem: *lit) {
+        // cppcheck-suppress useStlAlgorithm
         rv.push_back(elem.c, ourisalpha(elem.c));
     }
 

--- a/tools/hsbench/main.cpp
+++ b/tools/hsbench/main.cpp
@@ -727,6 +727,7 @@ double fastestResult(const vector<unique_ptr<ThreadContext>> &threads) {
     double best = threads[0]->results[0].seconds;
     for (const auto &t : threads) {
         for (const auto &r : t->results) {
+            // cppcheck-suppress useStlAlgorithm
             best = min(best, r.seconds);
         }
     }
@@ -737,6 +738,7 @@ static
 u64a byte_size(const vector<DataBlock> &corpus_blocks) {
     u64a total = 0;
     for (const DataBlock &block : corpus_blocks) {
+        // cppcheck-suppress useStlAlgorithm
         total += block.payload.size();
     }
 
@@ -757,6 +759,7 @@ void displayResults(const vector<unique_ptr<ThreadContext>> &threads,
 
     // Sanity check: all of our results should have the same match count.
     for (const auto &t : threads) {
+        // cppcheck-suppress useStlAlgorithm
         if (!all_of(begin(t->results), end(t->results),
                     [&matchesPerRun](const ResultEntry &e) {
                         return e.matches == matchesPerRun;
@@ -813,6 +816,7 @@ void displayCsvResults(const vector<unique_ptr<ThreadContext>> &threads,
 
     // Sanity check: all of our results should have the same match count.
     for (const auto &t : threads) {
+        // cppcheck-suppress useStlAlgorithm
         if (!all_of(begin(t->results), end(t->results),
                     [&matchesPerRun](const ResultEntry &e) {
                         return e.matches == matchesPerRun;
@@ -867,6 +871,7 @@ void sqlResults(const vector<unique_ptr<ThreadContext>> &threads,
 
     // Sanity check: all of our results should have the same match count.
     for (const auto &t : threads) {
+        // cppcheck-suppress useStlAlgorithm
         if (!all_of(begin(t->results), end(t->results),
                     [&matchesPerRun](const ResultEntry &e) {
                         return e.matches == matchesPerRun;

--- a/unit/internal/graph_undirected.cpp
+++ b/unit/internal/graph_undirected.cpp
@@ -57,6 +57,7 @@ template<typename Graph, typename Range>
 vector<size_t> to_indices(const Range &range, const Graph &g) {
     vector<size_t> indices;
     for (const auto &elem : range) {
+        // cppcheck-suppress useStlAlgorithm
         indices.push_back(g[elem].index);
     }
     sort(indices.begin(), indices.end());
@@ -68,6 +69,7 @@ vector<size_t> to_indices(const std::initializer_list<T> &range,
                           const Graph &g) {
     vector<size_t> indices;
     for (const auto &elem : range) {
+        // cppcheck-suppress useStlAlgorithm
         indices.push_back(g[elem].index);
     }
     sort(indices.begin(), indices.end());

--- a/util/cross_compile.cpp
+++ b/util/cross_compile.cpp
@@ -61,6 +61,7 @@ unique_ptr<hs_platform_info> xcompileReadMode(const char *s) {
 
     if (!opt.empty()) {
         for (const auto &xcompile : xcompile_options) {
+            // cppcheck-suppress useStlAlgorithm
             if (opt == xcompile.name) {
                 rv.cpu_features = xcompile.cpu_features;
                 found_mode = true;

--- a/util/ng_corpus_generator.cpp
+++ b/util/ng_corpus_generator.cpp
@@ -80,11 +80,13 @@ string pathToString(const NGHolder &g, const VertexPath &p) {
 /** True if this graph has no non-special successors of start or startDs. */
 static
 bool graph_is_empty(const NGHolder &g) {
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &v : adjacent_vertices_range(g.start, g)) {
         if (!is_special(v, g)) {
             return false;
         }
     }
+    // cppcheck-suppress useStlAlgorithm
     for (const auto &v : adjacent_vertices_range(g.start, g)) {
         if (!is_special(v, g)) {
             return false;
@@ -468,6 +470,7 @@ void CorpusGeneratorUtf8::generateCorpus(vector<string> &data) {
     }
 
     for (const auto &e : raw) {
+        // cppcheck-suppress useStlAlgorithm
         data.push_back(encodeUtf8(e));
     }
 }
@@ -545,6 +548,7 @@ CorpusGeneratorUtf8::pathToCorpus(const vector<CodePointSet> &path) {
 
     // Generate a corpus from our path
     for (const auto &e : path) {
+        // cppcheck-suppress useStlAlgorithm
         s.push_back(getChar(e));
     }
 


### PR DESCRIPTION
this is part 2 of the useStlAlgorithm cppcheck warnings. 
Most of these are simply comments to ignore the warning, as in almost all
cases replacing a simple operation with a function call will kill performance and make
clear to understand code more muddled. 
we did use it in most of the instances of copy, fill, and accumulate. 
Closes some: #252