### PR TITLE
shufti-double: fix regressions from #325

### DIFF
--- a/src/nfa/accel.c
+++ b/src/nfa/accel.c
@@ -160,11 +160,12 @@ const u8 *run_accel(const union AccelAux *accel, const u8 *c, const u8 *c_end) {
             return c;
         }
 
-        /* need to stop one early to get an accurate end state */
+        /* Shufti double handles its own ending boundary checks internally
+         * to correctly identify matches at the last byte. */
         rv = shuftiDoubleExec(accel->dshufti.lo1,
                               accel->dshufti.hi1,
                               accel->dshufti.lo2,
-                              accel->dshufti.hi2, c, c_end - 1);
+                              accel->dshufti.hi2, c, c_end);
         break;
 
     case ACCEL_RED_TAPE:

--- a/src/nfa/shufti_simd.hpp
+++ b/src/nfa/shufti_simd.hpp
@@ -208,7 +208,7 @@ const u8 *check_last_byte(SuperVector<S> mask2_lo, SuperVector<S> mask2_hi,
     uint8_t last_elem = mask.u.u8[mask_len - 1];
 
     SuperVector<S> reduce = mask2_lo | mask2_hi;
-    for(uint16_t i = S; i > 2; i/=2) {
+    for(uint16_t i = S; i >= 2; i/=2) {
         reduce = reduce | reduce.vshr(i/2);
     }
     uint8_t match_inverted = reduce.u.u8[0] | last_elem;

--- a/src/nfa/shufti_simd.hpp
+++ b/src/nfa/shufti_simd.hpp
@@ -260,7 +260,6 @@ const u8 *shuftiDoubleExecReal(m128 mask1_lo, m128 mask1_hi, m128 mask2_lo, m128
             first_char_mask.print8("inout_c1 shifted");
         }
 
-        first_char_mask = SuperVector<S>::Ones();
         while(d + S <= buf_end) {
             __builtin_prefetch(d + 64);
             DEBUG_PRINTF("d %p \n", d);

--- a/unit/internal/shufti.cpp
+++ b/unit/internal/shufti.cpp
@@ -990,6 +990,94 @@ TEST(DoubleShufti, ExecNoOverreadPageBoundary) {
     munmap(pages, page_size);
 }
 
+TEST(DoubleShufti, ExecMatchVectorEdge) {
+    m128 lo1, hi1, lo2, hi2;
+
+    flat_set<pair<u8, u8>> lits;
+    lits.insert(make_pair('a', 'b'));
+
+    bool ret = shuftiBuildDoubleMasks(CharReach(), lits, reinterpret_cast<u8 *>(&lo1), reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2), reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    const int len = 80;
+    const int vector_size = 16;
+    for (size_t start = 1; start < vector_size; start++) {
+        char t[len];
+        memset(t, 'z', len);
+        char *buf = t + start;
+        int buf_len = len - start;
+
+        uintptr_t aligned = (reinterpret_cast<uintptr_t>(buf) + vector_size - 1) &
+                            ~static_cast<uintptr_t>(vector_size - 1);
+        ptrdiff_t boundary = reinterpret_cast<const char *>(aligned) - buf;
+
+        if (boundary < 1 || boundary >= buf_len - 1) continue;
+
+        buf[boundary - 1] = 'a';
+        buf[boundary] = 'b';
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(buf),
+                                        reinterpret_cast<u8 *>(buf) + buf_len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(buf + boundary - 1), rv)
+            << "Failed for start=" << start << " boundary=" << boundary;
+    }
+}
+
+TEST(DoubleShufti, ExecNoMatchLastByte) {
+    m128 lo1, hi1, lo2, hi2;
+
+    flat_set<pair<u8, u8>> lits;
+    lits.insert(make_pair('x', 'y'));
+
+    bool ret = shuftiBuildDoubleMasks(CharReach(), lits, reinterpret_cast<u8 *>(&lo1), reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2), reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    const int maxlen = 80;
+    char t1[maxlen + 1];
+    for (int len = 17; len < maxlen; len++) {
+        memset(t1, 'b', len + 1);
+        t1[len - 1] = 'x';
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(t1),
+                                        reinterpret_cast<u8 *>(t1) + len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len), rv)
+            << "Failed for len=" << len;
+    }
+}
+
+TEST(DoubleShufti, ExecMatchLastByte) {
+    m128 lo1, hi1, lo2, hi2;
+
+    CharReach onebyte;
+    flat_set<pair<u8, u8>> twobyte;
+
+    onebyte.set('a');
+    twobyte.insert(make_pair('x', 'y'));
+
+    bool ret = shuftiBuildDoubleMasks(onebyte, twobyte, reinterpret_cast<u8 *>(&lo1), reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2), reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    const int maxlen = 80;
+    char t1[maxlen + 1];
+    for (int len = 17; len < maxlen; len++) {
+        memset(t1, 'b', len + 1);
+        t1[len - 1] = 'a';
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(t1),
+                                        reinterpret_cast<u8 *>(t1) + len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len - 1), rv);
+    }
+}
+
 TEST(ReverseShufti, ExecNoMatch1) {
     m128 lo, hi;
 


### PR DESCRIPTION
1. As reported in #358, #325 introduced a false negative. The caller side told the buffer length as c_end - 1, so that shuftiDoubleExec() unexpectedly tried to match the byte before the last byte with single char patterns.

2. check_last_byte() reduces the mask to make a wildcard mask, which matches any character that could match as the second byte of a double-byte pattern. However, the loop condition i > 2 skipped the final vshr(1) step, causing only even-indexed bytes to be folded into the reduce result.

3. After peel-off stage for alignment, the carry-over state was discarded.

4. Add some unit tests for this fixes.

@AhnLab-OSS @AhnLab-OSSG