### PR TITLE
Supervector fixes v2

### DIFF
--- a/src/nfa/arm/shufti.hpp
+++ b/src/nfa/arm/shufti.hpp
@@ -41,7 +41,7 @@ const SuperVector<S> blockSingleMask(SuperVector<S> mask_lo, SuperVector<S> mask
     c_lo = mask_lo.template pshufb<false>(c_lo);
     c_hi = mask_hi.template pshufb<false>(c_hi);
 
-    return (c_lo & c_hi) > (SuperVector<S>::Zeroes());
+    return (c_lo & c_hi) != (SuperVector<S>::Zeroes());
 }
 
 template <uint16_t S>

--- a/src/util/supervector/arch/arm/impl.cpp
+++ b/src/util/supervector/arch/arm/impl.cpp
@@ -227,7 +227,7 @@ really_inline SuperVector<16> SuperVector<16>::operator>(SuperVector<16> const &
 template <>
 really_inline SuperVector<16> SuperVector<16>::operator>=(SuperVector<16> const &b) const
 {
-    return SuperVector<16>(vcgeq_u8(u.u8x16[0], b.u.u8x16[0]));
+    return SuperVector<16>(vcgeq_s8(u.s8x16[0], b.u.s8x16[0]));
 }
 
 template <>
@@ -239,7 +239,7 @@ really_inline SuperVector<16> SuperVector<16>::operator<(SuperVector<16> const &
 template <>
 really_inline SuperVector<16> SuperVector<16>::operator<=(SuperVector<16> const &b) const
 {
-    return SuperVector<16>(vcgeq_s8(u.s8x16[0], b.u.s8x16[0]));
+    return SuperVector<16>(vcleq_s8(u.s8x16[0], b.u.s8x16[0]));
 }
 
 template <>
@@ -374,7 +374,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_8  (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 8) return Zeroes();
+    if (N >= 8) return Zeroes();
     int8x16_t shift_indices = vdupq_n_s8(N);
     return SuperVector<16>(vshlq_s8(u.s8x16[0], shift_indices));
 }
@@ -383,7 +383,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_16 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 16) return Zeroes();
     int16x8_t shift_indices = vdupq_n_s16(N);
     return SuperVector<16>(vshlq_s16(u.s16x8[0], shift_indices));
 }
@@ -392,7 +392,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_32 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 32) return Zeroes();
+    if (N >= 32) return Zeroes();
     int32x4_t shift_indices = vdupq_n_s32(N);
     return SuperVector<16>(vshlq_s32(u.s32x4[0], shift_indices));
 }
@@ -401,7 +401,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_64 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 64) return Zeroes();
+    if (N >= 64) return Zeroes();
     int64x2_t shift_indices = vdupq_n_s64(N);
     return SuperVector<16>(vshlq_s64(u.s64x2[0], shift_indices));
 }
@@ -410,7 +410,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_128(uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 16) return Zeroes();
 #if defined(HAVE__BUILTIN_CONSTANT_P)
     if (__builtin_constant_p(N)) {
         return SuperVector<16>(vextq_u8(vdupq_n_u8(0), u.u8x16[0], 16 - N));
@@ -431,43 +431,43 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_8  (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 8) return Zeroes();
+    if (N >= 8) return Zeroes();
     int8x16_t shift_indices = vdupq_n_s8(-N);
-    return SuperVector<16>(vshlq_s8(u.s8x16[0], shift_indices));
+    return SuperVector<16>(vshlq_u8(u.u8x16[0], shift_indices));
 }
 
 template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_16 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 16) return Zeroes();
     int16x8_t shift_indices = vdupq_n_s16(-N);
-    return SuperVector<16>(vshlq_s16(u.s16x8[0], shift_indices));
+    return SuperVector<16>(vshlq_u16(u.u16x8[0], shift_indices));
 }
 
 template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_32 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 32) return Zeroes();
+    if (N >= 32) return Zeroes();
     int32x4_t shift_indices = vdupq_n_s32(-N);
-    return SuperVector<16>(vshlq_s32(u.s32x4[0], shift_indices));
+    return SuperVector<16>(vshlq_u32(u.u32x4[0], shift_indices));
 }
 
 template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_64 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 64) return Zeroes();
+    if (N >= 64) return Zeroes();
     int64x2_t shift_indices = vdupq_n_s64(-N);
-    return SuperVector<16>(vshlq_s64(u.s64x2[0], shift_indices));
+    return SuperVector<16>(vshlq_u64(u.u64x2[0], shift_indices));
 }
 
 template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_128(uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 16) return Zeroes();
 #if defined(HAVE__BUILTIN_CONSTANT_P)
     if (__builtin_constant_p(N)) {
          return SuperVector<16>(vextq_u8(u.u8x16[0], vdupq_n_u8(0), N));

--- a/src/util/supervector/arch/ppc64el/impl.cpp
+++ b/src/util/supervector/arch/ppc64el/impl.cpp
@@ -221,7 +221,7 @@ really_inline SuperVector<16> SuperVector<16>::operator^(SuperVector<16> const &
 template <>
 really_inline SuperVector<16> SuperVector<16>::operator!() const
 {
-    return  SuperVector<16>(vec_xor(u.v128[0], u.v128[0]));
+    return  SuperVector<16>(vec_xor(u.s8x16[0], vec_splat_s8(-1)));
 }
 
 template <>
@@ -410,6 +410,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_8  (uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 8) return Zeroes();
     uint8x16_t shift_indices = vec_splats((uint8_t) N);
     return SuperVector<16>(vec_sl(u.u8x16[0], shift_indices));
 }
@@ -418,6 +419,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_16 (uint8_t const UNUSED N) const
 {
     if (N == 0) return *this;
+    if (N >= 16) return Zeroes();
     uint16x8_t shift_indices = vec_splats((uint16_t) N);
     return SuperVector<16>(vec_sl(u.u16x8[0], shift_indices));
 }
@@ -426,6 +428,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_32 (uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 32) return Zeroes();
     uint32x4_t shift_indices = vec_splats((uint32_t) N);
     return SuperVector<16>(vec_sl(u.u32x4[0], shift_indices));
 }
