### PR TITLE
hs_valid_platform: Fix check for SSE4.2

### DIFF
--- a/src/hs_valid_platform.c
+++ b/src/hs_valid_platform.c
@@ -40,10 +40,10 @@
 
 HS_PUBLIC_API
 hs_error_t HS_CDECL hs_valid_platform(void) {
-    /* Hyperscan requires SSSE3, anything else is a bonus */
+    /* Vectorscan requires SSE4.2, anything else is a bonus */
 #if !defined(VS_SIMDE_BACKEND) && (defined(ARCH_IA32) || defined(ARCH_X86_64))
     // cppcheck-suppress knownConditionTrueFalse
-    if (check_ssse3()) {
+    if (check_sse42()) {
         return HS_SUCCESS;
     } else {
         return HS_ARCH_ERROR;


### PR DESCRIPTION
Vectorscan requires SSE4.2 as a minimum on x86_64. For Hyperscan this used to be SSSE3.

Applications that use the library call hs_valid_platform() to check if the CPU fulfils this minimum requirement. However, when Vectorscan upgraded to SSE4.2, the check was not updated. This leads to the library trying to execute instructions that are not supported, resulting in the application to crash.

This might not have been noticed as the CPUs that do not support SSE4.2 are rather old and unlikely to run any load where performance is an issue. However, I believe that the library should not let the application crash.