### PR TITLE
sve2: Test SVE2 availability with both HWCAP_SVE and HWCAP2_SVE2

### DIFF
--- a/src/util/arch/arm/cpuid_inline.h
+++ b/src/util/arch/arm/cpuid_inline.h
@@ -60,7 +60,7 @@ int check_sve(void) {
 static inline
 int check_sve2(void) {
     unsigned long hwcap2 = getauxval(AT_HWCAP2);
-    if (hwcap2 & HWCAP2_SVE2) {
+    if (check_sve() && (hwcap2 & HWCAP2_SVE2)) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
hwcaps accidentally returns HWCAP2_SVE2 when only SME features are supported, not SVE. Note that this bug has been fixed on kernel mainline 6.14.

For more informations about this, see below:
https://lore.kernel.org/r/20250107-arm64-2024-dpisa-v6-1-7578da51fc3d@kernel.org

@AhnLab-OSS @AhnLab-OSSG