@@ -434,6 +437,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_64 (uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 64) return Zeroes();
     uint64x2_t shift_indices = vec_splats((ulong64_t) N);
     return SuperVector<16>(vec_sl(u.u64x2[0], shift_indices));
 }
@@ -442,6 +446,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshl_128(uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 16) return Zeroes();
     SuperVector sl{N << 3};
     return SuperVector<16>(vec_slo(u.u8x16[0], sl.u.u8x16[0]));
 }
@@ -456,6 +461,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_8  (uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 8) return Zeroes();
     uint8x16_t shift_indices = vec_splats((uint8_t) N);
     return SuperVector<16>(vec_sr(u.u8x16[0], shift_indices));
 }
@@ -464,6 +470,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_16 (uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 16) return Zeroes();
     uint16x8_t shift_indices = vec_splats((uint16_t) N);
     return SuperVector<16>(vec_sr(u.u16x8[0], shift_indices));
 }
@@ -472,6 +479,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_32 (uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 32) return Zeroes();
     uint32x4_t shift_indices = vec_splats((uint32_t) N);
     return SuperVector<16>(vec_sr(u.u32x4[0], shift_indices));
 }
@@ -480,6 +488,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_64 (uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 64) return Zeroes();
     uint64x2_t shift_indices = vec_splats((ulong64_t) N);
     return SuperVector<16>(vec_sr(u.u64x2[0], shift_indices));
 }
@@ -488,6 +497,7 @@ template <>
 really_inline SuperVector<16> SuperVector<16>::vshr_128(uint8_t const N) const
 {
     if (N == 0) return *this;
+    if (N >= 16) return Zeroes();
     SuperVector sr{N << 3};
     return SuperVector<16>(vec_sro(u.u8x16[0], sr.u.u8x16[0]));
 }
@@ -501,8 +511,9 @@ really_inline SuperVector<16> SuperVector<16>::vshr(uint8_t const N) const
 template <>
 really_inline SuperVector<16> SuperVector<16>::operator>>(uint8_t const N) const
 {
-#if defined(HAVE__BUILTIN_CONSTANT_P)
     if (N == 0) return *this;
+    if (N >= 16) return Zeroes();
+#if defined(HAVE__BUILTIN_CONSTANT_P)
     if (__builtin_constant_p(N)) {
         return SuperVector<16>(vec_sld(vec_splat_s8(0),  u.s8x16[0], 16 - N));
     }
@@ -513,8 +524,9 @@ really_inline SuperVector<16> SuperVector<16>::operator>>(uint8_t const N) const
 template <>
 really_inline SuperVector<16> SuperVector<16>::operator<<(uint8_t const N) const
 {
-#if defined(HAVE__BUILTIN_CONSTANT_P)
     if (N == 0) return *this;
+    if (N >= 16) return Zeroes();
+#if defined(HAVE__BUILTIN_CONSTANT_P)
     if (__builtin_constant_p(N)) {
         return SuperVector<16>(vec_sld(u.s8x16[0], vec_splat_s8(0), N));
     }

--- a/src/util/supervector/arch/x86/impl.cpp
+++ b/src/util/supervector/arch/x86/impl.cpp
@@ -151,7 +151,7 @@ really_inline SuperVector<16> SuperVector<16>::operator^(SuperVector<16> const &
 template <>
 really_inline SuperVector<16> SuperVector<16>::operator!() const
 {
-    return SuperVector<16>(_mm_xor_si128(u.v128[0], u.v128[0]));
+    return SuperVector<16>(_mm_xor_si128(u.v128[0], _mm_set1_epi8(0xFF)));
 }
 
 template <>
@@ -352,9 +352,9 @@ really_inline SuperVector<16> SuperVector<16>::vshl_32 (uint8_t const N) const
     }
 #endif
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 32) return Zeroes();
     SuperVector result;
-    Unroller<1, 16>::iterator([&,v=this](auto const i) { if (N == i.value) result = {SuperVector<16>(_mm_slli_epi32(v->u.v128[0], i.value))}; });
+    Unroller<1, 32>::iterator([&,v=this](auto const i) { if (N == i.value) result = {SuperVector<16>(_mm_slli_epi32(v->u.v128[0], i.value))}; });
     return result;
 }
 
@@ -367,9 +367,9 @@ really_inline SuperVector<16> SuperVector<16>::vshl_64 (uint8_t const N) const
     }
 #endif
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 64) return Zeroes();
     SuperVector result;
-    Unroller<1, 16>::iterator([&,v=this](auto const i) { if (N == i.value) result = {SuperVector<16>(_mm_slli_epi64(v->u.v128[0], i.value))}; });
+    Unroller<1, 64>::iterator([&,v=this](auto const i) { if (N == i.value) result = {SuperVector<16>(_mm_slli_epi64(v->u.v128[0], i.value))}; });
     return result;
 }
 
