### PR TITLE
Fix Clang Tidy warning optin.performance.Padding

### DIFF
--- a/benchmarks/benchmarks.hpp
+++ b/benchmarks/benchmarks.hpp
@@ -41,8 +41,12 @@
 
 class MicroBenchmark {
 public:
+    struct hs_scratch scratch{};
     char const *label;
     size_t size;
+    std::vector<u8> buf;
+    ue2::bytecode_ptr<noodTable> nt;
+    ue2::CharReach chars;
 
     // Shufti/Truffle
     union {
@@ -57,12 +61,6 @@ public:
 #endif
         };
     };
-    ue2::CharReach chars;
-    std::vector<u8> buf;
-
-    // Noodle
-    struct hs_scratch scratch{};
-    ue2::bytecode_ptr<noodTable> nt;
 
     MicroBenchmark(char const *label_, size_t size_)
         : label(label_), size(size_), buf(size_){};

--- a/unit/internal/rose_mask_32.cpp
+++ b/unit/internal/rose_mask_32.cpp
@@ -40,9 +40,9 @@ union RoseLookaroundMask32 {
 
 struct ValidateMask32TestInfo {
     RoseLookaroundMask32 data;
-    u32 valid_mask;
     RoseLookaroundMask32 and_mask;
     RoseLookaroundMask32 cmp_mask;
+    u32 valid_mask;
     u32 neg_mask;
 };
 


### PR DESCRIPTION
Fixes some optin.performance.Padding

closes some: #253 