### PR TITLE
Bug fix/clang tidy warnings part3

### DIFF
--- a/src/fdr/fdr_compile.cpp
+++ b/src/fdr/fdr_compile.cpp
@@ -206,8 +206,7 @@ bytecode_ptr<FDR> FDRCompiler::setupFDR() {
     assert(ISALIGNED_CL(ptr));
     fdr->floodOffset = verify_u32(ptr - fdr_base);
     memcpy(ptr, floodTable.get(), floodTable.size());
-    ptr += floodTable.size(); // last write, no need to round up
-
+    
     return fdr;
 }
 

--- a/src/fdr/teddy_compile.cpp
+++ b/src/fdr/teddy_compile.cpp
@@ -597,7 +597,7 @@ bytecode_ptr<FDR> TeddyCompiler::build() {
     assert(ISALIGNED_CL(ptr));
     teddy->floodOffset = verify_u32(ptr - teddy_base);
     memcpy(ptr, floodTable.get(), floodTable.size());
-    ptr += floodTable.size();
+    
 
     // Write teddy masks.
     u8 *baseMsk = teddy_base + ROUNDUP_CL(headerSize);

--- a/src/fdr/teddy_engine_description.h
+++ b/src/fdr/teddy_engine_description.h
@@ -39,7 +39,7 @@ namespace ue2 {
 
 #define TEDDY_BUCKET_LOAD 6
 
-struct TeddyEngineDef {
+struct TeddyEngineDef {     //NOLINT (clang-analyzer-optin.performance.Padding)
     u32 id;
     u64a cpu_features;
     u32 numMasks;

--- a/src/nfa/limex_internal.h
+++ b/src/nfa/limex_internal.h
@@ -163,12 +163,12 @@ struct LimExNFA##size {                                                     \
     m512 exceptionAndMask; /**< exception and mask */                       \
 };
 
-CREATE_NFA_LIMEX(32)
-CREATE_NFA_LIMEX(64)
-CREATE_NFA_LIMEX(128)
-CREATE_NFA_LIMEX(256)
-CREATE_NFA_LIMEX(384)
-CREATE_NFA_LIMEX(512)
+CREATE_NFA_LIMEX(32)        //NOLINT (clang-analyzer-optin.performance.Padding)
+CREATE_NFA_LIMEX(64)        //NOLINT (clang-analyzer-optin.performance.Padding)
+CREATE_NFA_LIMEX(128)       //NOLINT (clang-analyzer-optin.performance.Padding)
+CREATE_NFA_LIMEX(256)       //NOLINT (clang-analyzer-optin.performance.Padding)
+CREATE_NFA_LIMEX(384)       //NOLINT (clang-analyzer-optin.performance.Padding)
+CREATE_NFA_LIMEX(512)       //NOLINT (clang-analyzer-optin.performance.Padding)
 
 /** \brief Structure describing a bounded repeat within the LimEx NFA.
  *


### PR DESCRIPTION
Closes some: #253
closed in this PR 
src/fdr/fdr_compile.cpp:209:5 deadstores
src/fdr/teddy_compile.cpp:600:5 deadstores
src/nfa/limex_internal.h:171:1      NOLINT
src/fdr/teddy_engine_description.h:42:8  NOLINT

There are 8 clang-analyzer-cplusplus.NewDelete warnings remaning in boost library ignored in this pr