@@ -427,9 +427,9 @@ really_inline SuperVector<16> SuperVector<16>::vshr_32 (uint8_t const N) const
     }
 #endif
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 32) return Zeroes();
     SuperVector result;
-    Unroller<1, 16>::iterator([&,v=this](auto const i) { if (N == i.value) result = {SuperVector<16>(_mm_srli_epi32(v->u.v128[0], i.value))}; });
+    Unroller<1, 32>::iterator([&,v=this](auto const i) { if (N == i.value) result = {SuperVector<16>(_mm_srli_epi32(v->u.v128[0], i.value))}; });
     return result;
 }
 
@@ -442,9 +442,9 @@ really_inline SuperVector<16> SuperVector<16>::vshr_64 (uint8_t const N) const
     }
 #endif
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 64) return Zeroes();
     SuperVector result;
-    Unroller<1, 16>::iterator([&,v=this](auto const i) { if (N == i.value) result = {SuperVector<16>(_mm_srli_epi64(v->u.v128[0], i.value))}; });
+    Unroller<1, 64>::iterator([&,v=this](auto const i) { if (N == i.value) result = {SuperVector<16>(_mm_srli_epi64(v->u.v128[0], i.value))}; });
     return result;
 }
 
@@ -502,7 +502,7 @@ template<>
 really_inline SuperVector<16> SuperVector<16>::Ones_vshl(uint8_t const N)
 {
     if (N == 0) return Ones();
-    else return Ones().vshr_128(N);
+    else return Ones().vshl_128(N);
 }
 
 template <>
@@ -710,7 +710,7 @@ really_inline SuperVector<32> SuperVector<32>::operator^(SuperVector<32> const &
 template <>
 really_inline SuperVector<32> SuperVector<32>::operator!() const
 {
-    return SuperVector<32>(_mm256_xor_si256(u.v256[0], u.v256[0]));
+    return SuperVector<32>(_mm256_xor_si256(u.v256[0], _mm256_set1_epi8(0xFF)));
 }
 
 template <>
@@ -882,7 +882,7 @@ really_inline SuperVector<32> SuperVector<32>::vshr_256_imm() const
     if constexpr (N == 16) return {SuperVector<32>(_mm256_permute2x128_si256(u.v256[0], u.v256[0], _MM_SHUFFLE(2, 0, 0, 1)))};
     if constexpr (N == 32) return Zeroes();
     if constexpr (N < 16) {
-        return {SuperVector<32>(_mm256_alignr_epi8(u.v256[0], _mm256_permute2x128_si256(u.v256[0], u.v256[0], _MM_SHUFFLE(0, 0, 2, 0)), 16 - N))};
+        return {SuperVector<32>(_mm256_alignr_epi8(_mm256_permute2x128_si256(u.v256[0], u.v256[0], _MM_SHUFFLE(2, 0, 0, 1)), u.v256[0], N))};
     } else {
         return {SuperVector<32>(_mm256_srli_si256(_mm256_permute2x128_si256(u.v256[0], u.v256[0], _MM_SHUFFLE(2, 0, 0, 1)), N - 16))};
     }
@@ -901,6 +901,7 @@ template SuperVector<32> SuperVector<32>::vshl_64_imm<1>() const;
 template SuperVector<32> SuperVector<32>::vshl_64_imm<4>() const;
 template SuperVector<32> SuperVector<32>::vshl_128_imm<1>() const;
 template SuperVector<32> SuperVector<32>::vshl_128_imm<4>() const;
+template SuperVector<32> SuperVector<32>::vshl_imm<1>() const;
 template SuperVector<32> SuperVector<32>::vshr_16_imm<1>() const;
 template SuperVector<32> SuperVector<32>::vshr_64_imm<1>() const;
 template SuperVector<32> SuperVector<32>::vshr_64_imm<4>() const;
@@ -941,9 +942,9 @@ template <>
 really_inline SuperVector<32> SuperVector<32>::vshl_64 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 32) return Zeroes();
+    if (N >= 64) return Zeroes();
     SuperVector result;
-    Unroller<1, 32>::iterator([&,v=this](auto const i) { constexpr uint8_t n = i.value; if (N == n) result = {SuperVector<32>(_mm256_slli_epi64(v->u.v256[0], n))}; });
+    Unroller<1, 64>::iterator([&,v=this](auto const i) { constexpr uint8_t n = i.value; if (N == n) result = {SuperVector<32>(_mm256_slli_epi64(v->u.v256[0], n))}; });
     return result;
 }
 
@@ -1014,9 +1015,9 @@ template <>
 really_inline SuperVector<32> SuperVector<32>::vshr_64 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 32) return Zeroes();
+    if (N >= 64) return Zeroes();
     SuperVector result;
-    Unroller<1, 32>::iterator([&,v=this](auto const i) { constexpr uint8_t n = i.value; if (N == n) result = {SuperVector<32>(_mm256_srli_epi64(v->u.v256[0], n))}; });
+    Unroller<1, 64>::iterator([&,v=this](auto const i) { constexpr uint8_t n = i.value; if (N == n) result = {SuperVector<32>(_mm256_srli_epi64(v->u.v256[0], n))}; });
     return result;
 }
 
