### PR TITLE
cmake: add PKGCONFIG_EXTRA_LIBS option for pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ set(HAVE_SHMGET ${HAVE_SHMGET} CACHE BOOL "shmget()")
 configure_file(${CMAKE_MODULE_PATH}/config.h.in ${PROJECT_BINARY_DIR}/config.h)
 configure_file(src/hs_version.h.in ${PROJECT_BINARY_DIR}/hs_version.h)
 
+set(PKGCONFIG_EXTRA_LIBS "" CACHE STRING "Extra libraries to add to pkg-config Libs")
 configure_file(libhs.pc.in libhs.pc @ONLY) # only replace @ quoted vars
 install(FILES ${CMAKE_BINARY_DIR}/libhs.pc
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/chimera/libch.pc.in
+++ b/chimera/libch.pc.in
@@ -7,6 +7,6 @@ Name: libch
 Description: Intel(R) Chimera Library
 Version: @HS_VERSION@
 Requires.private: libhs
-Libs: -L${libdir} -lchimera
+Libs: -L${libdir} -lchimera @PKGCONFIG_EXTRA_LIBS@
 Libs.private: @PRIVATE_LIBS@
 Cflags: -I${includedir}/hs

--- a/libhs.pc.in
+++ b/libhs.pc.in
@@ -6,5 +6,5 @@ includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
 Name: libhs
 Description: A portable fork of the high-performance regular expression matching library
 Version: @HS_VERSION@
-Libs: -L${libdir} -lhs
+Libs: -L${libdir} -lhs @PKGCONFIG_EXTRA_LIBS@
 Cflags: -I${includedir}/hs


### PR DESCRIPTION
## Summary

This PR adds a `PKGCONFIG_EXTRA_LIBS` CMake cache variable that allows users to append arbitrary flags to the `Libs:` line in generated pkg-config files.

## Motivation

When using vectorscan with CGO (Go's C bindings) through a GCC-based toolchain (rather than g++), the linker fails because it doesn't automatically link the C++ standard library. The generated `.pc` files only specify `-lhs`, which is insufficient when the final link step uses a C compiler.

**Example error scenario:**
```
/usr/bin/ld: undefined reference to `std::__cxx11::basic_string...`
/usr/bin/ld: undefined reference to `operator new(unsigned long)'
```

With this change, users can specify the required dependencies:
```bash
cmake -DPKGCONFIG_EXTRA_LIBS="-lstdc++ -lm" ...
```

And `pkg-config --libs libhs` will correctly output:
```
-L/usr/local/lib -lhs -lstdc++ -lm
```

## Compatibility

This is a non-breaking change. The variable defaults to empty, so existing builds are unaffected.

---

Thank you for maintaining vectorscan! It's been invaluable for our cross-platform regex matching needs, and we appreciate the work that goes into keeping this project active and well-maintained.