### PR TITLE
Clang 17+ is more restrictive on rebind<T> on MacOS/Boost, remove warning

### DIFF
--- a/cmake/cflags-generic.cmake
+++ b/cmake/cflags-generic.cmake
@@ -36,6 +36,11 @@ if(NETBSD)
     set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -DHAVE_BUILTIN_POPCOUNT")
 endif()
 
+if(MACOSX)
+    set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wno-deprecated-declarations")
+    set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 # these end up in the config file
 CHECK_C_COMPILER_FLAG(-fvisibility=hidden HAS_C_HIDDEN)
 CHECK_CXX_COMPILER_FLAG(-fvisibility=hidden HAS_CXX_HIDDEN)

--- a/cmake/cflags-generic.cmake
+++ b/cmake/cflags-generic.cmake
@@ -37,8 +37,9 @@ if(NETBSD)
 endif()
 
 if(MACOSX)
-    set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wno-deprecated-declarations")
-    set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-deprecated-declarations")
+    # Boost headers cause such complains on MacOS
+    set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wno-deprecated-declarations -Wno-unused-parameter")
+    set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-deprecated-declarations -Wno-unused-parameter")
 endif()
 
 # these end up in the config file

--- a/cmake/osdetection.cmake
+++ b/cmake/osdetection.cmake
@@ -17,6 +17,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
     set(NETBSD true)
 endif(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+endif()
+
 if (ARCH_IA32 OR ARCH_X86_64)
   option(FAT_RUNTIME "Build a library that supports multiple microarchitectures" ON)
 else()


### PR DESCRIPTION
Current MacOS builds fail, for example: 

https://buildbot-ci.vectorcamp.gr/#/builders/86/builds/326

This depends on Boost fixing this upstream and on homebrew, but in the long run we want to move away from Boost, for now we remove the warning on MacOS builds only.