### PR TITLE
Bug fix/clang tidy warnings part2

### DIFF
--- a/src/nfagraph/ng_limex.cpp
+++ b/src/nfagraph/ng_limex.cpp
@@ -677,7 +677,7 @@ constructNFA(const NGHolder &h_in, const ReportManager *rm,
 
     if (has_managed_reports(*h)) {
         assert(rm);
-        remapReportsToPrograms(*h, *rm);
+        remapReportsToPrograms(*h, *rm);    //NOLINT (clang-analyzer-core.NonNullParamChecker)
     }
 
     if (!cc.streaming || !cc.grey.compressNFAState) {

--- a/src/parser/buildstate.cpp
+++ b/src/parser/buildstate.cpp
@@ -158,7 +158,7 @@ GlushkovBuildStateImpl::GlushkovBuildStateImpl(NFABuilder &b,
     lasts.emplace_back(startState);
     lasts.emplace_back(startDotstarState);
     firsts.emplace_back(startDotstarState);
-    connectRegions(lasts, firsts);
+    connectRegions(lasts, firsts);  //NOLINT    (cplusplus.VirtualCall)
 
     // accept to acceptEod edges already wired
 
@@ -341,7 +341,7 @@ void GlushkovBuildStateImpl::connectSuccessors(const PositionInfo &from,
             Position fakedot = builder.makePositions(1);
             builder.addCharReach(fakedot, CharReach(0x00, 0xff));
             builder.setNodeReportID(fakedot, -1);
-            addSuccessor(fakedot, acceptState);
+            addSuccessor(fakedot, acceptState); //NOLINT    (cplusplus.VirtualCall)
             *accept = fakedot;
         } else {
             // We might lead to accept via an assertion vertex, so we add the

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -225,7 +225,7 @@ hs_error_t alloc_scratch(const hs_scratch_t *proto, hs_scratch_t **scratch) {
     assert(ISALIGNED_CL(current));
     s->fullState = (char *)current;
     s->fullStateSize = fullStateSize;
-    current += fullStateSize;
+    current += fullStateSize;   //NOLINT (clang-analyzer-deadcode.DeadStores)
 
     *scratch = s;
 

--- a/src/util/multibit.h
+++ b/src/util/multibit.h
@@ -345,9 +345,10 @@ void mmbit_clear(u8 *bits, u32 total_bits) {
 /** \brief Specialisation of \ref mmbit_set for flat models. */
 static really_inline
 char mmbit_set_flat(u8 *bits, u32 total_bits, u32 key) {
+    assert(bits);
     bits += mmbit_flat_select_byte(key, total_bits);
     u8 mask = 1U << (key % 8);
-    char was_set = !!(*bits & mask);
+    char was_set = !!(*bits & mask);    //NOLINT (clang-analyzer-core.NullDereference)
     *bits |= mask;
     return was_set;
 }

--- a/src/util/partial_store.h
+++ b/src/util/partial_store.h
@@ -36,6 +36,9 @@
 
 static really_inline
 void partial_store_u32(void *ptr, u32 value, u32 numBytes) {
+    if(ptr == NULL){
+        return;
+    }
     assert(numBytes <= 4);
     switch (numBytes) {
     case 4:
@@ -61,6 +64,9 @@ void partial_store_u32(void *ptr, u32 value, u32 numBytes) {
 static really_inline
 u32 partial_load_u32(const void *ptr, u32 numBytes) {
     u32 value;
+    if(ptr == NULL){
+        return 0;
+    }
     assert(numBytes <= 4);
     switch (numBytes) {
     case 4:
@@ -87,6 +93,9 @@ u32 partial_load_u32(const void *ptr, u32 numBytes) {
 
 static really_inline
 void partial_store_u64a(void *ptr, u64a value, u32 numBytes) {
+    if(ptr == NULL){
+        return;
+    }
     assert(numBytes <= 8);
     switch (numBytes) {
     case 8:
@@ -132,6 +141,9 @@ void partial_store_u64a(void *ptr, u64a value, u32 numBytes) {
 static really_inline
 u64a partial_load_u64a(const void *ptr, u32 numBytes) {
     u64a value;
+    if(ptr == NULL){
+        return 0;
+    }
     assert(numBytes <= 8);
     switch (numBytes) {
     case 8:

--- a/src/util/partial_store.h
+++ b/src/util/partial_store.h
@@ -36,9 +36,7 @@
 
 static really_inline
 void partial_store_u32(void *ptr, u32 value, u32 numBytes) {
-    if(ptr == NULL){
-        return;
-    }
+    assert(ptr);
     assert(numBytes <= 4);
     switch (numBytes) {
     case 4:
@@ -64,9 +62,7 @@ void partial_store_u32(void *ptr, u32 value, u32 numBytes) {
 static really_inline
 u32 partial_load_u32(const void *ptr, u32 numBytes) {
     u32 value;
-    if(ptr == NULL){
-        return 0;
-    }
+    assert(ptr);
     assert(numBytes <= 4);
     switch (numBytes) {
     case 4:
@@ -93,9 +89,7 @@ u32 partial_load_u32(const void *ptr, u32 numBytes) {
 
 static really_inline
 void partial_store_u64a(void *ptr, u64a value, u32 numBytes) {
-    if(ptr == NULL){
-        return;
-    }
+    assert(ptr);
     assert(numBytes <= 8);
     switch (numBytes) {
     case 8:
@@ -141,9 +135,7 @@ void partial_store_u64a(void *ptr, u64a value, u32 numBytes) {
 static really_inline
 u64a partial_load_u64a(const void *ptr, u32 numBytes) {
     u64a value;
-    if(ptr == NULL){
-        return 0;
-    }
+    assert(ptr);
     assert(numBytes <= 8);
     switch (numBytes) {
     case 8:

--- a/src/util/unaligned.h
+++ b/src/util/unaligned.h
@@ -40,19 +40,25 @@
 /// Perform an unaligned 16-bit load
 static really_inline
 u16 unaligned_load_u16(const void *ptr) {
+    if (ptr == NULL) {
+        return 0;  // Return a default value
+    }
     struct unaligned { u16 u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     const struct unaligned *uptr = (const struct unaligned *)ptr;
-    return uptr->u;
+    return uptr->u;     //NOLINT    (clang-analyzer-core.NullDereference)
 }
 
 /// Perform an unaligned 32-bit load
 static really_inline
 u32 unaligned_load_u32(const void *ptr) {
+    if (ptr == NULL) {
+        return 0;  // Return a default value
+    }
     struct unaligned { u32 u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     const struct unaligned *uptr = (const struct unaligned *)ptr;
-    return uptr->u;
+    return uptr->u;     //NOLINT    (clang-analyzer-core.NullDereference)
 }
 
 /// Perform an unaligned 64-bit load

--- a/src/util/unaligned.h
+++ b/src/util/unaligned.h
@@ -40,9 +40,7 @@
 /// Perform an unaligned 16-bit load
 static really_inline
 u16 unaligned_load_u16(const void *ptr) {
-    if (ptr == NULL) {
-        return 0;  // Return a default value
-    }
+    assert(ptr);
     struct unaligned { u16 u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     const struct unaligned *uptr = (const struct unaligned *)ptr;
@@ -52,9 +50,7 @@ u16 unaligned_load_u16(const void *ptr) {
 /// Perform an unaligned 32-bit load
 static really_inline
 u32 unaligned_load_u32(const void *ptr) {
-    if (ptr == NULL) {
-        return 0;  // Return a default value
-    }
+    assert(ptr);
     struct unaligned { u32 u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     const struct unaligned *uptr = (const struct unaligned *)ptr;
@@ -64,18 +60,17 @@ u32 unaligned_load_u32(const void *ptr) {
 /// Perform an unaligned 64-bit load
 static really_inline
 u64a unaligned_load_u64a(const void *ptr) {
-    if (ptr == NULL) {
-        return 0;  // Return a default value
-    }
+    assert(ptr);
     struct unaligned { u64a u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     const struct unaligned *uptr = (const struct unaligned *)ptr;
-    return uptr->u;
+    return uptr->u;     //NOLINT (clang-analyzer-core.uninitialized.UndefReturn)
 }
 
 /// Perform an unaligned 16-bit store
 static really_inline
 void unaligned_store_u16(void *ptr, u16 val) {
+    assert(ptr);
     struct unaligned { u16 u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     struct unaligned *uptr = (struct unaligned *)ptr;
@@ -85,6 +80,7 @@ void unaligned_store_u16(void *ptr, u16 val) {
 /// Perform an unaligned 32-bit store
 static really_inline
 void unaligned_store_u32(void *ptr, u32 val) {
+    assert(ptr);
     struct unaligned { u32 u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     struct unaligned *uptr = (struct unaligned *)ptr;
@@ -94,6 +90,7 @@ void unaligned_store_u32(void *ptr, u32 val) {
 /// Perform an unaligned 64-bit store
 static really_inline
 void unaligned_store_u64a(void *ptr, u64a val) {
+    assert(ptr);
     struct unaligned { u64a u; } PACKED__MAY_ALIAS;
     // cppcheck-suppress cstyleCast
     struct unaligned *uptr = (struct unaligned *)ptr;

--- a/tools/hsbench/data_corpus.cpp
+++ b/tools/hsbench/data_corpus.cpp
@@ -78,7 +78,7 @@ vector<DataBlock> readCorpus(const string &filename) {
         ostringstream err;
         err << "Unable to open database '" << filename << "': "
             << sqlite3_errmsg(db);
-        status = sqlite3_close(db);
+        status = sqlite3_close(db); //NOLINT (clang-analyzer-deadcode.DeadStores)
         assert(status == SQLITE_OK);
         throw DataCorpusError(err.str());
     }
@@ -91,9 +91,9 @@ vector<DataBlock> readCorpus(const string &filename) {
     status = sqlite3_prepare_v2(db, query.c_str(), query.size(), &statement,
                                 nullptr);
     if (status != SQLITE_OK) {
-        status = sqlite3_finalize(statement);
+        status = sqlite3_finalize(statement);   //NOLINT (clang-analyzer-deadcode.DeadStores)
         assert(status == SQLITE_OK);
-        status = sqlite3_close(db);
+        status = sqlite3_close(db);         //NOLINT (clang-analyzer-deadcode.DeadStores)
         assert(status == SQLITE_OK);
 
         ostringstream oss;
@@ -115,17 +115,17 @@ vector<DataBlock> readCorpus(const string &filename) {
         oss << "Error retrieving blocks from corpus: "
             << sqlite3_errmsg(db);
 
-        status = sqlite3_finalize(statement);
+        status = sqlite3_finalize(statement);   //NOLINT (clang-analyzer-deadcode.DeadStores)
         assert(status == SQLITE_OK);
-        status = sqlite3_close(db);
+        status = sqlite3_close(db);             //NOLINT (clang-analyzer-deadcode.DeadStores)
         assert(status == SQLITE_OK);
 
         throw DataCorpusError(oss.str());
     }
 
-    status = sqlite3_finalize(statement);
+    status = sqlite3_finalize(statement);       //NOLINT (clang-analyzer-deadcode.DeadStores)
     assert(status == SQLITE_OK);
-    status = sqlite3_close(db);
+    status = sqlite3_close(db);                 //NOLINT (clang-analyzer-deadcode.DeadStores)
     assert(status == SQLITE_OK);
 
     if (blocks.empty()) {

--- a/tools/hsbench/main.cpp
+++ b/tools/hsbench/main.cpp
@@ -234,13 +234,13 @@ void processArgs(int argc, char *argv[], vector<BenchmarkSigs> &sigSets,
 #endif
         ;
     int in_sigfile = 0;
-    int do_per_scan = 0;
-    int do_compress = 0;
+    static int do_per_scan = 0;
+    static int do_compress = 0;
     int do_compress_size = 0;
-    int do_echo_matches = 0;
-    int do_sql_output = 0;
+    static int do_echo_matches = 0;
+    static int do_sql_output = 0;
     int option_index = 0;
-    int literalFlag = 0;
+    static int literalFlag = 0;
     vector<string> sigFiles;
 
     static struct option longopts[] = {

--- a/tools/hsbench/sqldb.cpp
+++ b/tools/hsbench/sqldb.cpp
@@ -56,7 +56,7 @@ sqlite3 *initDB(const string &filename) {
         ostringstream oss;
         oss << "Unable to open database '" << filename
             << "': " << sqlite3_errmsg(db);
-        status = sqlite3_close(db);
+        status = sqlite3_close(db);     //NOLINT (clang-analyzer-deadcode.DeadStores)
         assert(status == SQLITE_OK);
         throw SqlFailure(oss.str());
     }
@@ -115,7 +115,7 @@ sqlite3 *initDB(const string &filename) {
 fail:
     ostringstream oss;
     oss << "Unable to create tables: " << sqlite3_errmsg(db);
-    status = sqlite3_close(db);
+    status = sqlite3_close(db); //NOLINT (clang-analyzer-deadcode.DeadStores)
     assert(status == SQLITE_OK);
     throw SqlFailure(oss.str());
 }

--- a/tools/hscheck/main.cpp
+++ b/tools/hscheck/main.cpp
@@ -494,7 +494,7 @@ static
 void processArgs(int argc, char *argv[], UNUSED const unique_ptr<Grey> &grey) {
     const char options[] = "e:E:s:z:hHLNV8G:T:BC";
     bool signatureSet = false;
-    int literalFlag = 0;
+    static int literalFlag = 0;
 
     static struct option longopts[] = {
         {"literal-on", no_argument, &literalFlag, 1},


### PR DESCRIPTION
Fixes/supresses some of the clang-tidy warnings

closes some:https://github.com/VectorCamp/vectorscan/issues/253

ignored in this pr:
8 clang-analyzer-cplusplus.NewDelete (boost libr)
55 clang-analyzer-deadcode.DeadStores (build parser)
1 clang-analyzer-optin.cplusplus.VirtualCall (gtest)
11 clang-analyzer-optin.performance.Padding  (fdr limex)
2 clang-analyzer-valist.Uninitialized (gest)