### PR TITLE
Draft: Fix double shufti's false positive

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -176,6 +176,31 @@ int main(){
         }
 
         for (size_t i = 0; i < std::size(sizes); i++) {
+            MicroBenchmark bench("Double Shufti", sizes[i]);
+            run_benchmarks(
+                sizes[i], MAX_LOOPS / sizes[i], matches[m], false, bench,
+                [&](MicroBenchmark &b) {
+                    ue2::shuftiBuildMasks(b.chars, reinterpret_cast<u8 *>(&b.lo), reinterpret_cast<u8 *>(&b.hi));
+                    b.chars.clear();
+                    ue2::flat_set<std::pair<u8, u8>> pattern;
+                    pattern.insert({'a', 'b'});
+                    ue2::shuftiBuildDoubleMasks(b.chars, pattern,
+                                                reinterpret_cast<u8 *>(&b.truffle_mask_lo),
+                                                reinterpret_cast<u8 *>(&b.truffle_mask_hi),
+                                                reinterpret_cast<u8 *>(&b.double_shufti_lo2),
+                                                reinterpret_cast<u8 *>(&b.double_shufti_hi2));
+                    memset(b.buf.data(), 'b', b.size);
+                },
+                [&](MicroBenchmark &b) {
+                    return shuftiDoubleExec(b.truffle_mask_lo,
+                                            b.truffle_mask_hi,
+                                            b.double_shufti_lo2,
+                                            b.double_shufti_hi2,
+                                            b.buf.data(), b.buf.data() + b.size);
+                });
+        }
+
+        for (size_t i = 0; i < std::size(sizes); i++) {
             MicroBenchmark bench("Truffle", sizes[i]);
             run_benchmarks(
                 sizes[i], MAX_LOOPS / sizes[i], matches[m], false, bench,

--- a/benchmarks/benchmarks.hpp
+++ b/benchmarks/benchmarks.hpp
@@ -61,6 +61,7 @@ public:
 #endif
         };
     };
+    m128 double_shufti_lo2, double_shufti_hi2;
 
     MicroBenchmark(char const *label_, size_t size_)
         : label(label_), size(size_), buf(size_){};

