### PR TITLE
shufti-double: Fix check_last_byte: use AND-reduce and fix loop bound

### DIFF
--- a/src/nfa/shufti_simd.hpp
+++ b/src/nfa/shufti_simd.hpp
@@ -207,11 +207,13 @@ const u8 *check_last_byte(SuperVector<S> mask2_lo, SuperVector<S> mask2_hi,
                     SuperVector<S> mask, uint8_t mask_len, const u8 *buf_end) {
     uint8_t last_elem = mask.u.u8[mask_len - 1];
 
-    SuperVector<S> reduce = mask2_lo | mask2_hi;
-    for(uint16_t i = S; i > 2; i/=2) {
-        reduce = reduce | reduce.vshr(i/2);
+    SuperVector<S> reduce_lo = mask2_lo;
+    SuperVector<S> reduce_hi = mask2_hi;
+    for(uint16_t i = S; i >= 2; i/=2) {
+        reduce_lo &= reduce_lo.vshr(i/2);
+        reduce_hi &= reduce_hi.vshr(i/2);
     }
-    uint8_t match_inverted = reduce.u.u8[0] | last_elem;
+    uint8_t match_inverted = reduce_lo.u.u8[0] | reduce_hi.u.u8[0] | last_elem;
 
     // if 0xff, then no match
     int match = match_inverted != 0xff;


### PR DESCRIPTION
The check_last_byte function had two bugs:

1. The loop condition i > 2 skipped the final vshr(1) step, causing only even-indexed bytes to be folded into the reduce result. Odd-indexed bytes of mask2_lo and mask2_hi were never included. Fixed by changing the loop condition to i >= 2.

2. The reduce operation used OR instead of AND. The purpose of the reduce is to compute a "wildcard" mask representing whether there exists any character that could match as the second byte of a double-byte pattern. For each bit b, we need: There exists lo that mask2_lo[lo].bit_b == 0, which is equivalent to AND-reduce(mask2_lo).bit_b == 0. Using OR-reduce caused the result to be nearly always 0xFF, making check_last_byte almost always return NULL and miss valid single-char matches at the buffer end.

Fixes: https://github.com/VectorCamp/vectorscan/issues/358

@AhnLab-OSS @AhnLab-OSSG