### PR TITLE
accel: Fix offset clamping in do_accel_block to not go before start

### DIFF
--- a/src/hwlm/hwlm.c
+++ b/src/hwlm/hwlm.c
@@ -97,16 +97,16 @@ void do_accel_block(const union AccelAux *aux, const u8 *buf, size_t len,
     const u8 *ptr = buf + *start;
     const u8 *end = buf + len;
     const u8 offset = aux->generic.offset;
-    ptr = run_hwlm_accel(aux, ptr, end);
+    const u8 *rv = run_hwlm_accel(aux, ptr, end);
 
     if (offset) {
-        ptr -= offset;
-        if (ptr < buf) {
-            ptr = buf;
+        rv -= offset;
+        if (rv < buf) {
+            rv = buf;
         }
     }
-    assert(ptr >= buf);
-    *start = ptr - buf;
+    assert(rv >= buf);
+    *start = rv - buf;
 }
 
 static really_inline


### PR DESCRIPTION
When applying the accel offset, the result was clamped to buf which could produce a position before *start, potentially causing the caller to re-scan bytes that were already processed. Clamp to ptr (buf + *start) instead, so that the accelerator never rewinds past the original start position.

@AhnLab-OSS @AhnLab-OSSG