### PR TITLE
revert a change to assert 

### DIFF
--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -2966,8 +2966,7 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
             !lit_prog.empty()) {
             const auto &cfrag = fragments[pfrag.included_frag_id];
             assert(pfrag.s.length() >= cfrag.s.length() &&
-                   !pfrag.s.any_nocase() != !cfrag.s.any_nocase());
-                   /** !pfrag.s.any_nocase() >= !cfrag.s.any_nocase()); **/
+                   !pfrag.s.any_nocase() >= !cfrag.s.any_nocase());
             u32 child_offset = cfrag.lit_program_offset;
             DEBUG_PRINTF("child %u offset %u\n", cfrag.fragment_id,
                          child_offset);


### PR DESCRIPTION
the original logic might have been subtely clever (or else totally useless all these years), when we see which of the two we might delete that assert entirely. for now put it back as it was.