### PR TITLE
Fix 5.4.11's config step regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,19 @@ set_source_files_properties(
 
 ragelmaker(src/parser/control_verbs.rl)
 
+# BSD has the _np funcs in a _np header
+CHECK_INCLUDE_FILE_CXX(pthread_np.h HAVE_PTHREAD_NP_H)
+if (HAVE_PTHREAD_NP_H)
+    set (PTHREAD_NP_INC pthread_np.h)
+else ()
+    set (PTHREAD_NP_INC pthread.h)
+endif ()
+CHECK_CXX_SYMBOL_EXISTS(pthread_setaffinity_np ${PTHREAD_NP_INC} HAVE_DECL_PTHREAD_SETAFFINITY_NP)
+
+CHECK_FUNCTION_EXISTS(malloc_info HAVE_MALLOC_INFO)
+CHECK_FUNCTION_EXISTS(shmget HAVE_SHMGET)
+set(HAVE_SHMGET ${HAVE_SHMGET} CACHE BOOL "shmget()")
+
 # do substitutions
 configure_file(${CMAKE_MODULE_PATH}/config.h.in ${PROJECT_BINARY_DIR}/config.h)
 configure_file(src/hs_version.h.in ${PROJECT_BINARY_DIR}/hs_version.h)

--- a/tools/hsbench/CMakeLists.txt
+++ b/tools/hsbench/CMakeLists.txt
@@ -6,21 +6,9 @@ endif()
 
 include_directories(SYSTEM ${SQLITE3_INCLUDE_DIRS})
 
-# BSD has the _np funcs in a _np header
-CHECK_INCLUDE_FILE_CXX(pthread_np.h HAVE_PTHREAD_NP_H)
-if (HAVE_PTHREAD_NP_H)
-    set (PTHREAD_NP_INC pthread_np.h)
-else ()
-    set (PTHREAD_NP_INC pthread.h)
-endif ()
 
 set (CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -D_GNU_SOURCE")
 set (CMAKE_REQUIRED_LIBRARIES pthread)
-CHECK_CXX_SYMBOL_EXISTS(pthread_setaffinity_np ${PTHREAD_NP_INC} HAVE_DECL_PTHREAD_SETAFFINITY_NP)
-
-CHECK_FUNCTION_EXISTS(malloc_info HAVE_MALLOC_INFO)
-CHECK_FUNCTION_EXISTS(shmget HAVE_SHMGET)
-set(HAVE_SHMGET ${HAVE_SHMGET} CACHE BOOL "shmget()")
 
 # only set these after all tests are done
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_C_FLAGS}")


### PR DESCRIPTION
An old commit (24ae1670d) had the side effect of moving cmake defines after they were being used. This patch move them back to be defined before being used. Speed hsbench back up by ~ 0.8%