@@ -1314,7 +1315,7 @@ really_inline SuperVector<64> SuperVector<64>::operator^(SuperVector<64> const &
 template <>
 really_inline SuperVector<64> SuperVector<64>::operator!() const
 {
-    return {SuperVector<64>(_mm512_xor_si512(u.v512[0], u.v512[0]))};
+    return {SuperVector<64>(_mm512_xor_si512(u.v512[0], _mm512_set1_epi8(0xFF)))};
 }
 
 template <>
@@ -1440,14 +1441,36 @@ template <>
 template<uint8_t N>
 really_inline SuperVector<64> SuperVector<64>::vshl_256_imm() const
 {
-    return {};
+    if constexpr (N == 0) return *this;
+    if constexpr (N >= 32) return Zeroes();
+    SuperVector<32> lo(u.v256[0]);
+    SuperVector<32> hi(u.v256[1]);
+    return SuperVector<64>(lo.template vshl_256_imm<N>(), hi.template vshl_256_imm<N>());
 }
 
 template <>
 template<uint8_t N>
 really_inline SuperVector<64> SuperVector<64>::vshl_512_imm() const
 {
-    return {};
+    if constexpr (N == 0) return *this;
+    if constexpr (N < 32) {
+        SuperVector<32> lo256 = SuperVector<32>(u.v256[0]);
+        SuperVector<32> hi256 = SuperVector<32>(u.v256[1]);
+        SuperVector<32> carry = lo256 >> (32 - N);
+        lo256 = lo256 << N;
+        hi256 = (hi256 << N) | carry;
+        return SuperVector<64>(lo256, hi256);
+    }
+    if constexpr (N == 32) {
+        SuperVector<32> lo256 = SuperVector<32>(u.v256[0]);
+        return SuperVector<64>(SuperVector<32>::Zeroes(), lo256);
+    }
+    if constexpr (N < 64) {
+        SuperVector<32> lo256 = SuperVector<32>(u.v256[0]);
+        return SuperVector<64>(SuperVector<32>::Zeroes(), lo256 << (N - 32));
+    } else {
+        return Zeroes();
+    }
 }
 
 template <>
@@ -1497,13 +1520,10 @@ template<uint8_t N>
 really_inline SuperVector<64> SuperVector<64>::vshr_256_imm() const
 {
     if constexpr (N == 0) return *this;
-    if constexpr (N == 16) return {SuperVector<64>(_mm256_permute2x128_si256(u.v256[0], u.v256[0], _MM_SHUFFLE(2, 0, 0, 1)))};
-    if constexpr (N == 32) return Zeroes();
-    if constexpr (N < 16) {
-        return {SuperVector<64>(_mm256_alignr_epi8(u.v256[0], _mm256_permute2x128_si256(u.v256[0], u.v256[0], _MM_SHUFFLE(0, 0, 2, 0)), 16 - N))};
-    } else {
-        return {SuperVector<64>(_mm256_srli_si256(_mm256_permute2x128_si256(u.v256[0], u.v256[0], _MM_SHUFFLE(2, 0, 0, 1)), N - 16))};
-    }
+    if constexpr (N >= 32) return Zeroes();
+    SuperVector<32> lo(u.v256[0]);
+    SuperVector<32> hi(u.v256[1]);
+    return SuperVector<64>(lo.template vshr_256_imm<N>(), hi.template vshr_256_imm<N>());
 }
 
 template <>
@@ -1601,13 +1621,39 @@ really_inline SuperVector<64> SuperVector<64>::vshl_128(uint8_t const N) const
 template <>
 really_inline SuperVector<64> SuperVector<64>::vshl_256(uint8_t const N) const
 {
-    return vshl_128(N);
+    if (N == 0) return *this;
+    if (N >= 32) return Zeroes();
+    SuperVector<64> result;
+    Unroller<1, 32>::iterator([&,v=this](auto const i) {
+        constexpr uint8_t n = i.value;
+        if (N == n) result = SuperVector<64>(SuperVector<32>(v->u.v256[0]).vshl(n),
+                                             SuperVector<32>(v->u.v256[1]).vshl(n));
+    });
+    return result;
 }
 
 template <>
 really_inline SuperVector<64> SuperVector<64>::vshl_512(uint8_t const N) const
 {
-    return vshl_128(N);
+    if (N == 0) return *this;
+    if (N >= 64) return Zeroes();
+    SuperVector<64> result;
+    Unroller<1, 32>::iterator([&,v=this](auto const i) {
+        constexpr uint8_t n = i.value;
+        if (N == n) {
+            SuperVector<32> lo(v->u.v256[0]);
+            SuperVector<32> hi(v->u.v256[1]);
+            result = SuperVector<64>(lo.vshl(n), hi.vshl(n) | lo.vshr(32 - n));
+        }
+    });
+    Unroller<32, 64>::iterator([&,v=this](auto const i) {
+        constexpr uint8_t n = i.value;
+        if (N == n) {
+            SuperVector<32> lo(v->u.v256[0]);
+            result = SuperVector<64>(SuperVector<32>::Zeroes(), lo.vshl(n - 32));
+        }
+    });
+    return result;
 }
 
 template <>
@@ -1649,7 +1695,7 @@ template <>
 really_inline SuperVector<64> SuperVector<64>::vshr_64 (uint8_t const N) const
 {
     if (N == 0) return *this;
-    if (N == 16) return Zeroes();
+    if (N >= 64) return Zeroes();
     SuperVector result;
     Unroller<1, 64>::iterator([&,v=this](auto const i) { constexpr uint8_t n = i.value; if (N == n) result = {SuperVector<64>(_mm512_srli_epi64(v->u.v512[0], n))}; });
     return result;
@@ -1668,13 +1714,39 @@ really_inline SuperVector<64> SuperVector<64>::vshr_128(uint8_t const N) const
 template <>
 really_inline SuperVector<64> SuperVector<64>::vshr_256(uint8_t const N) const
 {
-    return vshr_128(N);
+    if (N == 0) return *this;
+    if (N >= 32) return Zeroes();
+    SuperVector<64> result;
+    Unroller<1, 32>::iterator([&,v=this](auto const i) {
+        constexpr uint8_t n = i.value;
+        if (N == n) result = SuperVector<64>(SuperVector<32>(v->u.v256[0]).vshr(n),
+                                             SuperVector<32>(v->u.v256[1]).vshr(n));
+    });
+    return result;
 }
 
 template <>
 really_inline SuperVector<64> SuperVector<64>::vshr_512(uint8_t const N) const
 {
-    return vshr_128(N);
+    if (N == 0) return *this;
+    if (N >= 64) return Zeroes();
+    SuperVector<64> result;
+    Unroller<1, 32>::iterator([&,v=this](auto const i) {
+        constexpr uint8_t n = i.value;
+        if (N == n) {
+            SuperVector<32> lo(v->u.v256[0]);
+            SuperVector<32> hi(v->u.v256[1]);
+            result = SuperVector<64>(lo.vshr(n) | hi.vshl(32 - n), hi.vshr(n));
+        }
+    });
+    Unroller<32, 64>::iterator([&,v=this](auto const i) {
+        constexpr uint8_t n = i.value;
+        if (N == n) {
+            SuperVector<32> hi(v->u.v256[1]);
+            result = SuperVector<64>(hi.vshr(n - 32), SuperVector<32>::Zeroes());
+        }
+    });
+    return result;
 }
 
 template <>

--- a/unit/internal/supervector.cpp
+++ b/unit/internal/supervector.cpp
@@ -92,6 +92,41 @@ TEST(SuperVectorUtilsTest,Equal128c){
     }
 }
 
+TEST(SuperVectorUtilsTest,NotEqual128c) {
+    u8 a[16], b[16];
+    for (int i = 0; i < 16; i++) { a[i] = static_cast<u8>(i); b[i] = static_cast<u8>(i); }
+    b[0] = 0xFF;
+    b[7] = 0xFF;
+    auto va = SuperVector<16>::loadu(a);
+    auto vb = SuperVector<16>::loadu(b);
+    auto ne = (va != vb);
+    for (int i = 0; i < 16; i++) {
+        if (a[i] != b[i]) {
+            ASSERT_EQ(ne.u.u8[i], 0xFF) << "byte " << i;
+        } else {
+            ASSERT_EQ(ne.u.u8[i], 0x00) << "byte " << i;
+        }
+    }
+}
+
+TEST(SuperVectorUtilsTest,Not128c) {
+    auto notZ = !SuperVector<16>::Zeroes();
+    for (int i = 0; i < 16; i++) {
+        ASSERT_EQ(notZ.u.u8[i], 0xFF);
+    }
+    auto notO = !SuperVector<16>::Ones();
+    for (int i = 0; i < 16; i++) {
+        ASSERT_EQ(notO.u.u8[i], 0x00);
+    }
+    u8 vec[16];
+    for (int i = 0; i < 16; i++) { vec[i] = static_cast<u8>(i * 17); }
+    auto v = SuperVector<16>::loadu(vec);
+    auto nv = !v;
+    for (int i = 0; i < 16; i++) {
+        ASSERT_EQ(nv.u.u8[i], static_cast<u8>(~vec[i]));
+    }
+}
+
 TEST(SuperVectorUtilsTest,And128c){
     auto SPResult = SuperVector<16>::Zeroes() & SuperVector<16>::Ones();
     for (int i=0; i<16; i++) {
@@ -353,6 +388,99 @@ TEST(SuperVectorUtilsTest,RShift128_128c){
     }
 }
 
+TEST(SuperVectorUtilsTest,OnesLShift_128c) {
+    for (int n = 0; n <= 16; n++) {
+        auto m = SuperVector<16>::Ones_vshl(static_cast<u8>(n));
+        for (int i = 0; i < 16; i++) {
+            if (i < n) {
+                ASSERT_EQ(m.u.u8[i], 0x00) << "n=" << n << " i=" << i;
+            } else {
+                ASSERT_EQ(m.u.u8[i], 0xFF) << "n=" << n << " i=" << i;
+            }
+        }
+    }
+}
+
+TEST(SuperVectorUtilsTest,OnesLShiftVsRShift_128c) {
+    for (int n = 1; n < 16; n++) {
+        auto vl = SuperVector<16>::Ones_vshl(static_cast<u8>(n));
+        auto vr = SuperVector<16>::Ones_vshr(static_cast<u8>(n));
+        bool differ = false;
+        for (int i = 0; i < 16; i++) {
+            if (vl.u.u8[i] != vr.u.u8[i]) { differ = true; break; }
+        }
+        ASSERT_TRUE(differ) << "Ones_vshl and Ones_vshr identical at n=" << n;
+    }
+}
+
+TEST(SuperVectorUtilsTest,LShift32_128c) {
+    u32 data[4] = {0x12345678, 0xAABBCCDD, 0x01020304, 0xDEADBEEF};
+    auto v = SuperVector<16>::loadu(data);
+    auto shifted = v.vshl_32(20);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u32[i], data[i] << 20) << "i=" << i;
+    }
+    shifted = v.vshl_32(31);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u32[i], data[i] << 31) << "i=" << i;
+    }
+    shifted = v.vshl_32(32);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u32[i], 0u) << "i=" << i;
+    }
+}
+
+TEST(SuperVectorUtilsTest, RShift32_128c) {
+    u32 data[4] = {0x12345678, 0xAABBCCDD, 0x01020304, 0xDEADBEEF};
+    auto v = SuperVector<16>::loadu(data);
+    auto shifted = v.vshr_32(20);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u32[i], data[i] >> 20) << "i=" << i;
+    }
+    shifted = v.vshr_32(31);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u32[i], data[i] >> 31) << "i=" << i;
+    }
+    shifted = v.vshr_32(32);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u32[i], 0u) << "i=" << i;
+    }
+}
+
+TEST(SuperVectorUtilsTest,Lshift64_128c) {
+    u64a data[2] = {0x123456789ABCDEF0ULL, 0xFEDCBA9876543210ULL};
+    auto v = SuperVector<16>::loadu(data);
+    auto shifted = v.vshl_64(32);
+    for (int i = 0; i < 2; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] << 32) << "i=" << i;
+    }
+    shifted = v.vshl_64(63);
+    for (int i = 0; i < 2; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] << 63) << "i=" << i;
+    }
+    shifted = v.vshl_64(64);
+    for (int i = 0; i < 2; i++) {
+        ASSERT_EQ(shifted.u.u64[i], 0ULL) << "i=" << i;
+    }
+}
+
+TEST(SuperVectorUtilsTest,Rshift64_128c) {
+    u64a data[2] = {0x123456789ABCDEF0ULL, 0xFEDCBA9876543210ULL};
+    auto v = SuperVector<16>::loadu(data);
+    auto shifted = v.vshr_64(32);
+    for (int i = 0; i < 2; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] >> 32) << "i=" << i;
+    }
+    shifted = v.vshr_64(63);
+    for (int i = 0; i < 2; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] >> 63) << "i=" << i;
+    }
+    shifted = v.vshr_64(64);
+    for (int i = 0; i < 2; i++) {
+        ASSERT_EQ(shifted.u.u64[i], 0ULL) << "i=" << i;
+    }
+}
+
 /*Define ALIGNR128 macro*/
 #define TEST_ALIGNR128(v1, v2, buf, l) {                                                 \
                                            auto v_aligned = v2.alignr(v1, l);            \
