### PR TITLE
Fix/fbsd gcc13 error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,14 @@ elseif (ARCH_ARM32 OR ARCH_AARCH64)
     include (${CMAKE_MODULE_PATH}/cflags-arm.cmake)
 elseif (ARCH_PPC64EL)
     include (${CMAKE_MODULE_PATH}/cflags-ppc64le.cmake)
+    
+    # fix unit-internal seg fault
+    if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+    endif()
+
 else ()
     message(FATAL_ERROR "Unsupported platform")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ elseif (ARCH_ARM32 OR ARCH_AARCH64)
 elseif (ARCH_PPC64EL)
     include (${CMAKE_MODULE_PATH}/cflags-ppc64le.cmake)
     
-    # fix unit-internal seg fault
+    # fix unit-internal seg fault for freebsd and gcc13
     if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -static-libstdc++")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,14 +141,6 @@ elseif (ARCH_ARM32 OR ARCH_AARCH64)
     include (${CMAKE_MODULE_PATH}/cflags-arm.cmake)
 elseif (ARCH_PPC64EL)
     include (${CMAKE_MODULE_PATH}/cflags-ppc64le.cmake)
-    
-    # fix unit-internal seg fault for freebsd and gcc13
-    if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -static-libstdc++")
-        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
-    endif()
-
 else ()
     message(FATAL_ERROR "Unsupported platform")
 endif ()

--- a/cmake/cflags-ppc64le.cmake
+++ b/cmake/cflags-ppc64le.cmake
@@ -16,3 +16,12 @@ int main() {
 if (NOT HAVE_VSX)
     message(FATAL_ERROR "VSX support required for Power support")
 endif ()
+
+# fix unit-internal seg fault for freebsd and gcc13
+if (FREEBSD AND CMAKE_COMPILER_IS_GNUCXX)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "13")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+    endif ()
+endif ()


### PR DESCRIPTION
Temporary fix for the segfault error on FreeBSD14 on Power8/Power9 with gcc 13, as seen here:

https://buildbot-ci.vectorcamp.gr/#/builders/200/builds/239