### PR TITLE
Improve the (cross-)build experience especially with LLVM

### DIFF
--- a/cmake/build_wrapper.sh
+++ b/cmake/build_wrapper.sh
@@ -5,6 +5,9 @@ cleanup () {
     rm -f ${SYMSFILE} ${KEEPSYMS}
 }
 
+NM="${NM:-nm}"
+OBJCOPY="${OBJCOPY:-objcopy}"
+
 PREFIX=$1
 KEEPSYMS_IN=$2
 shift 2
@@ -25,12 +28,12 @@ if [ `uname` = "FreeBSD" ]; then
 fi
 cp ${KEEPSYMS_IN} ${KEEPSYMS}
 # get all symbols from libc and turn them into patterns
-nm ${NM_FLAG} p -g -D ${LIBC_SO} | sed 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
+${NM} ${NM_FLAG} p -g -D ${LIBC_SO} | sed 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
 # build the object
 "$@"
 # rename the symbols in the object
-nm ${NM_FLAG} p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
+${NM} ${NM_FLAG} p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
 if test -s ${SYMSFILE}
 then
-    objcopy --redefine-syms=${SYMSFILE} ${OUT}
+    ${OBJCOPY} --redefine-syms=${SYMSFILE} ${OUT}
 fi

--- a/cmake/build_wrapper.sh
+++ b/cmake/build_wrapper.sh
@@ -28,11 +28,11 @@ if [ `uname` = "FreeBSD" ]; then
 fi
 cp ${KEEPSYMS_IN} ${KEEPSYMS}
 # get all symbols from libc and turn them into patterns
-${NM} ${NM_FLAG} p -g -D ${LIBC_SO} | sed 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
+${NM} ${NM_FLAG} posix -g -D ${LIBC_SO} | sed 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
 # build the object
 "$@"
 # rename the symbols in the object
-${NM} ${NM_FLAG} p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
+${NM} ${NM_FLAG} posix -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
 if test -s ${SYMSFILE}
 then
     ${OBJCOPY} --redefine-syms=${SYMSFILE} ${OUT}

--- a/cmake/cflags-generic.cmake
+++ b/cmake/cflags-generic.cmake
@@ -36,11 +36,9 @@ if(NETBSD)
     set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -DHAVE_BUILTIN_POPCOUNT")
 endif()
 
-if(MACOSX)
-    # Boost headers cause such complains on MacOS
-    set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wno-deprecated-declarations -Wno-unused-parameter")
-    set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-deprecated-declarations -Wno-unused-parameter")
-endif()
+# Boost headers cause such complains on MacOS or when building with LLVM toolchains
+set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wno-deprecated-declarations -Wno-unused-parameter")
+set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-deprecated-declarations -Wno-unused-parameter")
 
 # these end up in the config file
 CHECK_C_COMPILER_FLAG(-fvisibility=hidden HAS_C_HIDDEN)


### PR DESCRIPTION
This PR makes nm/objcopy selectable and enables building with LLVM toolchain for linux.

In the nixpkgs vectorscan package we currently do a string search and replace in `cmake/build_wrapper.sh` to select the correct `nm` or `objcopy` command. See [pkgs/by-name/ve/vectorscan/package.nix](https://github.com/NixOS/nixpkgs/blob/086b8fb31f8cbab212aa093fd4aa672970ff3212/pkgs/by-name/ve/vectorscan/package.nix#L32-L34). I assume others would have to do something similar, at least when doing some form of cross-compilation.

Disabling the "boost header compiler warnings" for all targets seems a bit hacky. But I haven't yet discovered a more elegant way.

I am open for feedback. :)
If desired, I can also split the PR or drop unwanted parts.