@@ -430,6 +558,41 @@ TEST(SuperVectorUtilsTest,Equal256c){
     auto SPResult = SP1.eq(SP2);
     for (int i=0; i<32; i++) {
         ASSERT_EQ(SPResult.u.s8[i],buf[i]);
+    }
+}
+
+TEST(SuperVectorUtilsTest,NotEqual256c) {
+    u8 a[32], b[32];
+    for (int i = 0; i < 32; i++) { a[i] = static_cast<u8>(i); b[i] = static_cast<u8>(i); }
+    b[0] = 0xFF;
+    b[31] = 0xFF;
+    auto va = SuperVector<32>::loadu(a);
+    auto vb = SuperVector<32>::loadu(b);
+    auto ne = (va != vb);
+    for (int i = 0; i < 32; i++) {
+        if (a[i] != b[i]) {
+            ASSERT_EQ(ne.u.u8[i], 0xFF) << "byte " << i;
+        } else {
+            ASSERT_EQ(ne.u.u8[i], 0x00) << "byte " << i;
+        }
+    }
+}
+
+TEST(SuperVectorUtilsTest,Not256c) {
+    auto notZ = !SuperVector<32>::Zeroes();
+    for (int i = 0; i < 32; i++) {
+        ASSERT_EQ(notZ.u.u8[i], 0xFF);
+    }
+    auto notO = !SuperVector<32>::Ones();
+    for (int i = 0; i < 32; i++) {
+        ASSERT_EQ(notO.u.u8[i], 0x00);
+    }
+    u8 vec[32];
+    for (int i = 0; i < 32; i++) { vec[i] = static_cast<u8>(i * 7 + 3); }
+    auto v = SuperVector<32>::loadu(vec);
+    auto nv = !v;
+    for (int i = 0; i < 32; i++) {
+        ASSERT_EQ(nv.u.u8[i], static_cast<u8>(~vec[i]));
     }
 }
 