--- a/src/nfa/arm/shufti.hpp
+++ b/src/nfa/arm/shufti.hpp
@@ -46,7 +46,7 @@ const SuperVector<S> blockSingleMask(SuperVector<S> mask_lo, SuperVector<S> mask
 
 template <uint16_t S>
 static really_inline
-SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi, SuperVector<S> mask2_lo, SuperVector<S> mask2_hi, SuperVector<S> chars) {
+SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi, SuperVector<S> mask2_lo, SuperVector<S> mask2_hi, SuperVector<S> chars, SuperVector<S> offset_char) {
 
     const SuperVector<S> low4bits = SuperVector<S>::dup_u8(0xf);
     SuperVector<S> chars_lo = chars & low4bits;
@@ -60,14 +60,18 @@ SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi,
     SuperVector<S> t1 = c1_lo | c1_hi;
     t1.print8("t1");
 
-    SuperVector<S> c2_lo = mask2_lo.template pshufb<true>(chars_lo);
+    SuperVector<S> chars_lo2 = offset_char & low4bits;
+    chars_lo.print8("chars_lo2");
+    SuperVector<S> chars_hi2 = offset_char.template vshr_64_imm<4>() & low4bits;
+    chars_hi.print8("chars_hi2");
+
+    SuperVector<S> c2_lo = mask2_lo.template pshufb<true>(chars_lo2);
     c2_lo.print8("c2_lo");
-    SuperVector<S> c2_hi = mask2_hi.template pshufb<true>(chars_hi);
+    SuperVector<S> c2_hi = mask2_hi.template pshufb<true>(chars_hi2);
     c2_hi.print8("c2_hi");
     SuperVector<S> t2 = c2_lo | c2_hi;
     t2.print8("t2");
-    t2.template vshr_128_imm<1>().print8("t2.vshr_128(1)");
-    SuperVector<S> t = t1 | (t2.template vshr_128_imm<1>());
+    SuperVector<S> t = t1 | t2;
     t.print8("t");
 
     return !t.eq(SuperVector<S>::Ones());

--- a/src/nfa/ppc64el/shufti.hpp
+++ b/src/nfa/ppc64el/shufti.hpp
@@ -48,7 +48,7 @@ const SuperVector<S> blockSingleMask(SuperVector<S> mask_lo, SuperVector<S> mask
 
 template <uint16_t S>
 static really_inline
-SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi, SuperVector<S> mask2_lo, SuperVector<S> mask2_hi, SuperVector<S> chars) {
+SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi, SuperVector<S> mask2_lo, SuperVector<S> mask2_hi, SuperVector<S> chars, SuperVector<S> offset_char) {
 
     const SuperVector<S> low4bits = SuperVector<S>::dup_u8(0xf);
     SuperVector<S> chars_lo = chars & low4bits;
@@ -62,14 +62,18 @@ SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi,
     SuperVector<S> t1 = c1_lo | c1_hi;
     t1.print8("t1");
 
-    SuperVector<S> c2_lo = mask2_lo.template pshufb<true>(chars_lo);
+    SuperVector<S> chars_lo2 = offset_char & low4bits;
+    chars_lo.print8("chars_lo2");
+    SuperVector<S> chars_hi2 = offset_char.template vshr_64_imm<4>() & low4bits;
+    chars_hi.print8("chars_hi2");
+
+    SuperVector<S> c2_lo = mask2_lo.template pshufb<true>(chars_lo2);
     c2_lo.print8("c2_lo");
-    SuperVector<S> c2_hi = mask2_hi.template pshufb<true>(chars_hi);
+    SuperVector<S> c2_hi = mask2_hi.template pshufb<true>(chars_hi2);
     c2_hi.print8("c2_hi");
     SuperVector<S> t2 = c2_lo | c2_hi;
     t2.print8("t2");
-    t2.template vshr_128_imm<1>().print8("t2.vshr_128(1)");
-    SuperVector<S> t = t1 | (t2.template vshr_128_imm<1>());
+    SuperVector<S> t = t1 | t2;
     t.print8("t");
 
     return t.eq(SuperVector<S>::Ones());

--- a/src/nfa/x86/shufti.hpp
+++ b/src/nfa/x86/shufti.hpp
@@ -46,7 +46,7 @@ const SuperVector<S> blockSingleMask(SuperVector<S> mask_lo, SuperVector<S> mask
 
 template <uint16_t S>
 static really_inline
-SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi, SuperVector<S> mask2_lo, SuperVector<S> mask2_hi, SuperVector<S> chars) {
+SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi, SuperVector<S> mask2_lo, SuperVector<S> mask2_hi, SuperVector<S> chars, SuperVector<S> offset_char) {
 
     const SuperVector<S> low4bits = SuperVector<S>::dup_u8(0xf);
     SuperVector<S> chars_lo = chars & low4bits;
@@ -60,14 +60,18 @@ SuperVector<S> blockDoubleMask(SuperVector<S> mask1_lo, SuperVector<S> mask1_hi,
     SuperVector<S> c1 = c1_lo | c1_hi;
     c1.print8("c1");
 
-    SuperVector<S> c2_lo = mask2_lo.pshufb(chars_lo);
+    SuperVector<S> chars_lo2 = offset_char & low4bits;
+    chars_lo.print8("chars_lo2");
+    SuperVector<S> chars_hi2 = offset_char.template vshr_64_imm<4>() & low4bits;
+    chars_hi.print8("chars_hi2");
+
+    SuperVector<S> c2_lo = mask2_lo.pshufb(chars_lo2);
     c2_lo.print8("c2_lo");
-    SuperVector<S> c2_hi = mask2_hi.pshufb(chars_hi);
+    SuperVector<S> c2_hi = mask2_hi.pshufb(chars_hi2);
     c2_hi.print8("c2_hi");
     SuperVector<S> c2 = c2_lo | c2_hi;
     c2.print8("c2");
-    c2.template vshr_128_imm<1>().print8("c2.vshr_128(1)");
-    SuperVector<S> c = c1 | (c2.template vshr_128_imm<1>());
+    SuperVector<S> c = c1 | c2;
     c.print8("c");
 
     return c.eq(SuperVector<S>::Ones());


### PR DESCRIPTION
When one have a search pattern with two characters (eg "ab"), and the first character is the last character of a vector, then it triggers a match, regardless of whether or not the second character appear in the next vector. (so only 'a' is require to match)
This patch fix it.

The bug have been reproduced on neon, sve and x86.
To experience the bug, just reverse the order of the pattern in the benchmark ("ba" instead of "ab" and you'll notice it returns almost instantaneously)

It does produce a 16% slowdown though. It might be faster to process the string 15 chars at a time instead of 16 and thus saving a load each time, but it requires more change than I can do just now.