### PR TITLE
Make vectorscan accept \0 starting pattern

### DIFF
--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -417,7 +417,7 @@ void addLitExpression(NG &ng, unsigned index, const char *expression,
                            "HS_FLAG_SOM_LEFTMOST are supported in literal API.");
     }
 
-    if (!strcmp(expression, "")) {
+    if (expLength == 0) {
         throw CompileError("Pure literal API doesn't support empty string.");
     }
 


### PR DESCRIPTION
Vectorscan used to reject such pattern because they were being compared to "" and found to be an empty string. We now check the pattern length instead.

I followed the pattern path down to some algorithm and didn't see anything that was relying on C string's null terminaison. It was always relying on the string length or some explicit parameter. I couldn't check for every single algorithm path though.