@@ -605,6 +768,24 @@ TEST(SuperVectorUtilsTest,LShift64_256c){
     }   
 }
 
+TEST(SuperVectorUtilsTest,LShift64_256c_LargeShift) {
+    u64a data[4] = {0x1111111111111111ULL, 0x2222222222222222ULL,
+                    0x3333333333333333ULL, 0x4444444444444444ULL};
+    auto v = SuperVector<32>::loadu(data);
+    auto shifted = v.vshl_64(48);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] << 48) << "i=" << i;
+    }
+    shifted = v.vshl_64(63);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] << 63) << "i=" << i;
+    }
+    shifted = v.vshl_64(64);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u64[i], 0ULL) << "i=" << i;
+    }
+}
+
 TEST(SuperVectorUtilsTest,RShift64_256c){
     u64a vec[4] = {128, 512, 256, 1024};
     auto SP = SuperVector<32>::loadu(vec);
@@ -616,6 +797,23 @@ TEST(SuperVectorUtilsTest,RShift64_256c){
     }   
 }
 
+TEST(SuperVectorUtilsTest,RShift64_256c_LargeShift) {
+    u64a data[4] = {0x1111111111111111ULL, 0x2222222222222222ULL,
+                    0x3333333333333333ULL, 0x4444444444444444ULL};
+    auto v = SuperVector<32>::loadu(data);
+    auto shifted = v.vshr_64(48);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] >> 48) << "i=" << i;
+    }
+    shifted = v.vshr_64(63);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] >> 63) << "i=" << i;
+    }
+    shifted = v.vshr_64(64);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(shifted.u.u64[i], 0ULL) << "i=" << i;
+    }
+}
 
 /*Define RSHIFT256 macro*/
 #define TEST_RSHIFT256(buf, vec, v, l) {                                                  \
