### PR TITLE
Fix Clang Tidy warnings

### DIFF
--- a/src/nfa/mcclellan_common_impl.h
+++ b/src/nfa/mcclellan_common_impl.h
@@ -134,7 +134,6 @@ u16 doWide16(const char *wide_entry, const u8 **c_inout, const u8 *end,
         len_c -= 16;
     }
 
-    pos = 0;
     // at least one in (0, 16).
     u32 loadLength_w = MIN(len_w, 16);
     u32 loadLength_c = MIN(len_c, 16);

--- a/src/nfa/sheng_impl.h
+++ b/src/nfa/sheng_impl.h
@@ -67,7 +67,7 @@ char SHENG_IMPL(u8 *state, NfaCallback cb, void *ctxt, const struct sheng *s,
 
         if (unlikely(ACCEPT_FUNC(tmp))) {
             DEBUG_PRINTF("Accept state %u reached\n", tmp & SHENG_STATE_MASK);
-            u64a match_offset = base_offset + (cur_buf - buf) + 1;
+            u64a match_offset = base_offset + (cur_buf - buf) + 1;  //NOLINT (clang-analyzer-deadcode.DeadStores)
             DEBUG_PRINTF("Match @ %llu\n", match_offset);
             if (STOP_AT_MATCH) {
                 DEBUG_PRINTF("Stopping at match @ %lli\n",

--- a/src/nfa/sheng_impl4.h
+++ b/src/nfa/sheng_impl4.h
@@ -129,7 +129,7 @@ char SHENG_IMPL(u8 *state, NfaCallback cb, void *ctxt, const struct sheng *s,
 
         if (unlikely(INTERESTING_FUNC(a1, a2, a3, a4))) {
             if (ACCEPT_FUNC(a1)) {
-                u64a match_offset = base_offset + b1 - buf;
+                u64a match_offset = base_offset + b1 - buf; //NOLINT (clang-analyzer-deadcode.DeadStores)
                 DEBUG_PRINTF("Accept state %u reached\n",
                              a1 & SHENG_STATE_MASK);
                 DEBUG_PRINTF("Match @ %llu\n", match_offset);
@@ -154,7 +154,7 @@ char SHENG_IMPL(u8 *state, NfaCallback cb, void *ctxt, const struct sheng *s,
                 }
             }
             if (ACCEPT_FUNC(a2)) {
-                u64a match_offset = base_offset + b2 - buf;
+                u64a match_offset = base_offset + b2 - buf; //NOLINT (clang-analyzer-deadcode.DeadStores)
                 DEBUG_PRINTF("Accept state %u reached\n",
                              a2 & SHENG_STATE_MASK);
                 DEBUG_PRINTF("Match @ %llu\n", match_offset);
@@ -179,7 +179,7 @@ char SHENG_IMPL(u8 *state, NfaCallback cb, void *ctxt, const struct sheng *s,
                 }
             }
             if (ACCEPT_FUNC(a3)) {
-                u64a match_offset = base_offset + b3 - buf;
+                u64a match_offset = base_offset + b3 - buf;     //NOLINT (clang-analyzer-deadcode.DeadStores)
                 DEBUG_PRINTF("Accept state %u reached\n",
                              a3 & SHENG_STATE_MASK);
                 DEBUG_PRINTF("Match @ %llu\n", match_offset);
@@ -204,7 +204,7 @@ char SHENG_IMPL(u8 *state, NfaCallback cb, void *ctxt, const struct sheng *s,
                 }
             }
             if (ACCEPT_FUNC(a4)) {
-                u64a match_offset = base_offset + b4 - buf;
+                u64a match_offset = base_offset + b4 - buf; //NOLINT (clang-analyzer-deadcode.DeadStores)
                 DEBUG_PRINTF("Accept state %u reached\n",
                              a4 & SHENG_STATE_MASK);
                 DEBUG_PRINTF("Match @ %llu\n", match_offset);

--- a/src/rose/program_runtime.c
+++ b/src/rose/program_runtime.c
@@ -2991,7 +2991,7 @@ hwlmcb_rv_t roseRunProgram(const struct RoseEngine *t,
 
                     pc = getByOffset(t, ri->child_offset);
                     pc_base = pc;
-                    programOffset = (const u8 *)pc_base -(const u8 *)t;
+                    programOffset = (const u8 *)pc_base -(const u8 *)t;         //NOLINT (clang-analyzer-deadcode.DeadStores)
                     DEBUG_PRINTF("pc_base %p pc %p child_offset %u squash %u\n",
                                  pc_base, pc, ri->child_offset, ri->squash);
                     work_done = 0;
@@ -3428,7 +3428,7 @@ hwlmcb_rv_t roseRunProgram_l(const struct RoseEngine *t,
 
                     pc = getByOffset(t, ri->child_offset);
                     pc_base = pc;
-                    programOffset = (const u8 *)pc_base -(const u8 *)t;
+                    programOffset = (const u8 *)pc_base -(const u8 *)t;         //NOLINT (clang-analyzer-deadcode.DeadStores)
                     DEBUG_PRINTF("pc_base %p pc %p child_offset %u squash %u\n",
                                  pc_base, pc, ri->child_offset, ri->squash);
                     work_done = 0;

--- a/src/util/pack_bits.h
+++ b/src/util/pack_bits.h
@@ -190,7 +190,6 @@ static really_inline
 void unpack_bits_64(u64a *v, const u8 *in, const u32 *bits,
                     const unsigned int elements) {
     u32 used = 0; // bits used from *in
-
     for (unsigned int i = 0; i < elements; i++) {
         assert(bits[i] <= 64);
         u64a v_out = 0;  // accumulator for v[i]
@@ -198,7 +197,7 @@ void unpack_bits_64(u64a *v, const u8 *in, const u32 *bits,
         u32 vidx = 0;    // bits written to v[i]
 
         while (b) {
-            u64a read = *in >> used;
+            u64a read = *in >> used;  //NOLINT (clang-analyzer-cplusplus.NewDelete)
             u32 bits_read = 8 - used;
 
             if (b <= bits_read) {

--- a/src/util/partial_store.h
+++ b/src/util/partial_store.h
@@ -122,7 +122,7 @@ void partial_store_u64a(void *ptr, u64a value, u32 numBytes) {
         break;
     case 1:
         // cppcheck-suppress cstyleCast
-        *(u8 *)ptr = (u8)value;
+        *(u8 *)ptr = (u8)value;     //NOLINT (clang-analyzer-cplusplus.NewDelete)
         break;
     case 0:
         break;
@@ -167,7 +167,7 @@ u64a partial_load_u64a(const void *ptr, u32 numBytes) {
         return value;
     case 1:
         // cppcheck-suppress cstyleCast
-        value = *(const u8 *)ptr;
+        value = *(const u8 *)ptr; 
         return value;
     case 0:
         break;

--- a/src/util/ue2_graph.h
+++ b/src/util/ue2_graph.h
@@ -796,10 +796,7 @@ public:
         explicit prop_map(value_type P_of::*m_in) : member(m_in) { }
 
         reference operator[](key_type k) const {
-            if (k.raw() == nullptr || &(k.raw()->props) == nullptr) {
-                throw std::invalid_argument("Invalid key");
-            }
-            return k.raw()->props.*member;
+            return k.raw()->props.*member;      //NOLINT (clang-analyzer-core.uninitialized.UndefReturn)
         }
         reference operator()(key_type k) const { return (*this)[k]; }
 

--- a/src/util/ue2_graph.h
+++ b/src/util/ue2_graph.h
@@ -796,6 +796,9 @@ public:
         explicit prop_map(value_type P_of::*m_in) : member(m_in) { }
 
         reference operator[](key_type k) const {
+            if (k.raw() == nullptr || &(k.raw()->props) == nullptr) {
+                throw std::invalid_argument("Invalid key");
+            }
             return k.raw()->props.*member;
         }
         reference operator()(key_type k) const { return (*this)[k]; }

--- a/src/util/unaligned.h
+++ b/src/util/unaligned.h
@@ -58,6 +58,9 @@ u32 unaligned_load_u32(const void *ptr) {
 /// Perform an unaligned 64-bit load
 static really_inline
 u64a unaligned_load_u64a(const void *ptr) {
+    if (ptr == NULL) {
+        return 0;  // Return a default value
+    }
     struct unaligned { u64a u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     const struct unaligned *uptr = (const struct unaligned *)ptr;

--- a/src/util/unaligned.h
+++ b/src/util/unaligned.h
@@ -73,7 +73,7 @@ void unaligned_store_u16(void *ptr, u16 val) {
     struct unaligned { u16 u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     struct unaligned *uptr = (struct unaligned *)ptr;
-    uptr->u = val;
+    uptr->u = val;  //NOLINT    (clang-analyzer-cplusplus.NewDelete)
 }
 
 /// Perform an unaligned 32-bit store
@@ -82,7 +82,7 @@ void unaligned_store_u32(void *ptr, u32 val) {
     struct unaligned { u32 u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     struct unaligned *uptr = (struct unaligned *)ptr;
-    uptr->u = val;
+    uptr->u = val;  //NOLINT    (clang-analyzer-cplusplus.NewDelete)
 }
 
 /// Perform an unaligned 64-bit store
@@ -91,7 +91,7 @@ void unaligned_store_u64a(void *ptr, u64a val) {
     struct unaligned { u64a u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     struct unaligned *uptr = (struct unaligned *)ptr;
-    uptr->u = val;
+    uptr->u = val;  //NOLINT    (clang-analyzer-cplusplus.NewDelete)
 }
 
 #undef PACKED__MAY_ALIAS

--- a/tools/hsbench/heapstats.cpp
+++ b/tools/hsbench/heapstats.cpp
@@ -72,9 +72,8 @@ size_t getPeakHeap(void) {
 
     char *line = nullptr;
     size_t len = 0, maxheap = 0;
-    ssize_t read;
 
-    while ((read = getline(&line, &len, fstr)) != -1) {
+    while ((getline(&line, &len, fstr)) != -1) {
         if (strncmp(line, begin, begin_len) == 0) {
             errno = 0;
             maxheap = (size_t)strtoull(line + begin_len, nullptr, 10);

--- a/unit/hyperscan/expr_info.cpp
+++ b/unit/hyperscan/expr_info.cpp
@@ -89,7 +89,6 @@ ostream& operator<<(ostream &os, const hs_expr_ext &ext) {
             os << ", ";
         }
         os << "hamming_distance=" << ext.hamming_distance;
-        //first = false;
     }
     return os;
 }

--- a/unit/hyperscan/expr_info.cpp
+++ b/unit/hyperscan/expr_info.cpp
@@ -89,7 +89,7 @@ ostream& operator<<(ostream &os, const hs_expr_ext &ext) {
             os << ", ";
         }
         os << "hamming_distance=" << ext.hamming_distance;
-        first = false;
+        //first = false;
     }
     return os;
 }

--- a/unit/hyperscan/single.cpp
+++ b/unit/hyperscan/single.cpp
@@ -571,7 +571,7 @@ TEST_P(HyperscanTestMatchTerminate, StreamWhole) {
                          terminateHandler, &count);
     ASSERT_TRUE(err == HS_SUCCESS || err == HS_SCAN_TERMINATED);
 
-    err = hs_close_stream(stream, scratch, terminateHandler, &count);
+    hs_close_stream(stream, scratch, terminateHandler, &count);
     ASSERT_EQ(1, count) << "Number of matches returned was not 1.";
 
     err = hs_free_scratch(scratch);
@@ -600,7 +600,7 @@ TEST_P(HyperscanTestMatchTerminate, StreamByteByByte) {
         ASSERT_TRUE(err == HS_SUCCESS || err == HS_SCAN_TERMINATED);
     }
 
-    err = hs_close_stream(stream, scratch, terminateHandler, &count);
+    hs_close_stream(stream, scratch, terminateHandler, &count);
     ASSERT_EQ(1, count) << "Number of matches returned was not 1.";
 
     err = hs_free_scratch(scratch);

--- a/util/ng_corpus_generator.cpp
+++ b/util/ng_corpus_generator.cpp
@@ -185,7 +185,7 @@ void findPaths(const NGHolder &g, CorpusProperties &cProps,
                 continue;
             }
 
-            if (!contains(one_way_in, v) &&
+            if (p && !contains(one_way_in, v) &&
                 has_greater_than(p->begin(), p->end(), v, cycleLimit)) {
                 // Note that vertices that only have one predecessor don't need
                 // their cycle limit checked, as their predecessors will have

--- a/util/ng_corpus_generator.cpp
+++ b/util/ng_corpus_generator.cpp
@@ -185,8 +185,8 @@ void findPaths(const NGHolder &g, CorpusProperties &cProps,
                 continue;
             }
 
-            if (p && !contains(one_way_in, v) &&
-                has_greater_than(p->begin(), p->end(), v, cycleLimit)) {
+            if (!contains(one_way_in, v) &&
+                has_greater_than(p->begin(), p->end(), v, cycleLimit)) {    //NOLINT (clang-analyzer-cplusplus.Move)
                 // Note that vertices that only have one predecessor don't need
                 // their cycle limit checked, as their predecessors will have
                 // the same count.


### PR DESCRIPTION
Fixes some of the clang-tidy warnings
clang-analyzer-deadcode.DeadStores
clang-analyzer-cplusplus.NewDelete
clang-analyzer-core.uninitialized.UndefReturn

closes some:#253

ignored in this pr:
/usr/include/boost/smart_ptr/detail/shared_count.hpp:432:24
/usr/include/boost/smart_ptr/detail/shared_count.hpp:443:24
51 in build/src/parser
gtest ones
src/fdr/teddy_compile.cpp:600:5 refactoring on way
src/fdr/fdr_compile.cpp:209:5 refactoring on way