### PR TITLE
partial_load_u64 will fail if buf == NULL/c_len == 0

### DIFF
--- a/src/rose/program_runtime.c
+++ b/src/rose/program_runtime.c
@@ -688,7 +688,9 @@ int roseCheckMask(const struct core_info *ci, u64a and_mask, u64a cmp_mask,
                 shift_l = c_len - ci->len;
                 c_len = ci->len;
             }
-            data = partial_load_u64a(ci->buf, c_len);
+            if (c_len) {
+                data = partial_load_u64a(ci->buf, c_len);
+            }
             data <<= h_len << 3;
             data |= data_h;
         }


### PR DESCRIPTION
Though not often, it does cause segfaults in some tests. Better have a proper fix.