@@ -695,6 +893,49 @@ TEST(SuperVectorUtilsTest,RShift128_256c){
     for(int j=0; j<16; j++) {
         TEST_RSHIFT128_256(buf, vec, SP, j);
     }
+}
+
+TEST(SuperVectorUtilsTest,OnesLShift_256c) {
+    for (int n = 0; n <= 32; n++) {
+        auto m = SuperVector<32>::Ones_vshl(static_cast<u8>(n));
+        for (int i = 0; i < 32; i++) {
+            if (i < n) {
+                ASSERT_EQ(m.u.u8[i], 0x00) << "n=" << n << " i=" << i;
+            } else {
+                ASSERT_EQ(m.u.u8[i], 0xFF) << "n=" << n << " i=" << i;
+            }
+        }
+    }
+}
+
+TEST(SuperVectorUtilsTest,RShiftImm256c) {
+    u8 vec[32];
+    for (int i = 0; i < 32; i++) { vec[i] = static_cast<u8>(i + 1); }
+    auto v = SuperVector<32>::loadu(vec);
+
+    auto r1 = v.template vshr_imm<1>();
+    auto r2 = v >> 1;
+    for (int i = 0; i < 32; i++) {
+        ASSERT_EQ(r1.u.u8[i], r2.u.u8[i]) << "byte " << i;
+    }
+    for (int i = 0; i < 31; i++) {
+        ASSERT_EQ(r1.u.u8[i], vec[i + 1]) << "byte " << i;
+    }
+    ASSERT_EQ(r1.u.u8[31], 0);
+}
+
+TEST(SuperVectorUtilsTest,RShiftVsLShiftImm256c) {
+    u8 vec[32];
+    for (int i = 0; i < 32; i++) { vec[i] = static_cast<u8>(i + 1); }
+    auto v = SuperVector<32>::loadu(vec);
+
+    auto shl = v.template vshl_imm<1>();
+    auto shr = v.template vshr_imm<1>();
+    bool differ = false;
+    for (int i = 0; i < 32; i++) {
+        if (shl.u.u8[i] != shr.u.u8[i]) { differ = true; break; }
+    }
+    ASSERT_TRUE(differ);
 }
 
 /*Define ALIGNR256 macro*/
@@ -777,6 +1018,41 @@ TEST(SuperVectorUtilsTest,Equal512c){
     auto SPResult = SP1.eq(SP2);
     for (int i=0; i<64; i++) {
         ASSERT_EQ(SPResult.u.s8[i],buf[i]);
+    }
+}
+
+TEST(SuperVectorUtilsTest,NotEqual512c) {
+    u8 a[64], b[64];
+    for (int i = 0; i < 64; i++) { a[i] = static_cast<u8>(i); b[i] = static_cast<u8>(i); }
+    b[0] = 0xFF;
+    b[63] = 0xFF;
+    auto va = SuperVector<64>::loadu(a);
+    auto vb = SuperVector<64>::loadu(b);
+    auto ne = (va != vb);
+    for (int i = 0; i < 64; i++) {
+        if (a[i] != b[i]) {
+            ASSERT_EQ(ne.u.u8[i], 0xFF) << "byte " << i;
+        } else {
+            ASSERT_EQ(ne.u.u8[i], 0x00) << "byte " << i;
+        }
+    }
+}
+
+TEST(SuperVectorUtilsTest,Not512c) {
+    auto notZ = !SuperVector<64>::Zeroes();
+    for (int i = 0; i < 64; i++) {
+        ASSERT_EQ(notZ.u.u8[i], 0xFF);
+    }
+    auto notO = !SuperVector<64>::Ones();
+    for (int i = 0; i < 64; i++) {
+        ASSERT_EQ(notO.u.u8[i], 0x00);
+    }
+    u8 vec[64];
+    for (int i = 0; i < 64; i++) { vec[i] = static_cast<u8>(i * 3 + 1); }
+    auto v = SuperVector<64>::loadu(vec);
+    auto nv = !v;
+    for (int i = 0; i < 64; i++) {
+        ASSERT_EQ(nv.u.u8[i], static_cast<u8>(~vec[i]));
     }
 }
 
@@ -960,6 +1236,29 @@ TEST(SuperVectorUtilsTest,RShift64_512c){
     }   
 }
 
