### PR TITLE
Fix remaining C style casts and suppressions

### DIFF
--- a/examples/pcapscan.cc
+++ b/examples/pcapscan.cc
@@ -106,7 +106,8 @@ struct FiveTuple {
         dstAddr = iphdr->ip_dst.s_addr;
 
         // UDP/TCP ports
-        const struct udphdr *uh = reinterpret_cast<const struct udphdr *>(iphdr) + (iphdr->ip_hl * 4);
+	const char * iphdr_base = reinterpret_cast<const char *>(iphdr);
+        const struct udphdr *uh = reinterpret_cast<const struct udphdr *>(iphdr_base + (iphdr->ip_hl * 4));
         srcPort = uh->uh_sport;
         dstPort = uh->uh_dport;
     }
@@ -231,7 +232,7 @@ public:
             }
 
             // Valid TCP or UDP packet
-            const struct ip *iphdr = reinterpret_cast<const struct ip *>(pktData) + sizeof(struct ether_header);
+            const struct ip *iphdr = reinterpret_cast<const struct ip *>(pktData + sizeof(struct ether_header));
             const char *payload = reinterpret_cast<const char *>(pktData) + offset;
 
             size_t id = stream_map.insert(std::make_pair(FiveTuple(iphdr),
@@ -572,7 +573,8 @@ int main(int argc, char **argv) {
  */
 static bool payloadOffset(const unsigned char *pkt_data, unsigned int *offset,
                           unsigned int *length) {
-    const ip *iph = reinterpret_cast<const ip *>(pkt_data) + sizeof(ether_header);
+    const ip *iph = reinterpret_cast<const ip *>(pkt_data + sizeof(ether_header));
+    const char *iph_base = reinterpret_cast<const char *>(iph);
     const tcphdr *th = nullptr;
 
     // Ignore packets that aren't IPv4
@@ -591,7 +593,7 @@ static bool payloadOffset(const unsigned char *pkt_data, unsigned int *offset,
 
     switch (iph->ip_p) {
     case IPPROTO_TCP:
-        th = reinterpret_cast<const tcphdr *>(iph) + ihlen;
+        th = reinterpret_cast<const tcphdr *>(iph_base + ihlen);
         thlen = th->th_off * 4;
         break;
     case IPPROTO_UDP:

--- a/src/nfa/castlecompile.cpp
+++ b/src/nfa/castlecompile.cpp
@@ -632,11 +632,12 @@ buildCastle(const CastleProto &proto,
 
         if (patchSize[i]) {
             RepeatInfo *info = reinterpret_cast<RepeatInfo *>(ptr);
-            u64a *table = reinterpret_cast<u64a *>(ROUNDUP_PTR(info +
+	    char *info_base = reinterpret_cast<char *>(info);
+            u64a *table = reinterpret_cast<u64a *>(ROUNDUP_PTR(info_base +
                                     sizeof(*info), alignof(u64a)));
             copy(tables.begin() + tableIdx,
                  tables.begin() + tableIdx + patchSize[i], table);
-            u32 diff = reinterpret_cast<ptrdiff_t>(table) - reinterpret_cast<ptrdiff_t>(info) +
+            u32 diff = reinterpret_cast<char *>(table) - info_base +
                        sizeof(u64a) * patchSize[i];
             info->length = diff;
             length += diff;

--- a/src/nfa/goughcompile.cpp
+++ b/src/nfa/goughcompile.cpp
@@ -1077,7 +1077,6 @@ bytecode_ptr<NFA> goughCompile(raw_som_dfa &raw, u8 somPrecision,
         return bytecode_ptr<NFA>(nullptr);
     }
 
-    // cppcheck-suppress cstyleCast
     const auto nfa = static_cast<const mcclellan *>(getImplNfa(basic_dfa.get()));
     u8 alphaShift = nfa->alphaShift;
     u32 edge_count = (1U << alphaShift) * raw.states.size();
@@ -1134,7 +1133,6 @@ bytecode_ptr<NFA> goughCompile(raw_som_dfa &raw, u8 somPrecision,
     gough_dfa->streamStateSize = base_state_size + slot_count * somPrecision;
     gough_dfa->scratchStateSize = (u32)(16 + scratch_slot_count * sizeof(u64a));
 
-    // cppcheck-suppress cstyleCast
     auto *m = reinterpret_cast<mcclellan *>(getMutableImplNfa(gough_dfa.get()));
     m->haig_offset = haig_offset;
 

--- a/src/nfa/limex_compile.cpp
+++ b/src/nfa/limex_compile.cpp
@@ -269,7 +269,7 @@ void maskClear(Mask &m) {
 template<class Mask>
 u8 *maskGetByte(Mask &m, u32 bit) {
     assert(bit < sizeof(m)*8);
-    u8 *m8 = (u8 *)&m;
+    u8 *m8 = reinterpret_cast<u8 *>(&m);
 
     return m8 + bit/8;
 }
@@ -290,7 +290,7 @@ void maskSetBits(Mask &m, const NFAStateSet &bits) {
 
 template<class Mask>
 bool isMaskZero(Mask &m) {
-    const u8 *m8 = (u8 *)&m;
+    const u8 *m8 = reinterpret_cast<u8 *>(&m);
     for (u32 i = 0; i < sizeof(m); i++) {
         if (m8[i]) {
             return false;
@@ -303,7 +303,7 @@ bool isMaskZero(Mask &m) {
 template<class Mask>
 void maskSetByte(Mask &m, const unsigned int idx, const char val) {
     assert(idx < sizeof(m));
-    char *m8 = (char *)&m;
+    char *m8 = reinterpret_cast<char *>(&m);
     char &byte = m8[idx];
     byte = val;
 }
@@ -1702,7 +1702,7 @@ struct Factory {
     static
     void allocState(NFA *nfa, u32 repeatscratchStateSize,
                     u32 repeatStreamState) {
-        const implNFA_t *limex = (implNFA_t *)getMutableImplNfa(nfa);
+        const implNFA_t *limex = reinterpret_cast<implNFA_t *>(getMutableImplNfa(nfa));
 
         // LimEx NFAs now store the following in state:
         // 1. state bitvector (always present)
@@ -1768,7 +1768,7 @@ struct Factory {
             u32 tableOffset, tugMaskOffset;
             size_t len = repeatAllocSize(br, &tableOffset, &tugMaskOffset);
             auto info = make_zeroed_bytecode_ptr<NFARepeatInfo>(len);
-            char *info_ptr = (char *)info.get();
+            char *info_ptr = reinterpret_cast<char *>(info.get());
 
             // Collect state space info.
             RepeatStateInfo rsi(br.type, br.repeatMin, br.repeatMax, br.minPeriod);
@@ -1783,8 +1783,7 @@ struct Factory {
             info->tugMaskOffset = tugMaskOffset;
 
             // Fill the RepeatInfo structure.
-            RepeatInfo *repeat =
-                (RepeatInfo *)(info_ptr + sizeof(NFARepeatInfo));
+            RepeatInfo *repeat = reinterpret_cast<RepeatInfo *>(info_ptr + sizeof(NFARepeatInfo));
             repeat->type = br.type;
             repeat->repeatMin = depth_to_u32(br.repeatMin);
             repeat->repeatMax = depth_to_u32(br.repeatMax);
@@ -1810,7 +1809,7 @@ struct Factory {
             }
 
             // Fill the tug mask.
-            tableRow_t *tugMask = (tableRow_t *)(info_ptr + tugMaskOffset);
+            tableRow_t *tugMask = reinterpret_cast<tableRow_t *>(info_ptr + tugMaskOffset);
             for (auto v : br.tug_triggers) {
                 u32 state_id = args.state_ids.at(v);
                 assert(state_id != NO_STATE);
@@ -1931,7 +1930,7 @@ struct Factory {
                          const u32 reportListOffset) {
         DEBUG_PRINTF("exceptionsOffset=%u\n", exceptionsOffset);
 
-        exception_t *etable = (exception_t *)((char *)limex + exceptionsOffset);
+        exception_t *etable = reinterpret_cast<exception_t *>(reinterpret_cast<char *>(limex) + exceptionsOffset);
         assert(ISALIGNED(etable));
 
         map<u32, ExceptionProto> exception_by_state;
@@ -1979,10 +1978,10 @@ struct Factory {
         limex->exceptionCount = ecount;
 
         if (args.num_states > 64 && args.cc.target_info.has_avx512vbmi()) {
-            const u8 *exceptionMask = (const u8 *)(&limex->exceptionMask);
-            u8 *shufMask = (u8 *)&limex->exceptionShufMask;
-            u8 *bitMask = (u8 *)&limex->exceptionBitMask;
-            u8 *andMask = (u8 *)&limex->exceptionAndMask;
+            const u8 *exceptionMask = reinterpret_cast<const u8 *>(&limex->exceptionMask);
+            u8 *shufMask = reinterpret_cast<u8 *>(&limex->exceptionShufMask);
+            u8 *bitMask = reinterpret_cast<u8 *>(&limex->exceptionBitMask);
+            u8 *andMask = reinterpret_cast<u8 *>(&limex->exceptionAndMask);
 
             u32 tot_cnt = 0;
             u32 pos = 0;
@@ -2042,7 +2041,7 @@ struct Factory {
         copy(reachMap.begin(), reachMap.end(), &limex->reachMap[0]);
 
         // Reach table is right after the LimEx structure.
-        tableRow_t *reachMask = (tableRow_t *)((char *)limex + reachOffset);
+        tableRow_t *reachMask = reinterpret_cast<tableRow_t *>(reinterpret_cast<char *>(limex) + reachOffset);
         assert(ISALIGNED(reachMask));
         for (size_t i = 0, end = reach.size(); i < end; i++) {
             maskSetBits(reachMask[i], reach[i]);
@@ -2056,7 +2055,7 @@ struct Factory {
         DEBUG_PRINTF("topsOffset=%u\n", topsOffset);
 
         limex->topOffset = topsOffset;
-        tableRow_t *topMasks = (tableRow_t *)((char *)limex + topsOffset);
+        tableRow_t *topMasks = reinterpret_cast<tableRow_t *>(reinterpret_cast<char *>(limex) + topsOffset);
         assert(ISALIGNED(topMasks));
 
         for (size_t i = 0, end = tops.size(); i < end; i++) {
@@ -2068,8 +2067,8 @@ struct Factory {
 
     static
     void writeAccelSsse3Masks(const NFAStateSet &accelMask, implNFA_t *limex) {
-        char *perm_base = (char *)&limex->accelPermute;
-        char *comp_base = (char *)&limex->accelCompare;
+        char *perm_base = reinterpret_cast<char *>(&limex->accelPermute);
+        char *comp_base = reinterpret_cast<char *>(&limex->accelCompare);
 
         u32 num = 0; // index in accel table.
         for (size_t i = accelMask.find_first(); i != accelMask.npos;
@@ -2080,8 +2079,8 @@ struct Factory {
             // PSHUFB permute and compare masks
             size_t mask_idx = sizeof(u_128) * (state_id / 128U);
             DEBUG_PRINTF("mask_idx=%zu\n", mask_idx);
-            u_128 *perm = (u_128 *)(perm_base + mask_idx);
-            u_128 *comp = (u_128 *)(comp_base + mask_idx);
+            u_128 *perm = reinterpret_cast<u_128 *>(perm_base + mask_idx);
+            u_128 *comp = reinterpret_cast<u_128 *>(comp_base + mask_idx);
             maskSetByte(*perm, num, ((state_id % 128U) / 8U));
             maskSetByte(*comp, num, ~(1U << (state_id % 8U)));
         }
@@ -2099,11 +2098,11 @@ struct Factory {
         // Write accel lookup table.
         limex->accelTableOffset = accelTableOffset;
         copy(accelTable.begin(), accelTable.end(),
-             (u8 *)((char *)limex + accelTableOffset));
+             reinterpret_cast<u8 *>(reinterpret_cast<char *>(limex) + accelTableOffset));
 
         // Write accel aux structures.
         limex->accelAuxOffset = accelAuxOffset;
-        AccelAux *auxTable = (AccelAux *)((char *)limex + accelAuxOffset);
+        AccelAux *auxTable = reinterpret_cast<AccelAux *>(reinterpret_cast<char *>(limex) + accelAuxOffset);
         assert(ISALIGNED(auxTable));
         copy(accelAux.begin(), accelAux.end(), auxTable);
 

--- a/src/nfa/mcclellan_internal.h
+++ b/src/nfa/mcclellan_internal.h
@@ -106,9 +106,10 @@ static really_inline
 const char *findShermanState(UNUSED const struct mcclellan *m,
                              const char *sherman_base_offset, u32 sherman_base,
                              u32 s) {
-    const char *rv
-        = sherman_base_offset + SHERMAN_FIXED_SIZE * (s - sherman_base);
+    const char *rv = sherman_base_offset + SHERMAN_FIXED_SIZE * (s - sherman_base);
+    // cppcheck-suppress cstyleCast
     assert(rv < (const char *)m + m->length - sizeof(struct NFA));
+    // cppcheck-suppress cstyleCast
     UNUSED u8 type = *(const u8 *)(rv + SHERMAN_TYPE_OFFSET);
     assert(type == SHERMAN_STATE);
     return rv;
@@ -123,13 +124,15 @@ char *findMutableShermanState(char *sherman_base_offset, u16 sherman_base,
 static really_inline
 const char *findWideEntry8(UNUSED const struct mcclellan *m,
                            const char *wide_base, u32 wide_limit, u32 s) {
+    // cppcheck-suppress cstyleCast
     UNUSED u8 type = *(const u8 *)wide_base;
     assert(type == WIDE_STATE);
-    const u32 entry_offset
-        = *(const u32 *)(wide_base
+    // cppcheck-suppress cstyleCast
+    const u32 entry_offset = *(const u32 *)(wide_base
         + WIDE_ENTRY_OFFSET8((s - wide_limit) * sizeof(u32)));
 
     const char *rv = wide_base + entry_offset;
+    // cppcheck-suppress cstyleCast
     assert(rv < (const char *)m + m->length - sizeof(struct NFA));
     return rv;
 }
@@ -137,21 +140,23 @@ const char *findWideEntry8(UNUSED const struct mcclellan *m,
 static really_inline
 const char *findWideEntry16(UNUSED const struct mcclellan *m,
                             const char *wide_base, u32 wide_limit, u32 s) {
+    // cppcheck-suppress cstyleCast
     UNUSED u8 type = *(const u8 *)wide_base;
     assert(type == WIDE_STATE);
-    const u32 entry_offset
-        = *(const u32 *)(wide_base
+    // cppcheck-suppress cstyleCast
+    const u32 entry_offset = *(const u32 *)(wide_base
         + WIDE_ENTRY_OFFSET16((s - wide_limit) * sizeof(u32)));
 
     const char *rv = wide_base + entry_offset;
+    // cppcheck-suppress cstyleCast
     assert(rv < (const char *)m + m->length - sizeof(struct NFA));
     return rv;
 }
 
 static really_inline
 char *findMutableWideEntry16(char *wide_base, u32 wide_limit, u32 s) {
-    u32 entry_offset
-        = *(const u32 *)(wide_base
+    // cppcheck-suppress cstyleCast
+    u32 entry_offset = *(const u32 *)(wide_base
         + WIDE_ENTRY_OFFSET16((s - wide_limit) * sizeof(u32)));
 
     return wide_base + entry_offset;

--- a/src/nfa/mpvcompile.cpp
+++ b/src/nfa/mpvcompile.cpp
@@ -180,7 +180,7 @@ void writeKiloPuff(const map<ClusterKey, vector<raw_puff>>::const_iterator &it,
 #ifdef HAVE_SVE2
     } else if (reach.count() >= 240) {
         kp->type = MPV_VERM16;
-        vermicelli16Build(~reach, reinterpret_casT<u8 *>(&kp->u.verm16.mask));
+        vermicelli16Build(~reach, reinterpret_cast<u8 *>(&kp->u.verm16.mask));
     } else if (reach.count() <= 16) {
         kp->type = MPV_NVERM16;
         vermicelli16Build(reach, reinterpret_cast<u8 *>(&kp->u.verm16.mask));

--- a/src/nfa/mpvcompile.cpp
+++ b/src/nfa/mpvcompile.cpp
@@ -180,25 +180,27 @@ void writeKiloPuff(const map<ClusterKey, vector<raw_puff>>::const_iterator &it,
 #ifdef HAVE_SVE2
     } else if (reach.count() >= 240) {
         kp->type = MPV_VERM16;
-        vermicelli16Build(~reach, (u8 *)&kp->u.verm16.mask);
+        vermicelli16Build(~reach, reinterpret_casT<u8 *>(&kp->u.verm16.mask));
     } else if (reach.count() <= 16) {
         kp->type = MPV_NVERM16;
-        vermicelli16Build(reach, (u8 *)&kp->u.verm16.mask);
+        vermicelli16Build(reach, reinterpret_cast<u8 *>(&kp->u.verm16.mask));
 #endif // HAVE_SVE2
-    } else if (shuftiBuildMasks(~reach, (u8 *)&kp->u.shuf.mask_lo,
-                                (u8 *)&kp->u.shuf.mask_hi) != -1) {
+    } else if (shuftiBuildMasks(~reach,
+                                reinterpret_cast<u8 *>(&kp->u.shuf.mask_lo),
+                                reinterpret_cast<u8 *>(&kp->u.shuf.mask_hi)) != -1) {
         kp->type = MPV_SHUFTI;
     } else {
         kp->type = MPV_TRUFFLE;
-        truffleBuildMasks(~reach, (u8 *)&kp->u.truffle.mask1,
-                          (u8 *)&kp->u.truffle.mask2);
+        truffleBuildMasks(~reach,
+                          reinterpret_cast<u8 *>(&kp->u.truffle.mask1),
+                          reinterpret_cast<u8 *>(&kp->u.truffle.mask2));
     }
 
     kp->count = verify_u32(puffs.size());
     kp->counter_offset = counter_offset;
 
     /* start of real puffette array */
-    kp->puffette_offset = verify_u32((char *)*pa - (char *)m);
+    kp->puffette_offset = verify_u32(reinterpret_cast<char *>(*pa) - reinterpret_cast<char *>(m));
     for (size_t i = 0; i < puffs.size(); i++) {
         assert(!it->first.auto_restart || puffs[i].unbounded);
         writePuffette(*pa + i, puffs[i], rm);
@@ -355,8 +357,8 @@ bytecode_ptr<NFA> mpvCompile(const vector<raw_puff> &puffs_in,
 
     auto nfa = make_zeroed_bytecode_ptr<NFA>(len);
 
-    mpv_puffette *pa_base = (mpv_puffette *)
-        ((char *)nfa.get() + sizeof(NFA) + sizeof(mpv)
+    char *nfa_base = reinterpret_cast<char *>(nfa.get());
+    mpv_puffette *pa_base = reinterpret_cast<mpv_puffette *>(nfa_base + sizeof(NFA) + sizeof(mpv)
          + sizeof(mpv_kilopuff) * puff_clusters.size()
          + sizeof(mpv_counter_info) * counters.size());
     mpv_puffette *pa = pa_base;
@@ -373,7 +375,7 @@ bytecode_ptr<NFA> mpvCompile(const vector<raw_puff> &puffs_in,
         min_repeat = min(min_repeat, puffs.front().repeats);
     }
 
-    mpv *m = (mpv *)getMutableImplNfa(nfa.get());
+    mpv *m = reinterpret_cast<mpv *>(getMutableImplNfa(nfa.get()));
     m->kilo_count = verify_u32(puff_clusters.size());
     m->counter_count = verify_u32(counters.size());
     m->puffette_count = puffette_count;
@@ -384,7 +386,7 @@ bytecode_ptr<NFA> mpvCompile(const vector<raw_puff> &puffs_in,
     m->top_kilo_begin = verify_u32(triggered_puffs.size());
     m->top_kilo_end = verify_u32(puff_clusters.size());
 
-    mpv_kilopuff *kp_begin = (mpv_kilopuff *)(m + 1);
+    mpv_kilopuff *kp_begin = reinterpret_cast<mpv_kilopuff *>(m + 1);
     mpv_kilopuff *kp = kp_begin;
     for (auto it = puff_clusters.begin(); it != puff_clusters.end(); ++it) {
         writeKiloPuff(it, rm,
@@ -392,14 +394,14 @@ bytecode_ptr<NFA> mpvCompile(const vector<raw_puff> &puffs_in,
                       kp, &pa);
         ++kp;
     }
-    assert((char *)pa == (char *)nfa.get() + len);
+    assert(reinterpret_cast<char *>(pa) == nfa_base + len);
 
-    mpv_counter_info *out_ci = (mpv_counter_info *)kp;
+    mpv_counter_info *out_ci = reinterpret_cast<mpv_counter_info *>(kp);
     for (const auto &counter : counters) {
         *out_ci = counter;
         ++out_ci;
     }
-    assert((char *)out_ci == (char *)pa_base);
+    assert(reinterpret_cast<char *>(out_ci) == reinterpret_cast<char *>(pa_base));
 
     writeCoreNfa(nfa.get(), len, min_repeat, max_counter, curr_comp_offset,
                  curr_decomp_offset);

--- a/src/nfa/nfa_build_util.cpp
+++ b/src/nfa/nfa_build_util.cpp
@@ -86,14 +86,14 @@ typedef bool (*nfa_dispatch_fn)(const NFA *nfa);
 template<typename T>
 static
 bool has_accel_limex(const NFA *nfa) {
-    const T *limex = (const T *)getImplNfa(nfa);
+    const T *limex = reinterpret_cast<const T *>(getImplNfa(nfa));
     return limex->accelCount;
 }
 
 template<typename T>
 static
 bool has_repeats_limex(const NFA *nfa) {
-    const T *limex = (const T *)getImplNfa(nfa);
+    const T *limex = reinterpret_cast<const T *>(getImplNfa(nfa));
     return limex->repeatCount;
 }
 
@@ -101,16 +101,16 @@ bool has_repeats_limex(const NFA *nfa) {
 template<typename T>
 static
 bool has_repeats_other_than_firsts_limex(const NFA *nfa) {
-    const T *limex = (const T *)getImplNfa(nfa);
-    const char *ptr = (const char *)limex;
+    const T *limex = reinterpret_cast<const T *>(getImplNfa(nfa));
+    const char *ptr = reinterpret_cast<const char *>(limex);
 
-    const u32 *repeatOffset = (const u32 *)(ptr + limex->repeatOffset);
+    const u32 *repeatOffset = reinterpret_cast<const u32 *>(ptr + limex->repeatOffset);
 
     for (u32 i = 0; i < limex->repeatCount; i++) {
         u32 offset = repeatOffset[i];
-        const NFARepeatInfo *info = (const NFARepeatInfo *)(ptr + offset);
+        const NFARepeatInfo *info = reinterpret_cast<const NFARepeatInfo *>(ptr + offset);
         const RepeatInfo *repeat =
-            (const RepeatInfo *)((const char *)info + sizeof(*info));
+            reinterpret_cast<const RepeatInfo *>(reinterpret_cast<const char *>(info) + sizeof(*info));
         if (repeat->type != REPEAT_FIRST) {
             return true;
         }

--- a/src/nfa/tamaramacompile.cpp
+++ b/src/nfa/tamaramacompile.cpp
@@ -142,9 +142,9 @@ buildTamarama(const TamaInfo &tamaInfo, const u32 queue,
     nfa->length = verify_u32(total_size);
     nfa->queueIndex = queue;
 
-    char *ptr = (char *)nfa.get() + sizeof(NFA);
+    char *ptr = reinterpret_cast<char *>(nfa.get()) + sizeof(NFA);
     char *base_offset = ptr;
-    Tamarama *t = (Tamarama *)ptr;
+    Tamarama *t = reinterpret_cast<Tamarama *>(ptr);
     t->numSubEngines = verify_u32(subSize);
     t->activeIdxSize = verify_u8(activeIdxSize);
 
@@ -152,11 +152,11 @@ buildTamarama(const TamaInfo &tamaInfo, const u32 queue,
     copy_bytes(ptr, top_base);
     ptr += byte_length(top_base);
 
-    u32 *offsets = (u32 *)ptr;
+    u32 *offsets = reinterpret_cast<u32 *>(ptr);
     char *sub_nfa_offset = ptr + sizeof(u32) * subSize;
     copyInSubnfas(base_offset, *nfa, tamaInfo, offsets, sub_nfa_offset,
                   activeIdxSize);
-    assert((size_t)(sub_nfa_offset - (char *)nfa.get()) <= total_size);
+    assert(static_cast<size_t>(sub_nfa_offset - reinterpret_cast<char *>(nfa.get())) <= total_size);
     return nfa;
 }
 

--- a/src/nfagraph/ng_lbr.cpp
+++ b/src/nfagraph/ng_lbr.cpp
@@ -182,7 +182,7 @@ bytecode_ptr<NFA> buildLbrVerm(const CharReach &cr, const depth &repeatMin,
     enum RepeatType rtype = chooseRepeatType(repeatMin, repeatMax, minPeriod,
                                              is_reset);
     auto nfa = makeLbrNfa<lbr_verm>(LBR_NFA_VERM, rtype, repeatMax);
-    struct lbr_verm *lv = (struct lbr_verm *)getMutableImplNfa(nfa.get());
+    struct lbr_verm *lv = reinterpret_cast<struct lbr_verm *>(getMutableImplNfa(nfa.get()));
     lv->c = escapes.find_first();
 
     fillNfa<lbr_verm>(nfa.get(), &lv->common, report, repeatMin, repeatMax,

--- a/src/parser/utf8_validate.cpp
+++ b/src/parser/utf8_validate.cpp
@@ -65,7 +65,7 @@ bool isValidUtf8(const char *expression, const size_t len) {
         return true;
     }
 
-    const u8 *s = (const u8 *)expression;
+    const u8 *s = reinterpret_cast<const u8 *>(expression);
     u32 val;
 
     size_t i = 0;

--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -2966,7 +2966,7 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
             !lit_prog.empty()) {
             const auto &cfrag = fragments[pfrag.included_frag_id];
             assert(pfrag.s.length() >= cfrag.s.length() &&
-                   !pfrag.s.any_nocase() == !cfrag.s.any_nocase());
+                   !pfrag.s.any_nocase() != !cfrag.s.any_nocase());
                    /** !pfrag.s.any_nocase() >= !cfrag.s.any_nocase()); **/
             u32 child_offset = cfrag.lit_program_offset;
             DEBUG_PRINTF("child %u offset %u\n", cfrag.fragment_id,

--- a/src/util/alloc.cpp
+++ b/src/util/alloc.cpp
@@ -68,8 +68,8 @@ namespace ue2 {
 #endif
 
 void *aligned_malloc_internal(size_t size, size_t align) {
-    // cppcheck-suppress cstyleCast
     void *mem= nullptr;;
+    // cppcheck-suppress cstyleCast
     int rv = posix_memalign(&mem, align, size);
     if (rv != 0) {
         DEBUG_PRINTF("posix_memalign returned %d when asked for %zu bytes\n",

--- a/src/util/uniform_ops.h
+++ b/src/util/uniform_ops.h
@@ -41,37 +41,58 @@
 #include "unaligned.h"
 
 // Aligned loads
+#ifndef __cplusplus__
 #define load_u8(a)          (*(const u8 *)(a))
 #define load_u16(a)         (*(const u16 *)(a))
 #define load_u32(a)         (*(const u32 *)(a))
 #define load_u64a(a)        (*(const u64a *)(a))
+#else
+#define load_u8(a)          (*(reinterpret_cast<const u8 *>(a))
+#define load_u16(a)         (*(reinterpret_cast<const u16 *>(a))
+#define load_u32(a)         (*(reinterpret_cast<const u32 *>(a))
+#define load_u64a(a)        (*(reinterpret_cast<const u64a *>(a))
+#endif // __cplusplus__
 #define load_m128(a)        load128(a)
 #define load_m256(a)        load256(a)
 #define load_m384(a)        load384(a)
 #define load_m512(a)        load512(a)
 
 // Unaligned loads
+#ifndef __cplusplus__
 #define loadu_u8(a)          (*(const u8 *)(a))
 #define loadu_u16(a)         unaligned_load_u16((const u8 *)(a))
 #define loadu_u32(a)         unaligned_load_u32((const u8 *)(a))
 #define loadu_u64a(a)        unaligned_load_u64a((const u8 *)(a))
+#else
+#define loadu_u8(a)          (*(reinterpret_cast<const u8 *>(a))
+#define loadu_u16(a)         unaligned_load_u16(reinterpret_cast<const u8 *>(a))
+#define loadu_u32(a)         unaligned_load_u32(reinterpret_cast<const u8 *>(a))
+#define loadu_u64a(a)        unaligned_load_u64a(reinterpret_cast<const u8 *>(a))
+#endif // __cplusplus__
 #define loadu_m128(a)        loadu128(a)
 #define loadu_m256(a)        loadu256(a)
 #define loadu_m384(a)        loadu384(a)
 #define loadu_m512(a)        loadu512(a)
 
 // Aligned stores
-#define store_u8(ptr, a)    do { *(u8 *)(ptr) = (a); } while(0)
-#define store_u16(ptr, a)   do { *(u16 *)(ptr) = (a); } while(0)
-#define store_u32(ptr, a)   do { *(u32 *)(ptr) = (a); } while(0)
-#define store_u64a(ptr, a)  do { *(u64a *)(ptr) = (a); } while(0)
+#ifndef __cplusplus__
+#define store_u8(ptr, a)    do { *(reinterpret_cast<u8 *>(ptr)) = (a); } while(0)
+#define store_u16(ptr, a)   do { *(reinterpret_cast<u16 *>(ptr)) = (a); } while(0)
+#define store_u32(ptr, a)   do { *(reinterpret_cast<u32 *>(ptr)) = (a); } while(0)
+#define store_u64a(ptr, a)  do { *(reinterpret_cast<u64a *>(ptr)) = (a); } while(0)
+#else
+#endif // __cplusplus__
 #define store_m128(ptr, a)  store128(ptr, a)
 #define store_m256(ptr, a)  store256(ptr, a)
 #define store_m384(ptr, a)  store384(ptr, a)
 #define store_m512(ptr, a)  store512(ptr, a)
 
 // Unaligned stores
+#ifndef __cplusplus__
 #define storeu_u8(ptr, a)    do { *(u8 *)(ptr) = (a); } while(0)
+#else
+#define storeu_u8(ptr, a)    do { *(reinterpret_cast<u8 *>(ptr)) = (a); } while(0)
+#endif // __cplusplus__
 #define storeu_u16(ptr, a)   unaligned_store_u16(ptr, a)
 #define storeu_u32(ptr, a)   unaligned_store_u32(ptr, a)
 #define storeu_u64a(ptr, a)  unaligned_store_u64a(ptr, a)

--- a/unit/hyperscan/extparam.cpp
+++ b/unit/hyperscan/extparam.cpp
@@ -104,7 +104,7 @@ TEST(ExtParam, LargeExactOffset) {
     // Try the exact match.
     corpus = "hatstand" + string(199983, '_') + "teakettle";
     err = hs_scan(db, corpus.c_str(), corpus.length(), 0, scratch, record_cb,
-                  (void *)&c);
+                  reinterpret_cast<void *>(&c));
     ASSERT_EQ(HS_SUCCESS, err);
     ASSERT_EQ(1U, c.matches.size());
     ASSERT_EQ(MatchRecord(200000, 0), c.matches[0]);

--- a/unit/hyperscan/som.cpp
+++ b/unit/hyperscan/som.cpp
@@ -52,7 +52,7 @@ static
 int vectorCallback(unsigned id, unsigned long long from,
                    unsigned long long to, unsigned, void *ctx) {
     //printf("match id %u at (%llu,%llu)\n", id, from, to);
-    vector<Match> *matches = (vector<Match> *)ctx;
+    vector<Match> *matches = reinterpret_cast<vector<Match> *>(ctx);
     matches->push_back(Match(id, from, to));
     return 0;
 }

--- a/unit/internal/lbr.cpp
+++ b/unit/internal/lbr.cpp
@@ -212,7 +212,7 @@ TEST_P(LbrTest, MatchMax) {
     const string corpus = matchingCorpus(params.max);
 
     initQueue();
-    q.buffer = (const u8 *)corpus.c_str();
+    q.buffer = reinterpret_cast<const u8 *>(corpus.c_str());
     q.length = corpus.length();
     u64a end = corpus.length();
 

--- a/util/database_util.cpp
+++ b/util/database_util.cpp
@@ -94,7 +94,7 @@ hs_database_t * loadDatabase(const char *filename, bool verbose) {
     }
     size_t len = st.st_size;
 
-    bytes = (char *)mmap(nullptr, len, PROT_READ, MAP_SHARED, fd, 0);
+    bytes = reinterpret_cast<char *>(mmap(nullptr, len, PROT_READ, MAP_SHARED, fd, 0));
     if (bytes == MAP_FAILED) {
         cout << "mmap failed" << endl;
         close(fd);

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -141,7 +141,7 @@ void prettyPrintRange(std::ostream &out, it_t begin, it_t end) {
 static really_inline
 char *makeHex(const unsigned char *pat, unsigned patlen) {
     size_t hexlen = patlen * 4;
-    char *hexbuf = (char *)malloc(hexlen + 1);
+    char *hexbuf = reinterpret_cast<char *>(malloc(hexlen + 1));
     unsigned i;
     char *buf;
     for (i = 0, buf = hexbuf; i < patlen; i++, buf += 4) {


### PR DESCRIPTION
Fix wrong casts, were the reason for creepy bugs that passed the tests but caused the benchmarks to segfault.
Also add more C style cast fixes in src/nfa