+TEST(SuperVectorUtilsTest,RShift64_512c_LargeShift) {
+    u64a data[8] = {0x1111111111111111ULL, 0x2222222222222222ULL,
+                    0x3333333333333333ULL, 0x4444444444444444ULL,
+                    0x5555555555555555ULL, 0x6666666666666666ULL,
+                    0x7777777777777777ULL, 0x8888888888888888ULL};
+    auto v = SuperVector<64>::loadu(data);
+    auto shifted = v.vshr_64(16);
+    for (int i = 0; i < 8; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] >> 16) << "i=" << i;
+    }
+    shifted = v.vshr_64(48);
+    for (int i = 0; i < 8; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] >> 48) << "i=" << i;
+    }
+    shifted = v.vshr_64(63);
+    for (int i = 0; i < 8; i++) {
+        ASSERT_EQ(shifted.u.u64[i], data[i] >> 63) << "i=" << i;
+    }
+    shifted = v.vshr_64(64);
+    for (int i = 0; i < 8; i++) {
+        ASSERT_EQ(shifted.u.u64[i], 0ULL) << "i=" << i;
+    }
+}
 
 /*Define RSHIFT512 macro*/
 #define TEST_RSHIFT512(buf, vec, v, l) {                                                  \
@@ -1043,6 +1342,61 @@ TEST(SuperVectorUtilsTest,LShift128_512c){
     for(int j=0; j<16;j++){
         TEST_LSHIFT128_512(buf, vec, SP, j);
     }
+}
+
+TEST(SuperVectorUtilsTest,OnesLShift512c) {
+    for (int n = 0; n <= 64; n++) {
+        auto m = SuperVector<64>::Ones_vshl(static_cast<u8>(n));
+        for (int i = 0; i < 64; i++) {
+            if (i < n) {
+                ASSERT_EQ(m.u.u8[i], 0x00) << "n=" << n << " i=" << i;
+            } else {
+                ASSERT_EQ(m.u.u8[i], 0xFF) << "n=" << n << " i=" << i;
+            }
+        }
+    }
+}
+
+TEST(SuperVectorUtilsTest,LShiftImm512c) {
+    u8 vec[64];
+    for (int i = 0; i < 64; i++) { vec[i] = static_cast<u8>(i + 1); }
+    auto v = SuperVector<64>::loadu(vec);
+
+    auto imm = v.template vshl_imm<1>();
+    auto op  = v << 1;
+    for (int i = 0; i < 64; i++) {
+        ASSERT_EQ(imm.u.u8[i], op.u.u8[i]) << "byte " << i;
+    }
+    ASSERT_EQ(imm.u.u8[0], 0);
+    ASSERT_EQ(imm.u.u8[1], 1);
+}
+
+TEST(SuperVectorUtilsTest,RShiftImm512c) {
+    u8 vec[64];
+    for (int i = 0; i < 64; i++) { vec[i] = static_cast<u8>(i + 1); }
+    auto v = SuperVector<64>::loadu(vec);
+
+    auto imm = v.template vshr_imm<1>();
+    auto op  = v >> 1;
+    for (int i = 0; i < 64; i++) {
+        ASSERT_EQ(imm.u.u8[i], op.u.u8[i]) << "byte " << i;
+    }
+    ASSERT_EQ(imm.u.u8[0], 2);
+    ASSERT_EQ(imm.u.u8[63], 0);
+}
+
+TEST(SuperVectorUtilsTest,LShiftVsRShiftImm512c) {
+    u8 vec[64];
+    for (int i = 0; i < 64; i++) { vec[i] = static_cast<u8>(i + 1); }
+    auto v = SuperVector<64>::loadu(vec);
+
+    auto shl = v.template vshl_imm<1>();
+    auto shr = v.template vshr_imm<1>();
+    bool differ = false;
+    for (int i = 0; i < 64; i++) {
+        if (shl.u.u8[i] != shr.u.u8[i]) { differ = true; break; }
+    }
+    ASSERT_TRUE(differ);
 }
 
 /*Define ALIGNR512 macro*/


### PR DESCRIPTION
Fix critical bugs found in the SuperVector SIMD abstraction layer.

SuperVector operator!() — x86 (SSE/AVX2/AVX512), ppc64el:
  - Was XOR-ing with self (always returns Zeroes instead of bitwise NOT).
  - Note that some other operators depends on operator!().

SuperVector<16> Ones_vshl() — x86:
  - Called vshr_128() instead of vshl_128().

Element-wise shift boundary and Unroller range — x86:
  - vshl_32/vshr_32 on SuperVector<16>: zero-boundary was N==16,
    instead of N>=32; Unroller range was <1,16> not <1,32>.
  - vshl_64/vshr_64 on SuperVector<16>: same issue.
  - vshl_64/vshr_64 on SuperVector<32>: same issue.
  - vshr_64 on SuperVector<64>: same issue.

SuperVector<32> vshr_256_imm — x86:
  - Was a copy-paste of vshl_256_imm.

SuperVector<64> vshl_256_imm / vshl_512_imm — x86:

  - Were unimplemented stubs returning empty SuperVector.

SuperVector<64> vshr_256_imm — x86:
  - Operated on v256[0] only with broken SuperVector<32> logic.

SuperVector<64> vsh{l,r}_* — x86, ppc64el, arm:
  - Were incorrectly delegating to vshl_128/vshr_128. (x86)
  - Did not have boundary checks. PPC wraps when it tries to shift
    more than bit length. (ppc64el)
  - Had signed rshifts. (arm)

comparison operators - arm:
  - operator>=: used vcgeq_u8 (unsigned) instead of vcgeq_s8 (signed).
  - operator<=: used vcgeq_s8 (>=) instead of vcleq_s8 (<=).

ARM shufti blockSingleMask:
  - Used operator> instead of operator!= for zero-test, which relied on
    the broken signed comparison and missed matches with high-bit-set bytes.

Also adds comprehensive unit tests covering all fixed bugs.

@AhnLab-OSS @AhnLab-OSSG