### PR TITLE
Fix accelerator bugs (SVE/AVX-512/x86) and add comprehensive unit tests

### DIFF
--- a/src/hwlm/noodle_engine_sve.hpp
+++ b/src/hwlm/noodle_engine_sve.hpp
@@ -50,8 +50,8 @@ hwlm_error_t singleCheckMatched(const struct noodTable *n, const u8 *buf,
                                 size_t len, const struct cb_info *cbi,
                                 const u8 *d, svbool_t matched) {
     if (unlikely(svptest_any(svptrue_b8(), matched))) {
-        hwlmcb_rv_t rv = checkMatched(n, buf, len, cbi, d, matched,
-                                      n->msk_len != 1);
+        hwlm_error_t rv = checkMatched(n, buf, len, cbi, d, matched,
+                                       n->msk_len != 1);
         RETURN_IF_TERMINATED(rv);
     }
     return HWLM_SUCCESS;
@@ -88,7 +88,7 @@ hwlm_error_t scanSingleLoop(const struct noodTable *n, const u8 *buf,
     for (size_t i = 0; i < loops; i++, d += svcntb()) {
         DEBUG_PRINTF("d %p \n", d);
         svbool_t matched = singleMatched(chars, d, svptrue_b8());
-        hwlmcb_rv_t rv = singleCheckMatched(n, buf, len, cbi, d, matched);
+        hwlm_error_t rv = singleCheckMatched(n, buf, len, cbi, d, matched);
         RETURN_IF_TERMINATED(rv);
     }
     DEBUG_PRINTF("d %p e %p \n", d, e);
@@ -120,7 +120,7 @@ hwlm_error_t scanSingle(const struct noodTable *n, const u8 *buf, size_t len,
     const u8 *d1 = ROUNDUP_PTR(d, svcntb_pat(SV_POW2));
     if (d != d1) {
         DEBUG_PRINTF("until aligned %p \n", d1);
-        hwlmcb_rv_t rv = scanSingleOnce(n, buf, len, cbi, chars, d, d1);
+        hwlm_error_t rv = scanSingleOnce(n, buf, len, cbi, chars, d, d1);
         RETURN_IF_TERMINATED(rv);
     }
     return scanSingleLoop(n, buf, len, cbi, chars, d1, e);
@@ -140,8 +140,8 @@ hwlm_error_t doubleCheckMatched(const struct noodTable *n, const u8 *buf,
         // d - 1 won't underflow as the first position in buf has been dealt
         // with meaning that d > buf
         assert(d > buf);
-        hwlmcb_rv_t rv = checkMatched(n, buf, len, cbi, d - 1, matched,
-                                      n->msk_len != 2);
+        hwlm_error_t rv = checkMatched(n, buf, len, cbi, d - 1, matched,
+                                       n->msk_len != 2);
         RETURN_IF_TERMINATED(rv);
     }
     return HWLM_SUCCESS;
@@ -177,7 +177,7 @@ hwlm_error_t scanDoubleOnce(const struct noodTable *n, const u8 *buf,
 
     // we reuse u8 predicates for u16 lanes. This means that we will check against one
     // extra \0 character at the end of the vector.
-    if(unlikely(n->key1 == '\0')) {
+    if (unlikely(n->key1 == '\0')) {
         if (size % 2) {
             // if odd, vec has an odd number of lanes and has the spurious \0
             svbool_t lane_to_disable = svrev_b8(svpfirst(svrev_b8(pg), svpfalse()));
@@ -244,15 +244,15 @@ hwlm_error_t scanDouble(const struct noodTable *n, const u8 *buf, size_t len,
 
     svuint8_t chars = svreinterpret_u8(getCharMaskDouble(n->key0, n->key1, noCase));
 
-    if (scan_len <= svcntb()) {
+    if ((size_t)(e - d) <= svcntb()) {
         return scanDoubleOnce(n, buf, len, cbi, chars, d, e);
     }
     // peel off first part to align to the vector size
     const u8 *d1 = ROUNDUP_PTR(d, svcntb_pat(SV_POW2));
     if (d != d1) {
         DEBUG_PRINTF("until aligned %p \n", d1);
-        hwlmcb_rv_t rv = scanDoubleOnce(n, buf, len, cbi, chars,
-                                        d, d1);
+        hwlm_error_t rv = scanDoubleOnce(n, buf, len, cbi, chars,
+                                         d, d1);
         RETURN_IF_TERMINATED(rv);
     }
     return scanDoubleLoop(n, buf, len, cbi, chars, d1, e);

--- a/src/nfa/shufti_sve.hpp
+++ b/src/nfa/shufti_sve.hpp
@@ -173,7 +173,7 @@ svbool_t doubleMatched(svuint8_t mask1_lo, svuint8_t mask1_hi,
     svuint8_t t      = svorr_x(svptrue_b8(), merged_t1, t2);
     *inout_t1 = new_t1;
 
-    return svnot_z(svptrue_b8(), svcmpeq(svptrue_b8(), t, (uint8_t)0xff));
+    return svnot_z(pg, svcmpeq(pg, t, (uint8_t)0xff));
 }
 
 static really_inline

--- a/src/nfa/truffle_simd.hpp
+++ b/src/nfa/truffle_simd.hpp
@@ -247,7 +247,7 @@ const u8 *rtruffleExecSVE(m256 shuf_mask_32, const u8 *buf, const u8 *buf_end){
     if (work_buffer != buf) {
         svuint8_t chars;
         if (buf_end - buf < vect_size_int8) {
-            const svbool_t remaining_lanes = svwhilele_b8(0ll, buf_end - buf);
+            const svbool_t remaining_lanes = svwhilelt_b8(0ll, buf_end - buf);
             chars = svld1(remaining_lanes, buf);
         } else {
             chars = svld1(svptrue_b8(), buf);

--- a/src/nfa/vermicelli_simd.cpp
+++ b/src/nfa/vermicelli_simd.cpp
@@ -175,7 +175,7 @@ static const u8 *nvermicelliExecReal(SuperVector<S> const chars, SuperVector<S> 
 
     if (d != buf_end) {
         SuperVector<S> data = SuperVector<S>::loadu(buf_end - S);
-        rv = vermicelliBlockNeg(data, chars, casemask, buf_end - S, buf_end - d);
+        rv = vermicelliBlockNeg(data, chars, casemask, buf_end - S, S);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end) return rv;
     }

--- a/src/util/arch/common/simd_utils.h
+++ b/src/util/arch/common/simd_utils.h
@@ -115,7 +115,7 @@ ALIGN_CL_DIRECTIVE static const u8 simd_onebit_masks[] = {
 #if !defined(HAVE_SIMD_256_BITS)
 
 static really_really_inline
-m256 lshift64_m256(m256 a, int b) {
+m256 lshift64_m256(m256 a, unsigned b) {
     m256 rv = a;
     rv.lo = lshift64_m128(rv.lo, b);
     rv.hi = lshift64_m128(rv.hi, b);
@@ -123,7 +123,7 @@ m256 lshift64_m256(m256 a, int b) {
 }
 
 static really_inline
-m256 rshift64_m256(m256 a, int b) {
+m256 rshift64_m256(m256 a, unsigned b) {
     m256 rv = a;
     rv.lo = rshift64_m128(rv.lo, b);
     rv.hi = rshift64_m128(rv.hi, b);
@@ -687,9 +687,7 @@ int diff512(m512 a, m512 b) {
 
 static really_inline
 int isnonzero512(m512 a) {
-    m256 x = or256(a.lo, a.lo);
-    m256 y = or256(a.hi, a.hi);
-    return isnonzero256(or256(x, y));
+    return isnonzero256(or256(a.lo, a.hi));
 }
 
 /**
@@ -715,7 +713,7 @@ u32 diffrich64_512(m512 a, m512 b) {
 // aligned load
 static really_inline
 m512 load512(const void *ptr) {
-    assert(ISALIGNED_N(ptr, alignof(m256)));
+    assert(ISALIGNED_N(ptr, alignof(m512)));
     // cppcheck-suppress cstyleCast
     m512 rv = { load256(ptr), load256((const char *)ptr + 32) };
     return rv;

--- a/src/util/arch/x86/simd_utils.h
+++ b/src/util/arch/x86/simd_utils.h
@@ -146,7 +146,17 @@ m128 lshift64_m128(m128 a, unsigned b) {
     return _mm_sll_epi64(a, x);
 }
 
-#define rshift64_m128(a, b) _mm_srli_epi64((a), (b))
+static really_really_inline
+m128 rshift64_m128(m128 a, unsigned b) {
+#if defined(HAVE__BUILTIN_CONSTANT_P)
+    if (__builtin_constant_p(b)) {
+        return _mm_srli_epi64(a, b);
+    }
+#endif
+    m128 x = _mm_cvtsi32_si128(b);
+    return _mm_srl_epi64(a, x);
+}
+
 #define eq128(a, b)         _mm_cmpeq_epi8((a), (b))
 #define eq64_m128(a, b)     _mm_cmpeq_epi64((a), (b))
 #define movemask128(a)      ((u32)_mm_movemask_epi8((a)))
@@ -519,7 +529,16 @@ m256 lshift64_m256(m256 a, unsigned b) {
     return _mm256_sll_epi64(a, x);
 }
 
-#define rshift64_m256(a, b) _mm256_srli_epi64((a), (b))
+static really_really_inline
+m256 rshift64_m256(m256 a, unsigned b) {
+#if defined(HAVE__BUILTIN_CONSTANT_P)
+    if (__builtin_constant_p(b)) {
+        return _mm256_srli_epi64(a, b);
+    }
+#endif
+    m128 x = _mm_cvtsi32_si128(b);
+    return _mm256_srl_epi64(a, x);
+}
 
 static really_inline m256 set1_4x64(u64a c) {
     return _mm256_set1_epi64x(c);
@@ -944,7 +963,17 @@ m512 lshift64_m512(m512 a, unsigned b) {
     return _mm512_sll_epi64(a, x);
 }
 
-#define rshift64_m512(a, b) _mm512_srli_epi64((a), (b))
+static really_really_inline
+m512 rshift64_m512(m512 a, unsigned b) {
+#if defined(HAVE__BUILTIN_CONSTANT_P)
+    if (__builtin_constant_p(b)) {
+        return _mm512_srli_epi64(a, b);
+    }
+#endif
+    m128 x = _mm_cvtsi32_si128(b);
+    return _mm512_srl_epi64(a, x);
+}
+
 #define rshift128_m512(a, count_immed) _mm512_bsrli_epi128(a, count_immed)
 #define lshift128_m512(a, count_immed) _mm512_bslli_epi128(a, count_immed)
 

--- a/src/util/state_compress.c
+++ b/src/util/state_compress.c
@@ -125,11 +125,10 @@ void storecompressed128_64bit(void *ptr, m128 xvec, m128 mvec) {
     u32 ALIGN_ATTR(16) bits[2] = { popcount64(m[0]), popcount64(m[1]) };
 
     // Compress each 64-bit chunk individually.
-    xvec = compress128(xvec, mvec);
-    store128(x, xvec);
+    u64a v[2] = { compress64(x[0], m[0]), compress64(x[1], m[1]) };
 
     // Write packed data out.
-    pack_bits_64(ptr, x, bits, 2);
+    pack_bits_64(ptr, v, bits, 2);
 }
 #endif
 

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -115,6 +115,7 @@ set(unit_internal_SOURCES
     internal/utf8_validate.cpp
     internal/util_string.cpp
     internal/vermicelli.cpp
+    internal/vermicelli_extra.cpp
     internal/main.cpp
     )
 if (BUILD_AVX2)

--- a/unit/gtest/gtest-all.cc
+++ b/unit/gtest/gtest-all.cc
@@ -7475,12 +7475,12 @@ static int ExecDeathTestChildMain(void* child_arg) {
 // correct answer.
 void StackLowerThanAddress(const void* ptr, bool* result) GTEST_NO_INLINE_;
 void StackLowerThanAddress(const void* ptr, bool* result) {
-  int dummy;
+  int dummy = 0;
   *result = (&dummy < ptr);
 }
 
 bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;

--- a/unit/internal/noodle.cpp
+++ b/unit/internal/noodle.cpp
@@ -260,3 +260,416 @@ TEST(Noodle, noodCutoverDouble) {
     ctxt.clear();
 }
 
+// --- Additional tests for SVE and general edge case coverage ---
+
+// Test: callback that terminates matching early
+static
+hwlmcb_rv_t hlmTerminateAfterN(size_t to, u32 id,
+                               UNUSED struct hs_scratch *scratch) {
+    ctxt.push_back(hlmMatchEntry(to, id));
+    if (ctxt.size() >= 3) {
+        return HWLM_TERMINATE_MATCHING;
+    }
+    return HWLM_CONTINUE_MATCHING;
+}
+
+TEST(Noodle, noodTerminateSingle) {
+    // Fill buffer with 'a' and terminate after 3 matches
+    const size_t data_len = 256;
+    u8 data[data_len];
+    memset(data, 'a', data_len);
+
+    u32 id = 1000;
+    hwlmLiteral lit(std::string("a", 1), false, id);
+    auto n = noodBuildTable(lit);
+    ASSERT_TRUE(static_cast<bool>(n));
+
+    struct hs_scratch scratch;
+    hwlm_error_t rv = noodExec(n.get(), data, data_len, 0,
+                               hlmTerminateAfterN, &scratch);
+    ASSERT_EQ(HWLM_TERMINATED, rv);
+    ASSERT_EQ(3U, ctxt.size());
+    ctxt.clear();
+}
+
+TEST(Noodle, noodTerminateDouble) {
+    // Fill buffer with 'a' and terminate after 3 double matches
+    const size_t data_len = 256;
+    u8 data[data_len];
+    memset(data, 'a', data_len);
+
+    u32 id = 1000;
+    hwlmLiteral lit(std::string("aa", 2), false, id);
+    auto n = noodBuildTable(lit);
+    ASSERT_TRUE(static_cast<bool>(n));
+
+    struct hs_scratch scratch;
+    hwlm_error_t rv = noodExec(n.get(), data, data_len, 0,
+                               hlmTerminateAfterN, &scratch);
+    ASSERT_EQ(HWLM_TERMINATED, rv);
+    ASSERT_EQ(3U, ctxt.size());
+    ctxt.clear();
+}
+
+// Test: no match at all
+TEST(Noodle, noodNoMatchSingle) {
+    const size_t data_len = 512;
+    u8 data[data_len];
+    memset(data, 'b', data_len);
+
+    noodleMatch(data, data_len, "a", 1, 0, hlmSimpleCallback);
+    ASSERT_EQ(0U, ctxt.size());
+    ctxt.clear();
+}
+
+TEST(Noodle, noodNoMatchDouble) {
+    const size_t data_len = 512;
+    u8 data[data_len];
+    memset(data, 'b', data_len);
+
+    noodleMatch(data, data_len, "ac", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(0U, ctxt.size());
+    ctxt.clear();
+}
+
+// Test: very short buffers (edge cases for scan_len checks)
+TEST(Noodle, noodShortBufferSingle) {
+    u8 data[1] = {'x'};
+
+    noodleMatch(data, 1, "x", 1, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(0U, ctxt[0].to);
+    ctxt.clear();
+
+    noodleMatch(data, 1, "y", 1, 0, hlmSimpleCallback);
+    ASSERT_EQ(0U, ctxt.size());
+    ctxt.clear();
+}
+
+TEST(Noodle, noodShortBufferDouble) {
+    // 2 bytes: minimum for a double scan
+    u8 data2[2] = {'a', 'b'};
+    noodleMatch(data2, 2, "ab", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(1U, ctxt[0].to);
+    ctxt.clear();
+
+    // 3 bytes
+    u8 data3[3] = {'a', 'b', 'c'};
+    noodleMatch(data3, 3, "bc", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(2U, ctxt[0].to);
+    ctxt.clear();
+
+    // 2 bytes, no match
+    noodleMatch(data2, 2, "ba", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(0U, ctxt.size());
+    ctxt.clear();
+}
+
+// Test: NUL byte in patterns (exercises key1 == '\0' path in scanDoubleOnce)
+TEST(Noodle, noodNulByteSingle) {
+    const size_t data_len = 64;
+    u8 data[data_len];
+    memset(data, 'a', data_len);
+    data[10] = '\0';
+    data[30] = '\0';
+
+    noodleMatch(data, data_len, "\0", 1, 0, hlmSimpleCallback);
+    ASSERT_EQ(2U, ctxt.size());
+    ASSERT_EQ(10U, ctxt[0].to);
+    ASSERT_EQ(30U, ctxt[1].to);
+    ctxt.clear();
+}
+
+TEST(Noodle, noodNulByteDouble) {
+    const size_t data_len = 64;
+    u8 data[data_len];
+    memset(data, 'a', data_len);
+    // Create "a\0" pattern at position 10 and 30
+    data[11] = '\0';
+    data[31] = '\0';
+
+    noodleMatch(data, data_len, "a\0", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(2U, ctxt.size());
+    ASSERT_EQ(11U, ctxt[0].to);
+    ASSERT_EQ(31U, ctxt[1].to);
+    ctxt.clear();
+}
+
+TEST(Noodle, noodNulByteDoubleReverse) {
+    // Pattern: "\0a"
+    const size_t data_len = 64;
+    u8 data[data_len];
+    memset(data, 'a', data_len);
+    data[10] = '\0';
+    data[30] = '\0';
+
+    noodleMatch(data, data_len, "\0a", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(2U, ctxt.size());
+    ASSERT_EQ(11U, ctxt[0].to);
+    ASSERT_EQ(31U, ctxt[1].to);
+    ctxt.clear();
+}
+
+// Test: non-alphabetic characters with noCase flag
+TEST(Noodle, noodNonAlphaNoCase) {
+    const size_t data_len = 128;
+    u8 data[data_len];
+    memset(data, '1', data_len);
+
+    // noCase should have no effect on digits
+    noodleMatch(data, data_len, "1", 1, 1, hlmSimpleCallback);
+    ASSERT_EQ(128U, ctxt.size());
+    ctxt.clear();
+
+    // Non-alpha double
+    memset(data, '!', data_len);
+    data[0] = '#';
+    noodleMatch(data, data_len, "#!", 2, 1, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(1U, ctxt[0].to);
+    ctxt.clear();
+}
+
+// Test: case-insensitive double matching
+TEST(Noodle, noodDoubleCaseInsensitive) {
+    const size_t data_len = 128;
+    u8 data[data_len];
+
+    // "aB" pattern should match "ab", "aB", "Ab", "AB" with noCase
+    memset(data, 'x', data_len);
+    data[10] = 'a'; data[11] = 'b';
+    data[20] = 'A'; data[21] = 'B';
+    data[30] = 'a'; data[31] = 'B';
+    data[40] = 'A'; data[41] = 'b';
+
+    noodleMatch(data, data_len, "aB", 2, 1, hlmSimpleCallback);
+    ASSERT_EQ(4U, ctxt.size());
+    ASSERT_EQ(11U, ctxt[0].to);
+    ASSERT_EQ(21U, ctxt[1].to);
+    ASSERT_EQ(31U, ctxt[2].to);
+    ASSERT_EQ(41U, ctxt[3].to);
+    ctxt.clear();
+
+    // Without noCase, only exact match
+    noodleMatch(data, data_len, "aB", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(31U, ctxt[0].to);
+    ctxt.clear();
+}
+
+// Test: various buffer sizes to exercise scanLoop vs scanOnce paths
+// This is especially important for SVE where vector length varies
+TEST(Noodle, noodVariousSizesSingle) {
+    for (u32 len = 1; len <= 512; len++) {
+        std::vector<u8> data(len, 'z');
+
+        ctxt.clear();
+        noodleMatch(data.data(), len, "z", 1, 0, hlmSimpleCallback);
+        EXPECT_EQ(len, ctxt.size()) << "Failed at len=" << len;
+    }
+    ctxt.clear();
+}
+
+TEST(Noodle, noodVariousSizesDouble) {
+    for (u32 len = 2; len <= 512; len++) {
+        std::vector<u8> data(len, 'z');
+
+        ctxt.clear();
+        noodleMatch(data.data(), len, "zz", 2, 0, hlmSimpleCallback);
+        EXPECT_EQ(len - 1, ctxt.size()) << "Failed at len=" << len;
+    }
+    ctxt.clear();
+}
+
+// Test: match at the very end of buffer
+TEST(Noodle, noodMatchAtEnd) {
+    const size_t data_len = 128;
+    u8 data[data_len];
+    memset(data, 'x', data_len);
+    data[data_len - 1] = 'y';
+
+    noodleMatch(data, data_len, "y", 1, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(data_len - 1, ctxt[0].to);
+    ctxt.clear();
+
+    // Double at end
+    data[data_len - 2] = 'a';
+    data[data_len - 1] = 'b';
+    noodleMatch(data, data_len, "ab", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(data_len - 1, ctxt[0].to);
+    ctxt.clear();
+}
+
+// Test: match at the very beginning of buffer
+TEST(Noodle, noodMatchAtStart) {
+    const size_t data_len = 128;
+    u8 data[data_len];
+    memset(data, 'x', data_len);
+    data[0] = 'y';
+
+    noodleMatch(data, data_len, "y", 1, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(0U, ctxt[0].to);
+    ctxt.clear();
+
+    // Double at start
+    data[0] = 'a';
+    data[1] = 'b';
+    noodleMatch(data, data_len, "ab", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(1U, ctxt[0].to);
+    ctxt.clear();
+}
+
+// Test: single match in the middle of a large buffer (exercises loop path)
+TEST(Noodle, noodSingleMatchLargeBuffer) {
+    const size_t data_len = 4096;
+    std::vector<u8> data(data_len, 'x');
+    data[2048] = 'y';
+
+    noodleMatch(data.data(), data_len, "y", 1, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(2048U, ctxt[0].to);
+    ctxt.clear();
+}
+
+TEST(Noodle, noodDoubleMatchLargeBuffer) {
+    const size_t data_len = 4096;
+    std::vector<u8> data(data_len, 'x');
+    data[2048] = 'a';
+    data[2049] = 'b';
+
+    noodleMatch(data.data(), data_len, "ab", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(1U, ctxt.size());
+    ASSERT_EQ(2049U, ctxt[0].to);
+    ctxt.clear();
+}
+
+// Test: alignment sweep for double scan with NUL byte
+// This is critical for the SVE scanDoubleOnce key1=='\0' logic
+TEST(Noodle, noodNulByteCutoverDouble) {
+    const size_t max_data_len = 256;
+    u8 data[max_data_len + 16];
+    memset(data, 'z', max_data_len + 16);
+
+    for (u32 align = 0; align < 16; align++) {
+        for (u32 len = 3; len < max_data_len; len++) {
+            // Place a "z\0" at position len-2
+            u8 *base = data + align;
+            memset(base, 'z', len);
+            base[len - 1] = '\0';
+
+            ctxt.clear();
+            noodleMatch(base, len, "z\0", 2, 0, hlmSimpleCallback);
+            EXPECT_EQ(1U, ctxt.size())
+                << "align=" << align << " len=" << len;
+            if (ctxt.size() == 1) {
+                EXPECT_EQ(len - 1, ctxt[0].to)
+                    << "align=" << align << " len=" << len;
+            }
+
+            // Restore
+            base[len - 1] = 'z';
+        }
+    }
+    ctxt.clear();
+}
+
+// Test: streaming mode with double match spanning history and current buffer
+TEST(Noodle, noodStreamingDouble) {
+    u32 id = 1000;
+    hwlmLiteral lit(std::string("ab", 2), false, id);
+    auto n = noodBuildTable(lit);
+    ASSERT_TRUE(static_cast<bool>(n));
+
+    // 'a' at end of history, 'b' at start of current
+    u8 hbuf[4] = {'x', 'x', 'x', 'a'};
+    u8 buf[4] = {'b', 'x', 'x', 'x'};
+
+    struct hs_scratch scratch;
+    hwlm_error_t rv = noodExecStreaming(n.get(), hbuf, 4, buf, 4,
+                                        hlmSimpleCallback, &scratch);
+    ASSERT_EQ(HWLM_SUCCESS, rv);
+    ASSERT_EQ(1U, ctxt.size());
+    // The match end position should be 0 (first byte of buf)
+    ASSERT_EQ(0U, ctxt[0].to);
+    ctxt.clear();
+}
+
+// Test: streaming mode - no match across boundary
+TEST(Noodle, noodStreamingNoMatch) {
+    u32 id = 1000;
+    hwlmLiteral lit(std::string("ab", 2), false, id);
+    auto n = noodBuildTable(lit);
+    ASSERT_TRUE(static_cast<bool>(n));
+
+    u8 hbuf[4] = {'x', 'x', 'x', 'x'};
+    u8 buf[4] = {'x', 'x', 'x', 'x'};
+
+    struct hs_scratch scratch;
+    hwlm_error_t rv = noodExecStreaming(n.get(), hbuf, 4, buf, 4,
+                                        hlmSimpleCallback, &scratch);
+    ASSERT_EQ(HWLM_SUCCESS, rv);
+    ASSERT_EQ(0U, ctxt.size());
+    ctxt.clear();
+}
+
+// Test: offset parameter to start scanning from a later position
+TEST(Noodle, noodWithOffset) {
+    const size_t data_len = 128;
+    u8 data[data_len];
+    memset(data, 'a', data_len);
+
+    // Start scanning from offset 64
+    u32 id = 1000;
+    hwlmLiteral lit(std::string("a", 1), false, id);
+    auto n = noodBuildTable(lit);
+    ASSERT_TRUE(static_cast<bool>(n));
+
+    struct hs_scratch scratch;
+    hwlm_error_t rv = noodExec(n.get(), data, data_len, 64,
+                               hlmSimpleCallback, &scratch);
+    ASSERT_EQ(HWLM_SUCCESS, rv);
+    ASSERT_EQ(64U, ctxt.size());
+    ASSERT_EQ(64U, ctxt[0].to);
+    ctxt.clear();
+}
+
+// Test: long pattern (4+ chars) with double scan path
+TEST(Noodle, noodLongPatternCutover) {
+    const size_t max_data_len = 256;
+    u8 data[max_data_len + 16];
+    memset(data, 'a', max_data_len + 16);
+
+    for (u32 align = 0; align < 16; align++) {
+        for (u32 len = 4; len < max_data_len; len++) {
+            ctxt.clear();
+            noodleMatch(data + align, len, "aaaa", 4, 0, hlmSimpleCallback);
+            EXPECT_EQ(len - 3, ctxt.size())
+                << "align=" << align << " len=" << len;
+        }
+    }
+    ctxt.clear();
+}
+
+// Test: repeated pattern with multiple matches in single vector
+TEST(Noodle, noodDenseMatches) {
+    // Alternating 'ab' pattern creates dense double matches
+    const size_t data_len = 256;
+    u8 data[data_len];
+    for (size_t i = 0; i < data_len; i++) {
+        data[i] = (i % 2 == 0) ? 'a' : 'b';
+    }
+
+    noodleMatch(data, data_len, "ab", 2, 0, hlmSimpleCallback);
+    ASSERT_EQ(128U, ctxt.size());
+    for (u32 i = 0; i < 128; i++) {
+        ASSERT_EQ(i * 2 + 1, ctxt[i].to);
+    }
+    ctxt.clear();
+}
+

--- a/unit/internal/sheng.cpp
+++ b/unit/internal/sheng.cpp
@@ -121,14 +121,14 @@ static void init_raw_dfa16(struct ue2::raw_dfa *dfa, const ReportID rID)
     dfa->alpha_remap['f'] = 6;
     dfa->alpha_remap[256] = 7; /* for some reason there's a check that run on dfa->alpha_size-1 */
 
-                        /* a b c d e o f */
-    dfa->states[0].next = {0,0,0,0,0,0,0};
-    dfa->states[1].next = {2,2,1,1,1,1,1};      /* nothing */
-    dfa->states[2].next = {2,2,3,3,3,1,1};      /* [a,b] */
-    dfa->states[3].next = {2,2,4,4,4,1,1};      /* [a,b][c-e]{1} */
-    dfa->states[4].next = {2,2,5,5,5,1,1};      /* [a,b][c-e]{2} */
-    fill_straight_regex_sequence(dfa, 5, 7, 7); /* [a,b][c-e]{3}o */
-    dfa->states[7].next = {2,2,1,1,1,1,1};      /* [a,b][c-e]{3}of */
+                        /* a b c d e o f _ */
+    dfa->states[0].next = {0,0,0,0,0,0,0,0};
+    dfa->states[1].next = {2,2,1,1,1,1,1,1};      /* nothing */
+    dfa->states[2].next = {2,2,3,3,3,1,1,1};      /* [a,b] */
+    dfa->states[3].next = {2,2,4,4,4,1,1,1};      /* [a,b][c-e]{1} */
+    dfa->states[4].next = {2,2,5,5,5,1,1,1};      /* [a,b][c-e]{2} */
+    fill_straight_regex_sequence(dfa, 5, 7, 8); /* [a,b][c-e]{3}o */
+    dfa->states[7].next = {2,2,1,1,1,1,1,1};      /* [a,b][c-e]{3}of */
 }
 
 #if defined(HAVE_AVX512VBMI) || defined(HAVE_SVE)
@@ -176,14 +176,14 @@ static void init_raw_dfa32(struct ue2::raw_dfa *dfa, const ReportID rID)
     }
     dfa->alpha_remap[256] = 17; /* for some reason there's a check that run on dfa->alpha_size-1 */
 
-                         /* a b c d e o f 0 1 2 3 4 5 6 7 8 9 */
-    dfa->states[0].next  = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-    dfa->states[1].next  = {2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};  /* nothing */
-    dfa->states[2].next  = {2,2,3,3,3,1,1,1,1,1,1,1,1,1,1,1,1};  /* [a,b] */
-    dfa->states[3].next  = {2,2,4,4,4,1,1,1,1,1,1,1,1,1,1,1,1};  /* [a,b][c-e]{1} */
-    dfa->states[4].next  = {2,2,5,5,5,1,1,1,1,1,1,1,1,1,1,1,1};  /* [a,b][c-e]{2} */
-    fill_straight_regex_sequence(dfa, 5, 17, 17);                /* [a,b][c-e]{3}of012345678 */
-    dfa->states[17].next = {2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};  /* [a,b][c-e]{3}of0123456789 */
+                         /* a b c d e o f 0 1 2 3 4 5 6 7 8 9 _ */
+    dfa->states[0].next  = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+    dfa->states[1].next  = {2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};  /* nothing */
+    dfa->states[2].next  = {2,2,3,3,3,1,1,1,1,1,1,1,1,1,1,1,1,1};  /* [a,b] */
+    dfa->states[3].next  = {2,2,4,4,4,1,1,1,1,1,1,1,1,1,1,1,1,1};  /* [a,b][c-e]{1} */
+    dfa->states[4].next  = {2,2,5,5,5,1,1,1,1,1,1,1,1,1,1,1,1,1};  /* [a,b][c-e]{2} */
+    fill_straight_regex_sequence(dfa, 5, 17, 18);                /* [a,b][c-e]{3}of012345678 */
+    dfa->states[17].next = {2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};  /* [a,b][c-e]{3}of0123456789 */
 }
 #endif /* defined(HAVE_AVX512VBMI) || defined(HAVE_SVE) */
 

--- a/unit/internal/shufti.cpp
+++ b/unit/internal/shufti.cpp
@@ -1147,3 +1147,189 @@ TEST(ReverseShufti, ExecMatch6) {
         ASSERT_EQ(reinterpret_cast<const u8 *>(t1) + i, rv);
     }
 }
+
+// Test that having the first char of a two-byte pair at the last position of a
+// short buffer (shorter than a SIMD/SVE vector) does not produce a false match.
+// This is a regression test for an SVE bug where inactive vector lanes in
+// doubleMatched() were not properly masked by the predicate, causing false
+// positives when the last byte matched a first-char pattern and the inactive
+// lane (zero-filled) satisfied a null-byte second-char pattern.
+TEST(DoubleShufti, ExecNoMatchLastByteShortBufNullPair) {
+    m128 lo1, hi1, lo2, hi2;
+
+    flat_set<pair<u8, u8>> lits;
+
+    // Use a pattern where the second char is the null byte. This ensures
+    // mask2_lo[0] and mask2_hi[0] both have the bucket bit cleared, which
+    // causes inactive SVE lanes (loaded as 0) to produce t != 0xff.
+    lits.insert(make_pair('a', '\0'));
+
+    bool ret = shuftiBuildDoubleMasks(CharReach(), lits,
+                                      reinterpret_cast<u8 *>(&lo1),
+                                      reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2),
+                                      reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    // Use a large backing buffer filled with 'b' to ensure safe memory reads
+    // past buf_end on platforms that use unaligned vector loads (SIMD).
+    const int maxlen = 128;
+    char t1[maxlen];
+    memset(t1, 'b', maxlen);
+
+    // For short buffers (length 2 to 15), place 'a' at the last position.
+    // Since there is no '\0' following it within the buffer, no match should
+    // be reported.
+    for (int len = 2; len <= 15; len++) {
+        memset(t1, 'b', maxlen);
+        t1[len - 1] = 'a';
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(t1),
+                                        reinterpret_cast<u8 *>(t1) + len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len), rv)
+            << "False match for len=" << len;
+    }
+}
+
+// Same as above, but also test medium-length buffers (16-80) where the tail
+// portion processed with a partial predicate may expose the same issue.
+TEST(DoubleShufti, ExecNoMatchLastByteNullPairVaryLen) {
+    m128 lo1, hi1, lo2, hi2;
+
+    flat_set<pair<u8, u8>> lits;
+    lits.insert(make_pair('a', '\0'));
+
+    bool ret = shuftiBuildDoubleMasks(CharReach(), lits,
+                                      reinterpret_cast<u8 *>(&lo1),
+                                      reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2),
+                                      reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    const int maxlen = 256;
+    char t1[maxlen];
+
+    for (int len = 2; len < maxlen; len++) {
+        memset(t1, 'b', maxlen);
+        t1[len - 1] = 'a';
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(t1),
+                                        reinterpret_cast<u8 *>(t1) + len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len), rv)
+            << "False match for len=" << len;
+    }
+}
+
+// Verify that a real match of ('a', '\0') within a short buffer IS found.
+TEST(DoubleShufti, ExecMatchNullPairShortBuf) {
+    m128 lo1, hi1, lo2, hi2;
+
+    flat_set<pair<u8, u8>> lits;
+    lits.insert(make_pair('a', '\0'));
+
+    bool ret = shuftiBuildDoubleMasks(CharReach(), lits,
+                                      reinterpret_cast<u8 *>(&lo1),
+                                      reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2),
+                                      reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    const int maxlen = 128;
+    char t1[maxlen];
+
+    for (int len = 3; len <= 15; len++) {
+        memset(t1, 'b', maxlen);
+        // Place the pair ('a', '\0') inside the buffer
+        t1[len - 2] = 'a';
+        t1[len - 1] = '\0';
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(t1),
+                                        reinterpret_cast<u8 *>(t1) + len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len - 2), rv)
+            << "Match not found for len=" << len;
+    }
+}
+
+// Test short buffers with a normal two-byte pattern where first char is at the
+// last position. This should not match on any platform.
+TEST(DoubleShufti, ExecNoMatchLastByteShortBuf) {
+    m128 lo1, hi1, lo2, hi2;
+
+    flat_set<pair<u8, u8>> lits;
+    lits.insert(make_pair('x', 'y'));
+
+    bool ret = shuftiBuildDoubleMasks(CharReach(), lits,
+                                      reinterpret_cast<u8 *>(&lo1),
+                                      reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2),
+                                      reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    const int maxlen = 128;
+    char t1[maxlen];
+
+    for (int len = 2; len <= 15; len++) {
+        memset(t1, 'b', maxlen);
+        t1[len - 1] = 'x'; // first char at last position, no 'y' follows
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(t1),
+                                        reinterpret_cast<u8 *>(t1) + len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len), rv)
+            << "False match for len=" << len;
+    }
+}
+
+// Test short buffers with mixed one-byte and two-byte patterns. A one-byte
+// match at the last position should be correctly reported.
+TEST(DoubleShufti, ExecMatchMixedShortBuf) {
+    m128 lo1, hi1, lo2, hi2;
+
+    CharReach onebyte;
+    flat_set<pair<u8, u8>> twobyte;
+
+    onebyte.set('a');
+    twobyte.insert(make_pair('x', 'y'));
+
+    bool ret = shuftiBuildDoubleMasks(onebyte, twobyte,
+                                      reinterpret_cast<u8 *>(&lo1),
+                                      reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2),
+                                      reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    const int maxlen = 128;
+    char t1[maxlen];
+
+    // One-byte 'a' at the last position should be reported
+    for (int len = 2; len <= 15; len++) {
+        memset(t1, 'b', maxlen);
+        t1[len - 1] = 'a';
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(t1),
+                                        reinterpret_cast<u8 *>(t1) + len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len - 1), rv)
+            << "One-byte match not found for len=" << len;
+    }
+
+    // No match when target chars are absent
+    for (int len = 2; len <= 15; len++) {
+        memset(t1, 'b', maxlen);
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2,
+                                        reinterpret_cast<u8 *>(t1),
+                                        reinterpret_cast<u8 *>(t1) + len);
+
+        ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len), rv)
+            << "False match for len=" << len;
+    }
+}

--- a/unit/internal/truffle.cpp
+++ b/unit/internal/truffle.cpp
@@ -34,6 +34,9 @@
 #include "util/charreach.h"
 #include "util/simd_utils.h"
 
+#include <array>
+#include <cstring>
+
 using namespace ue2;
 
 TEST(Truffle, CompileDot) {
@@ -616,4 +619,476 @@ TEST(ReverseTruffle, ExecMatch5) {
 
         ASSERT_EQ(reinterpret_cast<const u8 *>(t1) + i, rv);
     }
+}
+
+/*
+ * Additional unit tests for truffle accelerator.
+ * These cover edge cases and areas not handled by the original test suite.
+ */
+
+// --- Compile/Roundtrip Tests ---
+
+TEST(Truffle, CompileRanges) {
+    // Test building masks for various character ranges and verify roundtrip
+    m128 mask1, mask2;
+    CharReach chars;
+
+    // Printable ASCII range
+    chars.setRange(0x20, 0x7e);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    CharReach out = truffle2cr(reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    ASSERT_EQ(out, chars);
+
+    // High byte range
+    chars.clear();
+    chars.setRange(0x80, 0xff);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    out = truffle2cr(reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    ASSERT_EQ(out, chars);
+
+    // Mixed low and high range
+    chars.clear();
+    chars.setRange(0x30, 0x39); // digits
+    chars.setRange(0xC0, 0xDF); // some high bytes
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    out = truffle2cr(reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    ASSERT_EQ(out, chars);
+}
+
+TEST(Truffle, CompileEmpty) {
+    // Empty character class - no characters set
+    m128 mask1, mask2;
+    CharReach chars; // empty
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    CharReach out = truffle2cr(reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    ASSERT_EQ(out, chars);
+    ASSERT_TRUE(out.none());
+}
+
+TEST(Truffle, CompileSameNibbleDiffHigh) {
+    // Characters with the same low nibble but different high nibble
+    // e.g., 'V' = 0x56 and 'e' = 0x65 have different nibbles, but
+    // 0x13 and 0x23 share low nibble 0x3 but differ in bits 4-6
+    m128 mask1, mask2;
+    CharReach chars;
+    chars.set(0x13);
+    chars.set(0x23);
+    chars.set(0x43);
+    chars.set(0x93);
+    chars.set(0xA3);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    CharReach out = truffle2cr(reinterpret_cast<u8 *>(&mask1), reinterpret_cast<u8 *>(&mask2));
+    ASSERT_EQ(out, chars);
+}
+
+// --- Forward Exec: Edge cases ---
+
+TEST(Truffle, ExecSingleByte) {
+    // Buffer of length 1 - matching char
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('Z');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[1] = { 'Z' };
+    const u8 *rv = truffleExec(lo, hi, buf, buf + 1);
+    ASSERT_EQ(buf, rv);
+}
+
+TEST(Truffle, ExecSingleByteNoMatch) {
+    // Buffer of length 1 - non-matching char
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('Z');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[1] = { 'A' };
+    const u8 *rv = truffleExec(lo, hi, buf, buf + 1);
+    ASSERT_EQ(buf + 1, rv);
+}
+
+TEST(Truffle, ExecHighByteMatch) {
+    // Test high byte characters (>= 0x80) match correctly
+    m128 lo, hi;
+    CharReach chars;
+    chars.set(0xAB);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[128];
+    memset(buf, 0x20, sizeof(buf));
+
+    for (size_t pos = 0; pos < 64; pos++) {
+        buf[pos] = 0xAB;
+        const u8 *rv = truffleExec(lo, hi, buf, buf + 128);
+        ASSERT_EQ(buf + pos, rv);
+        buf[pos] = 0x20; // restore
+    }
+}
+
+TEST(Truffle, ExecHighByteNoMatchSameNibble) {
+    // 0xAB and 0x2B share the same low nibble (0xB).
+    // Searching for 0xAB should NOT match 0x2B.
+    m128 lo, hi;
+    CharReach chars;
+    chars.set(0xAB);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[64];
+    memset(buf, 0x2B, sizeof(buf)); // same low nibble, different high nibble
+    const u8 *rv = truffleExec(lo, hi, buf, buf + 64);
+    ASSERT_EQ(buf + 64, rv);
+}
+
+TEST(Truffle, ExecNulCharMatch) {
+    // Searching for NUL character
+    m128 lo, hi;
+    CharReach chars;
+    chars.set(0x00);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[80];
+    memset(buf, 0xFF, sizeof(buf));
+    buf[45] = 0x00;
+    const u8 *rv = truffleExec(lo, hi, buf, buf + 80);
+    ASSERT_EQ(buf + 45, rv);
+}
+
+TEST(Truffle, ExecDotMatchAll) {
+    // Dot (all chars) should match the first byte
+    m128 lo, hi;
+    CharReach chars;
+    chars.setall();
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[64];
+    memset(buf, 0x42, sizeof(buf));
+    const u8 *rv = truffleExec(lo, hi, buf, buf + 64);
+    ASSERT_EQ(buf, rv); // first byte always matches
+}
+
+TEST(Truffle, ExecMatchAtBufferEnd) {
+    // Match only at the very last byte of the buffer
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('X');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[200];
+    memset(buf, '.', sizeof(buf));
+    buf[199] = 'X';
+    const u8 *rv = truffleExec(lo, hi, buf, buf + 200);
+    ASSERT_EQ(buf + 199, rv);
+}
+
+TEST(Truffle, ExecVaryingLengths) {
+    // Test with buffers of many different lengths (1 to 130)
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('q');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[130];
+    for (size_t len = 1; len <= 130; len++) {
+        memset(buf, '.', len);
+        // No match
+        const u8 *rv = truffleExec(lo, hi, buf, buf + len);
+        ASSERT_EQ(buf + len, rv) << "len=" << len;
+
+        // Match at last position
+        buf[len - 1] = 'q';
+        rv = truffleExec(lo, hi, buf, buf + len);
+        ASSERT_EQ(buf + len - 1, rv) << "len=" << len;
+    }
+}
+
+TEST(Truffle, ExecAlignmentSweep) {
+    // Test match at every offset within a larger buffer to exercise
+    // alignment code paths
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('!');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[256];
+    memset(buf, '.', sizeof(buf));
+
+    for (size_t offset = 0; offset < 64; offset++) {
+        buf[offset] = '!';
+        const u8 *rv = truffleExec(lo, hi, buf, buf + 256);
+        ASSERT_EQ(buf + offset, rv) << "offset=" << offset;
+        buf[offset] = '.';
+    }
+}
+
+TEST(Truffle, ExecMultipleCharsInClass) {
+    // Test character class with many different characters
+    m128 lo, hi;
+    CharReach chars;
+    // [a-zA-Z0-9]
+    chars.setRange('a', 'z');
+    chars.setRange('A', 'Z');
+    chars.setRange('0', '9');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    // Buffer of non-matching chars
+    u8 buf[64];
+    memset(buf, '!', sizeof(buf)); // not in character class
+
+    for (u8 c = '0'; c <= '9'; c++) {
+        buf[32] = c;
+        const u8 *rv = truffleExec(lo, hi, buf, buf + 64);
+        ASSERT_EQ(buf + 32, rv) << "char=" << (char)c;
+        buf[32] = '!';
+    }
+    for (u8 c = 'a'; c <= 'z'; c++) {
+        buf[32] = c;
+        const u8 *rv = truffleExec(lo, hi, buf, buf + 64);
+        ASSERT_EQ(buf + 32, rv) << "char=" << (char)c;
+        buf[32] = '!';
+    }
+    for (u8 c = 'A'; c <= 'Z'; c++) {
+        buf[32] = c;
+        const u8 *rv = truffleExec(lo, hi, buf, buf + 64);
+        ASSERT_EQ(buf + 32, rv) << "char=" << (char)c;
+        buf[32] = '!';
+    }
+}
+
+TEST(Truffle, ExecAllSingleCharClasses) {
+    // For every possible character class of size 1, verify match works
+    for (unsigned c = 0; c < 256; c++) {
+        m128 lo, hi;
+        CharReach chars;
+        chars.set((u8)c);
+        truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+        // Build a buffer that doesn't contain c (use c^1 if possible)
+        u8 filler = (u8)(c ^ 0x01);
+        if (filler == (u8)c) filler = (u8)(c ^ 0x02);
+        u8 buf[64];
+        memset(buf, filler, sizeof(buf));
+
+        // No match
+        const u8 *rv = truffleExec(lo, hi, buf, buf + 64);
+        ASSERT_EQ(buf + 64, rv) << "c=" << c;
+
+        // Place character at position 17
+        buf[17] = (u8)c;
+        rv = truffleExec(lo, hi, buf, buf + 64);
+        ASSERT_EQ(buf + 17, rv) << "c=" << c;
+    }
+}
+
+// --- Reverse Exec: Edge cases ---
+
+TEST(ReverseTruffle, ExecSingleByte) {
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('Z');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[1] = { 'Z' };
+    const u8 *rv = rtruffleExec(lo, hi, buf, buf + 1);
+    ASSERT_EQ(buf, rv);
+}
+
+TEST(ReverseTruffle, ExecSingleByteNoMatch) {
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('Z');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 raw[2] = { 0, 'A' };
+    u8 *buf = raw + 1;
+    const u8 *rv = rtruffleExec(lo, hi, buf, buf + 1);
+    ASSERT_EQ(raw, rv);
+}
+
+TEST(ReverseTruffle, ExecHighByteReverse) {
+    // Reverse search for high byte characters
+    m128 lo, hi;
+    CharReach chars;
+    chars.set(0xFE);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[128];
+    memset(buf, 0x20, sizeof(buf));
+
+    // Place match at various positions and verify reverse finds the last one
+    for (size_t pos = 64; pos < 128; pos++) {
+        memset(buf, 0x20, sizeof(buf));
+        buf[pos] = 0xFE;
+        const u8 *rv = rtruffleExec(lo, hi, buf, buf + 128);
+        ASSERT_EQ(buf + pos, rv) << "pos=" << pos;
+    }
+}
+
+TEST(ReverseTruffle, ExecNulReverse) {
+    // Reverse search for NUL
+    m128 lo, hi;
+    CharReach chars;
+    chars.set(0x00);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[80];
+    memset(buf, 0xFF, sizeof(buf));
+    buf[10] = 0x00;
+    buf[50] = 0x00;
+    const u8 *rv = rtruffleExec(lo, hi, buf, buf + 80);
+    ASSERT_EQ(buf + 50, rv); // should find the last NUL
+}
+
+TEST(ReverseTruffle, ExecMatchAtBufferStart) {
+    // Match only at the very first byte
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('X');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[200];
+    memset(buf, '.', sizeof(buf));
+    buf[0] = 'X';
+    const u8 *rv = rtruffleExec(lo, hi, buf, buf + 200);
+    ASSERT_EQ(buf, rv);
+}
+
+TEST(ReverseTruffle, ExecVaryingLengths) {
+    // Test reverse with buffers of many different lengths
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('q');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 raw[131];
+    u8 *buf = raw + 1;
+    for (size_t len = 1; len <= 130; len++) {
+        memset(buf, '.', len);
+        // No match
+        const u8 *rv = rtruffleExec(lo, hi, buf, buf + len);
+        ASSERT_EQ(raw, rv) << "len=" << len;
+
+        // Match at first position
+        buf[0] = 'q';
+        rv = rtruffleExec(lo, hi, buf, buf + len);
+        ASSERT_EQ(buf, rv) << "len=" << len;
+    }
+}
+
+TEST(ReverseTruffle, ExecLargeBuffer) {
+    // Large buffer reverse test
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('!');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[4096];
+    memset(buf, '.', sizeof(buf));
+    buf[2048] = '!';
+
+    const u8 *rv = rtruffleExec(lo, hi, buf, buf + 4096);
+    ASSERT_EQ(buf + 2048, rv);
+}
+
+TEST(ReverseTruffle, ExecAlignmentSweep) {
+    // Reverse alignment sweep
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('#');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[256];
+    memset(buf, '.', sizeof(buf));
+
+    for (size_t offset = 192; offset < 256; offset++) {
+        buf[offset] = '#';
+        const u8 *rv = rtruffleExec(lo, hi, buf, buf + 256);
+        ASSERT_EQ(buf + offset, rv) << "offset=" << offset;
+        buf[offset] = '.';
+    }
+}
+
+TEST(ReverseTruffle, ExecAllSingleCharClasses) {
+    // For every possible single-char class, verify reverse match works
+    for (unsigned c = 0; c < 256; c++) {
+        m128 lo, hi;
+        CharReach chars;
+        chars.set((u8)c);
+        truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+        u8 filler = (u8)(c ^ 0x01);
+        if (filler == (u8)c) filler = (u8)(c ^ 0x02);
+        u8 raw[65];
+        u8 *buf = raw + 1;
+        memset(buf, filler, 64);
+
+        // No match
+        const u8 *rv = rtruffleExec(lo, hi, buf, buf + 64);
+        ASSERT_EQ(raw, rv) << "c=" << c;
+
+        // Place character at position 40
+        buf[40] = (u8)c;
+        rv = rtruffleExec(lo, hi, buf, buf + 64);
+        ASSERT_EQ(buf + 40, rv) << "c=" << c;
+    }
+}
+
+TEST(ReverseTruffle, ExecMultipleMatches) {
+    // Verify reverse finds the LAST match
+    m128 lo, hi;
+    CharReach chars;
+    chars.set('a');
+    chars.set('b');
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[128];
+    memset(buf, '.', sizeof(buf));
+    buf[10] = 'a';
+    buf[50] = 'b';
+    buf[90] = 'a';
+
+    const u8 *rv = rtruffleExec(lo, hi, buf, buf + 128);
+    ASSERT_EQ(buf + 90, rv);
+
+    // Now check with restricted end
+    rv = rtruffleExec(lo, hi, buf, buf + 60);
+    ASSERT_EQ(buf + 50, rv);
+}
+
+// --- Forward: Boundary between low and high characters ---
+
+TEST(Truffle, ExecBoundaryChars) {
+    // Test characters at the 0x7f/0x80 boundary
+    m128 lo, hi;
+    CharReach chars;
+    chars.set(0x7f);
+    chars.set(0x80);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[64];
+    memset(buf, 0x41, sizeof(buf));
+
+    buf[20] = 0x80;
+    const u8 *rv = truffleExec(lo, hi, buf, buf + 64);
+    ASSERT_EQ(buf + 20, rv);
+
+    buf[20] = 0x41;
+    buf[15] = 0x7f;
+    rv = truffleExec(lo, hi, buf, buf + 64);
+    ASSERT_EQ(buf + 15, rv);
+}
+
+TEST(ReverseTruffle, ExecBoundaryChars) {
+    m128 lo, hi;
+    CharReach chars;
+    chars.set(0x7f);
+    chars.set(0x80);
+    truffleBuildMasks(chars, reinterpret_cast<u8 *>(&lo), reinterpret_cast<u8 *>(&hi));
+
+    u8 buf[64];
+    memset(buf, 0x41, sizeof(buf));
+
+    buf[40] = 0x7f;
+    buf[50] = 0x80;
+    const u8 *rv = rtruffleExec(lo, hi, buf, buf + 64);
+    ASSERT_EQ(buf + 50, rv);
 }

--- a/unit/internal/vermicelli_extra.cpp
+++ b/unit/internal/vermicelli_extra.cpp
@@ -559,7 +559,7 @@ TEST(NVermicelliExtra, ExactVecSizeLastDiff) {
 
 TEST(RVermicelliExtra, ExactVecSizeNoMatch) {
     std::vector<u8> buf(33, 'b');
-    u8 *data = buf.data() + 1;
+    const u8 *data = buf.data() + 1;
     const u8 *rv = rvermicelliExec('a', 0, data, data + 32);
     EXPECT_EQ(buf.data(), rv);
 }

--- a/unit/internal/vermicelli_extra.cpp
+++ b/unit/internal/vermicelli_extra.cpp
@@ -1,0 +1,750 @@
+/*
+ * Copyright (c) 2015-2016, Intel Corporation
+ * Copyright (c) 2021, Arm Limited
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Additional unit tests for vermicelli accelerator functions.
+ *
+ * Focuses on:
+ * - Small buffer edge cases (below VECTORSIZE)
+ * - Exact VECTORSIZE boundary
+ * - Single-byte buffers
+ * - Per-position match verification
+ * - Partial match semantics for double vermicelli
+ * - Missing reverse double NoMatch tests
+ * - Non-alphabetic characters
+ */
+
+#include "config.h"
+
+#include "gtest/gtest.h"
+#include "nfa/vermicelli.hpp"
+#include "util/bitutils.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// ============================================================================
+// Forward single-byte vermicelli: small buffer tests
+// ============================================================================
+
+TEST(VermicelliExtra, SmallMatchSingleByte) {
+    // Buffer of size 1
+    const u8 buf[1] = {'x'};
+    const u8 *rv = vermicelliExec('x', 0, buf, buf + 1);
+    EXPECT_EQ(buf, rv);
+}
+
+TEST(VermicelliExtra, SmallNoMatchSingleByte) {
+    const u8 buf[1] = {'y'};
+    const u8 *rv = vermicelliExec('x', 0, buf, buf + 1);
+    EXPECT_EQ(buf + 1, rv);
+}
+
+TEST(VermicelliExtra, SmallMatchTwoBytes) {
+    // Match at position 0
+    const u8 buf1[2] = {'x', 'y'};
+    EXPECT_EQ(buf1, vermicelliExec('x', 0, buf1, buf1 + 2));
+    // Match at position 1
+    const u8 buf2[2] = {'y', 'x'};
+    EXPECT_EQ(buf2 + 1, vermicelliExec('x', 0, buf2, buf2 + 2));
+}
+
+TEST(VermicelliExtra, SmallNoCaseMatch) {
+    // Searching uppercase with nocase in a 3-byte buffer containing lowercase
+    const u8 buf[3] = {'z', 'a', 'z'};
+    const u8 *rv = vermicelliExec('A', 1, buf, buf + 3);
+    EXPECT_EQ(buf + 1, rv);
+}
+
+TEST(VermicelliExtra, SmallRangeSweep) {
+    // For each buffer size from 1 to VECTORSIZE-1, place the target at
+    // every position and verify it is found correctly.
+    for (int len = 1; len < 32; len++) {
+        SCOPED_TRACE(len);
+        std::vector<u8> buf(len, 'b');
+        for (int pos = 0; pos < len; pos++) {
+            SCOPED_TRACE(pos);
+            buf[pos] = 'a';
+            const u8 *rv = vermicelliExec('a', 0, buf.data(),
+                                          buf.data() + len);
+            EXPECT_EQ(buf.data() + pos, rv);
+            buf[pos] = 'b';  // cppcheck-suppress unreadVariable // restore
+        }
+    }
+}
+
+// ============================================================================
+// Exact VECTORSIZE boundary tests
+// ============================================================================
+
+TEST(VermicelliExtra, ExactVecSizeNoMatch) {
+    // Buffer of exactly 32 bytes with no match
+    std::vector<u8> buf(32, 'b');
+    const u8 *rv = vermicelliExec('a', 0, buf.data(), buf.data() + 32);
+    EXPECT_EQ(buf.data() + 32, rv);
+}
+
+TEST(VermicelliExtra, ExactVecSizeMatchFirst) {
+    std::vector<u8> buf(32, 'b');
+    buf[0] = 'a';
+    const u8 *rv = vermicelliExec('a', 0, buf.data(), buf.data() + 32);
+    EXPECT_EQ(buf.data(), rv);
+}
+
+TEST(VermicelliExtra, ExactVecSizeMatchLast) {
+    std::vector<u8> buf(32, 'b');
+    buf[31] = 'a';
+    const u8 *rv = vermicelliExec('a', 0, buf.data(), buf.data() + 32);
+    EXPECT_EQ(buf.data() + 31, rv);
+}
+
+TEST(VermicelliExtra, ExactVecSizePlusOne) {
+    // VECTORSIZE + 1 bytes, match at last position (exercises tail path)
+    std::vector<u8> buf(33, 'b');
+    buf[32] = 'a';
+    const u8 *rv = vermicelliExec('a', 0, buf.data(), buf.data() + 33);
+    EXPECT_EQ(buf.data() + 32, rv);
+}
+
+// ============================================================================
+// Per-position match within SIMD register
+// ============================================================================
+
+TEST(VermicelliExtra, PerPositionForward) {
+    // Large buffer, sweep match through every position
+    const size_t LEN = 128;
+    for (size_t pos = 0; pos < LEN; pos++) {
+        SCOPED_TRACE(pos);
+        std::vector<u8> buf(LEN, 'b');
+        buf[pos] = 'a';
+        const u8 *rv = vermicelliExec('a', 0, buf.data(),
+                                      buf.data() + LEN);
+        EXPECT_EQ(buf.data() + pos, rv);
+    }
+}
+
+TEST(VermicelliExtra, PerPositionReverse) {
+    // Large buffer, sweep match through every position for reverse search
+    const size_t LEN = 128;
+    for (size_t pos = 0; pos < LEN; pos++) {
+        SCOPED_TRACE(pos);
+        std::vector<u8> buf(LEN, 'b');
+        buf[pos] = 'a';
+        const u8 *rv = rvermicelliExec('a', 0, buf.data(),
+                                       buf.data() + LEN);
+        EXPECT_EQ(buf.data() + pos, rv);
+    }
+}
+
+// ============================================================================
+// Non-alphabetic character tests
+// ============================================================================
+
+TEST(VermicelliExtra, NonAlphaChars) {
+    //                01234567890123456
+    const u8 buf[] = "hello, world! 123";
+    size_t len = strlen(reinterpret_cast<const char *>(buf));
+
+    // Space character at position 6
+    const u8 *rv = vermicelliExec(' ', 0, buf, buf + len);
+    EXPECT_EQ(buf + 6, rv);
+
+    // Digit '1' at position 14
+    rv = vermicelliExec('1', 0, buf, buf + len);
+    EXPECT_EQ(buf + 14, rv);
+
+    // Exclamation mark at position 12
+    rv = vermicelliExec('!', 0, buf, buf + len);
+    EXPECT_EQ(buf + 12, rv);
+
+    // Comma at position 5
+    rv = vermicelliExec(',', 0, buf, buf + len);
+    EXPECT_EQ(buf + 5, rv);
+}
+
+// ============================================================================
+// NVermicelli (negated) small buffer tests
+// ============================================================================
+
+TEST(NVermicelliExtra, SmallSingleByte) {
+    // 1-byte buffer, byte matches → buf_end
+    const u8 buf1[1] = {'a'};
+    EXPECT_EQ(buf1 + 1, nvermicelliExec('a', 0, buf1, buf1 + 1));
+
+    // 1-byte buffer, byte doesn't match → position 0
+    const u8 buf2[1] = {'b'};
+    EXPECT_EQ(buf2, nvermicelliExec('a', 0, buf2, buf2 + 1));
+}
+
+TEST(NVermicelliExtra, SmallRangeSweep) {
+    // Buffer of matching chars with one different char at each position
+    for (int len = 1; len < 32; len++) {
+        SCOPED_TRACE(len);
+        std::vector<u8> buf(len, 'a');
+        for (int pos = 0; pos < len; pos++) {
+            SCOPED_TRACE(pos);
+            buf[pos] = 'z';
+            const u8 *rv = nvermicelliExec('a', 0, buf.data(),
+                                           buf.data() + len);
+            EXPECT_EQ(buf.data() + pos, rv);
+            buf[pos] = 'a';  // cppcheck-suppress unreadVariable
+        }
+    }
+}
+
+TEST(NVermicelliExtra, NoCaseSmall) {
+    // nocase: both 'a' and 'A' should be considered 'the char'
+    const u8 buf[4] = {'a', 'A', 'a', 'b'};
+    const u8 *rv = nvermicelliExec('A', 1, buf, buf + 4);
+    EXPECT_EQ(buf + 3, rv);  // 'b' is the first non-matching
+}
+
+// ============================================================================
+// Reverse vermicelli small buffer tests
+// ============================================================================
+
+TEST(RVermicelliExtra, SmallSingleByte) {
+    const u8 buf[1] = {'x'};
+    EXPECT_EQ(buf, rvermicelliExec('x', 0, buf, buf + 1));
+
+    const u8 raw2[2] = {0, 'y'};
+    const u8 *buf2 = raw2 + 1;
+    EXPECT_EQ(raw2, rvermicelliExec('x', 0, buf2, buf2 + 1));
+}
+
+TEST(RVermicelliExtra, SmallThreeBytes) {
+    const u8 buf[3] = {'a', 'b', 'a'};
+    // Reverse should find the LAST 'a' at position 2
+    const u8 *rv = rvermicelliExec('a', 0, buf, buf + 3);
+    EXPECT_EQ(buf + 2, rv);
+
+    // Reverse find last 'b' at position 1
+    rv = rvermicelliExec('b', 0, buf, buf + 3);
+    EXPECT_EQ(buf + 1, rv);
+}
+
+TEST(RVermicelliExtra, SmallRangeSweep) {
+    for (int len = 1; len < 32; len++) {
+        SCOPED_TRACE(len);
+        std::vector<u8> buf(len, 'b');
+        for (int pos = 0; pos < len; pos++) {
+            SCOPED_TRACE(pos);
+            buf[pos] = 'a';
+            const u8 *rv = rvermicelliExec('a', 0, buf.data(),
+                                           buf.data() + len);
+            // Reverse returns the LAST match; 'a' is the only one at 'pos'
+            EXPECT_EQ(buf.data() + pos, rv);
+            buf[pos] = 'b';  // cppcheck-suppress unreadVariable
+        }
+    }
+}
+
+// ============================================================================
+// Reverse negated vermicelli small buffer tests
+// ============================================================================
+
+TEST(RNVermicelliExtra, SmallSingleByte) {
+    const u8 raw[2] = {0, 'a'};
+    const u8 *buf = raw + 1;
+    // All match → not found → raw (i.e. buf - 1)
+    EXPECT_EQ(raw, rnvermicelliExec('a', 0, buf, buf + 1));
+
+    const u8 buf2[1] = {'b'};
+    // Doesn't match → found at 0
+    EXPECT_EQ(buf2, rnvermicelliExec('a', 0, buf2, buf2 + 1));
+}
+
+TEST(RNVermicelliExtra, SmallRangeSweep) {
+    for (int len = 1; len < 32; len++) {
+        SCOPED_TRACE(len);
+        std::vector<u8> buf(len, 'a');
+        for (int pos = 0; pos < len; pos++) {
+            SCOPED_TRACE(pos);
+            buf[pos] = 'z';
+            const u8 *rv = rnvermicelliExec('a', 0, buf.data(),
+                                            buf.data() + len);
+            // Reverse negated finds the LAST non-matching byte
+            EXPECT_EQ(buf.data() + pos, rv);
+            buf[pos] = 'a';  // cppcheck-suppress unreadVariable
+        }
+    }
+}
+
+// ============================================================================
+// Double vermicelli: small buffer / edge case tests
+// ============================================================================
+
+TEST(DoubleVermicelliExtra, TwoByteBuffer) {
+    const u8 buf[2] = {'a', 'b'};
+    const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf, buf + 2);
+    EXPECT_EQ(buf, rv);
+
+    // No match
+    rv = vermicelliDoubleExec('b', 'a', 0, buf, buf + 2);
+    // 'b' at end → partial match
+    EXPECT_EQ(buf + 1, rv);  // last byte matches c1
+}
+
+TEST(DoubleVermicelliExtra, TwoByteNoFullMatch) {
+    const u8 buf[2] = {'x', 'y'};
+    const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf, buf + 2);
+    EXPECT_EQ(buf + 2, rv);
+}
+
+TEST(DoubleVermicelliExtra, ThreeByteMatchMiddle) {
+    const u8 buf[3] = {'x', 'a', 'b'};
+    const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf, buf + 3);
+    EXPECT_EQ(buf + 1, rv);
+}
+
+TEST(DoubleVermicelliExtra, SmallRangeSweep) {
+    // Sweep a double match through small buffers
+    for (int len = 2; len < 32; len++) {
+        SCOPED_TRACE(len);
+        for (int pos = 0; pos < len - 1; pos++) {
+            SCOPED_TRACE(pos);
+            std::vector<u8> buf(len, 'z');
+            buf[pos] = 'a';
+            buf[pos + 1] = 'b';
+            const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf.data(),
+                                                buf.data() + len);
+            EXPECT_EQ(buf.data() + pos, rv);
+        }
+    }
+}
+
+TEST(DoubleVermicelliExtra, PartialMatchAtEnd) {
+    // The last byte matches c1 but there is no c2 after it
+    const u8 buf[] = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxa";
+    size_t len = strlen(reinterpret_cast<const char *>(buf));
+    const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf, buf + len);
+    EXPECT_EQ(buf + len - 1, rv);  // Partial match at the very end
+}
+
+TEST(DoubleVermicelliExtra, NoCaseSmall) {
+    // nocase with small buffer
+    const u8 buf[3] = {'x', 'A', 'B'};
+    const u8 *rv = vermicelliDoubleExec('A', 'B', 1, buf, buf + 3);
+    EXPECT_EQ(buf + 1, rv);
+
+    const u8 buf2[3] = {'x', 'a', 'b'};
+    rv = vermicelliDoubleExec('A', 'B', 1, buf2, buf2 + 3);
+    EXPECT_EQ(buf2 + 1, rv);
+}
+
+TEST(DoubleVermicelliExtra, ExactVecSize) {
+    std::vector<u8> buf(32, 'z');
+    buf[30] = 'a';
+    buf[31] = 'b';
+    const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf.data(),
+                                        buf.data() + 32);
+    EXPECT_EQ(buf.data() + 30, rv);
+}
+
+TEST(DoubleVermicelliExtra, ExactVecSizePlusOne) {
+    // Match at the very end, in the tail path
+    std::vector<u8> buf(33, 'z');
+    buf[31] = 'a';
+    buf[32] = 'b';
+    const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf.data(),
+                                        buf.data() + 33);
+    EXPECT_EQ(buf.data() + 31, rv);
+}
+
+// ============================================================================
+// Reverse double vermicelli: NoMatch tests (were missing)
+// ============================================================================
+
+TEST(RDoubleVermicelliExtra, ExecNoMatch1) {
+    char t0[] = " bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    char *t1 = t0 + 1;
+
+    for (size_t i = 0; i < 16; i++) {
+        for (size_t j = 0; j < 16; j++) {
+            SCOPED_TRACE(i);
+            SCOPED_TRACE(j);
+            const u8 *begin = reinterpret_cast<const u8 *>(t1) + i;
+            const u8 *end = reinterpret_cast<const u8 *>(t1) + strlen(t1) - j;
+            if (begin >= end) continue;
+
+            const u8 *before_begin = begin - 1;
+            const u8 *rv = rvermicelliDoubleExec('a', 'b', 0, begin, end);
+            ASSERT_EQ(before_begin, rv);
+
+            rv = rvermicelliDoubleExec('B', 'B', 0, begin, end);
+            ASSERT_EQ(before_begin, rv);
+
+            rv = rvermicelliDoubleExec('A', 'B', 1, begin, end);
+            ASSERT_EQ(before_begin, rv);
+        }
+    }
+}
+
+// ============================================================================
+// Reverse double vermicelli: small buffer tests
+// ============================================================================
+
+TEST(RDoubleVermicelliExtra, TwoByteBuffer) {
+    const u8 buf[2] = {'a', 'b'};
+    // rvermicelliDoubleExec returns position of c2
+    const u8 *rv = rvermicelliDoubleExec('a', 'b', 0, buf, buf + 2);
+    EXPECT_EQ(buf + 1, rv);
+
+    // No match in reverse for 'b','a'
+    const u8 raw2[3] = {0, 'a', 'b'};
+    const u8 *buf2 = raw2 + 1;
+    rv = rvermicelliDoubleExec('b', 'a', 0, buf2, buf2 + 2);
+    EXPECT_EQ(raw2, rv);
+}
+
+TEST(RDoubleVermicelliExtra, SmallRangeSweep) {
+    for (int len = 2; len < 32; len++) {
+        SCOPED_TRACE(len);
+        for (int pos = 0; pos < len - 1; pos++) {
+            SCOPED_TRACE(pos);
+            std::vector<u8> buf(len, 'z');
+            buf[pos] = 'a';
+            buf[pos + 1] = 'b';
+            // Only match at (pos, pos+1), reverse finds it
+            const u8 *rv = rvermicelliDoubleExec('a', 'b', 0, buf.data(),
+                                                 buf.data() + len);
+            EXPECT_EQ(buf.data() + pos + 1, rv);  // returns c2 position
+        }
+    }
+}
+
+TEST(RDoubleVermicelliExtra, MultipleMatchesReverse) {
+    // Multiple double matches, reverse should find the last one
+    //                0123456789
+    const u8 buf[] = "xxaBxxaBxx";
+    size_t len = 10;
+    const u8 *rv = rvermicelliDoubleExec('a', 'B', 0, buf, buf + len);
+    EXPECT_EQ(buf + 7, rv);  // Last 'B' (c2) in 'aB' pair at pos 6,7
+}
+
+// ============================================================================
+// Double vermicelli masked: small buffer tests
+// ============================================================================
+
+TEST(DoubleVermicelliMaskedExtra, TwoByteBuffer) {
+    const u8 buf[2] = {'a', 'b'};
+    const u8 *rv = vermicelliDoubleMaskedExec('a', 'b', 0xff, 0xff,
+                                              buf, buf + 2);
+    EXPECT_EQ(buf, rv);
+}
+
+TEST(DoubleVermicelliMaskedExtra, SmallRangeSweep) {
+    for (int len = 2; len < 32; len++) {
+        SCOPED_TRACE(len);
+        for (int pos = 0; pos < len - 1; pos++) {
+            SCOPED_TRACE(pos);
+            std::vector<u8> buf(len, 'z');
+            buf[pos] = 'a';
+            buf[pos + 1] = 'b';
+            const u8 *rv = vermicelliDoubleMaskedExec('a', 'b', 0xff, 0xff,
+                                                      buf.data(),
+                                                      buf.data() + len);
+            EXPECT_EQ(buf.data() + pos, rv);
+        }
+    }
+}
+
+TEST(DoubleVermicelliMaskedExtra, MaskPartialBits) {
+    // Use masks to match only certain bits
+    // 'a' = 0x61, 'b' = 0x62, 'c' = 0x63
+    // With mask 0xfe, 'b' (0x62) and 'c' (0x63) both become 0x62
+    const u8 buf[3] = {'a', 'c', 'z'};
+    const u8 *rv = vermicelliDoubleMaskedExec('a', 'b', 0xff, 0xfe,
+                                              buf, buf + 3);
+    // 'a' & 0xff = 'a' matches c1='a', 'c' & 0xfe = 0x62 matches c2='b'=0x62
+    EXPECT_EQ(buf, rv);
+}
+
+// ============================================================================
+// Alignment stress test: varying start offset and length
+// ============================================================================
+
+TEST(VermicelliExtra, AlignmentStress) {
+    // Allocate a large buffer and test with various alignments
+    const size_t TOTAL = 256;
+    std::vector<u8> alloc(TOTAL + 64, 'b');
+    u8 *base = alloc.data();
+
+    // Ensure base is aligned to 64 (safe source)
+    u8 *aligned_base = reinterpret_cast<u8 *>(
+        (reinterpret_cast<uintptr_t>(base) + 63) & ~uintptr_t(63));
+
+    for (size_t offset = 0; offset < 32; offset++) {
+        for (size_t len = 1; len <= 128; len++) {
+            SCOPED_TRACE(offset);
+            SCOPED_TRACE(len);
+
+            u8 *buf = aligned_base + offset;
+            std::fill(buf, buf + len, 'b');
+
+            // No match
+            const u8 *rv = vermicelliExec('a', 0, buf, buf + len);
+            EXPECT_EQ(buf + len, rv);
+
+            // Place match at last position
+            buf[len - 1] = 'a';
+            rv = vermicelliExec('a', 0, buf, buf + len);
+            EXPECT_EQ(buf + len - 1, rv);
+            buf[len - 1] = 'b';
+
+            // Place match at first position
+            buf[0] = 'a';
+            rv = vermicelliExec('a', 0, buf, buf + len);
+            EXPECT_EQ(buf, rv);
+            buf[0] = 'b';
+        }
+    }
+}
+
+// ============================================================================
+// NVermicelli: exact VECTORSIZE boundary
+// ============================================================================
+
+TEST(NVermicelliExtra, ExactVecSizeAllMatch) {
+    std::vector<u8> buf(32, 'a');
+    const u8 *rv = nvermicelliExec('a', 0, buf.data(), buf.data() + 32);
+    EXPECT_EQ(buf.data() + 32, rv);
+}
+
+TEST(NVermicelliExtra, ExactVecSizeFirstDiff) {
+    std::vector<u8> buf(32, 'a');
+    buf[0] = 'x';
+    const u8 *rv = nvermicelliExec('a', 0, buf.data(), buf.data() + 32);
+    EXPECT_EQ(buf.data(), rv);
+}
+
+TEST(NVermicelliExtra, ExactVecSizeLastDiff) {
+    std::vector<u8> buf(32, 'a');
+    buf[31] = 'x';
+    const u8 *rv = nvermicelliExec('a', 0, buf.data(), buf.data() + 32);
+    EXPECT_EQ(buf.data() + 31, rv);
+}
+
+// ============================================================================
+// Reverse vermicelli: exact VECTORSIZE boundary
+// ============================================================================
+
+TEST(RVermicelliExtra, ExactVecSizeNoMatch) {
+    std::vector<u8> buf(33, 'b');
+    u8 *data = buf.data() + 1;
+    const u8 *rv = rvermicelliExec('a', 0, data, data + 32);
+    EXPECT_EQ(buf.data(), rv);
+}
+
+TEST(RVermicelliExtra, ExactVecSizeMatchFirst) {
+    std::vector<u8> buf(32, 'b');
+    buf[0] = 'a';
+    const u8 *rv = rvermicelliExec('a', 0, buf.data(), buf.data() + 32);
+    EXPECT_EQ(buf.data(), rv);
+}
+
+TEST(RVermicelliExtra, ExactVecSizeMatchLast) {
+    std::vector<u8> buf(32, 'b');
+    buf[31] = 'a';
+    const u8 *rv = rvermicelliExec('a', 0, buf.data(), buf.data() + 32);
+    EXPECT_EQ(buf.data() + 31, rv);
+}
+
+// ============================================================================
+// Double vermicelli: per-position sweep in large buffer
+// ============================================================================
+
+TEST(DoubleVermicelliExtra, PerPositionSweep) {
+    const size_t LEN = 128;
+    for (size_t pos = 0; pos < LEN - 1; pos++) {
+        SCOPED_TRACE(pos);
+        std::vector<u8> buf(LEN, 'z');
+        buf[pos] = 'a';
+        buf[pos + 1] = 'b';
+        const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf.data(),
+                                            buf.data() + LEN);
+        EXPECT_EQ(buf.data() + pos, rv);
+    }
+}
+
+TEST(RDoubleVermicelliExtra, PerPositionSweep) {
+    const size_t LEN = 128;
+    for (size_t pos = 0; pos < LEN - 1; pos++) {
+        SCOPED_TRACE(pos);
+        std::vector<u8> buf(LEN, 'z');
+        buf[pos] = 'a';
+        buf[pos + 1] = 'b';
+        const u8 *rv = rvermicelliDoubleExec('a', 'b', 0, buf.data(),
+                                             buf.data() + LEN);
+        EXPECT_EQ(buf.data() + pos + 1, rv);  // returns c2 pos
+    }
+}
+
+// ============================================================================
+// NVermicelli: per-position sweep
+// ============================================================================
+
+TEST(NVermicelliExtra, PerPositionSweep) {
+    const size_t LEN = 128;
+    for (size_t pos = 0; pos < LEN; pos++) {
+        SCOPED_TRACE(pos);
+        std::vector<u8> buf(LEN, 'a');
+        buf[pos] = 'x';
+        const u8 *rv = nvermicelliExec('a', 0, buf.data(),
+                                       buf.data() + LEN);
+        EXPECT_EQ(buf.data() + pos, rv);
+    }
+}
+
+// ============================================================================
+// RNVermicelli: per-position sweep
+// ============================================================================
+
+TEST(RNVermicelliExtra, PerPositionSweep) {
+    const size_t LEN = 128;
+    for (size_t pos = 0; pos < LEN; pos++) {
+        SCOPED_TRACE(pos);
+        std::vector<u8> buf(LEN, 'a');
+        buf[pos] = 'x';
+        const u8 *rv = rnvermicelliExec('a', 0, buf.data(),
+                                        buf.data() + LEN);
+        EXPECT_EQ(buf.data() + pos, rv);  // reverse: finds last non-match
+    }
+}
+
+// ============================================================================
+// Double vermicelli masked: per-position sweep
+// ============================================================================
+
+TEST(DoubleVermicelliMaskedExtra, PerPositionSweep) {
+    const size_t LEN = 128;
+    for (size_t pos = 0; pos < LEN - 1; pos++) {
+        SCOPED_TRACE(pos);
+        std::vector<u8> buf(LEN, 'z');
+        buf[pos] = 'a';
+        buf[pos + 1] = 'b';
+        const u8 *rv = vermicelliDoubleMaskedExec('a', 'b', 0xff, 0xff,
+                                                  buf.data(),
+                                                  buf.data() + LEN);
+        EXPECT_EQ(buf.data() + pos, rv);
+    }
+}
+
+// ============================================================================
+// Cross-boundary double match stress test
+// ============================================================================
+
+TEST(DoubleVermicelliExtra, CrossBoundarySweep) {
+    // Place a double match right at every potential SIMD boundary
+    // VECTORSIZE = 32 in this build
+    const size_t LEN = 256;
+    for (size_t start = 0; start < 32; start++) {
+        SCOPED_TRACE(start);
+        std::vector<u8> alloc(LEN + 64, 'z');
+        u8 *buf = alloc.data() + start;
+        size_t buflen = LEN;
+
+        for (size_t pos = 0; pos < buflen - 1; pos++) {
+            buf[pos] = 'a';
+            buf[pos + 1] = 'b';
+
+            const u8 *rv = vermicelliDoubleExec('a', 'b', 0, buf,
+                                                buf + buflen);
+            EXPECT_EQ(buf + pos, rv) << "start=" << start << " pos=" << pos;
+
+            buf[pos] = 'z';
+            buf[pos + 1] = 'z';
+        }
+    }
+}
+
+// ============================================================================
+// Consistency test: forward + reverse on same data
+// ============================================================================
+
+TEST(VermicelliExtra, ForwardReverseConsistency) {
+    const size_t LEN = 200;
+    std::vector<u8> buf(LEN, 'b');
+
+    // Place a single 'a' at each position
+    for (size_t pos = 0; pos < LEN; pos++) {
+        SCOPED_TRACE(pos);
+        buf[pos] = 'a';
+
+        const u8 *fwd = vermicelliExec('a', 0, buf.data(), buf.data() + LEN);
+        const u8 *rev = rvermicelliExec('a', 0, buf.data(), buf.data() + LEN);
+
+        // With only one match, forward and reverse should find the same
+        EXPECT_EQ(fwd, rev);
+        EXPECT_EQ(buf.data() + pos, fwd);
+
+        buf[pos] = 'b';
+    }
+
+    // Two matches: forward finds first, reverse finds last
+    buf[10] = 'a';
+    buf[190] = 'a';
+    const u8 *fwd = vermicelliExec('a', 0, buf.data(), buf.data() + LEN);
+    const u8 *rev = rvermicelliExec('a', 0, buf.data(), buf.data() + LEN);
+    EXPECT_EQ(buf.data() + 10, fwd);
+    EXPECT_EQ(buf.data() + 190, rev);
+}
+
+// ============================================================================
+// NVermicelli + RNVermicelli consistency
+// ============================================================================
+
+TEST(NVermicelliExtra, ForwardReverseConsistency) {
+    const size_t LEN = 200;
+    std::vector<u8> buf(LEN, 'a');
+
+    // Place a single different byte at each position
+    for (size_t pos = 0; pos < LEN; pos++) {
+        SCOPED_TRACE(pos);
+        buf[pos] = 'x';
+
+        const u8 *fwd = nvermicelliExec('a', 0, buf.data(), buf.data() + LEN);
+        const u8 *rev = rnvermicelliExec('a', 0, buf.data(), buf.data() + LEN);
+
+        EXPECT_EQ(fwd, rev);
+        EXPECT_EQ(buf.data() + pos, fwd);
+
+        buf[pos] = 'a';
+    }
+
+    // Two different bytes
+    buf[10] = 'x';
+    buf[190] = 'x';
+    const u8 *fwd = nvermicelliExec('a', 0, buf.data(), buf.data() + LEN);
+    const u8 *rev = rnvermicelliExec('a', 0, buf.data(), buf.data() + LEN);
+    EXPECT_EQ(buf.data() + 10, fwd);
+    EXPECT_EQ(buf.data() + 190, rev);
+}


### PR DESCRIPTION
## Summary

Fix multiple bugs in SIMD accelerators (shufti, truffle, noodle, vermicelli) and simd_utils across SVE, AVX-512, and generic x86 code paths. Add comprehensive unit tests to prevent regressions.

## Bug Fixes

### vermicelli: AVX-512 nvermicelli tail scan masking bug
The tail path in `nvermicelliExecReal` loads a vector from `buf_end - S`, placing unprocessed bytes at the end of the vector. However, `first_zero_match_inverted<64>` masks only the first `len` bytes, completely missing the actual tail. Fixed by scanning the full vector (S=16/S=32 already did this implicitly).

### shufti-double: false positive on vector boundary
Use predicate mask to prevent false positives when scanning across vector boundaries.

### truffle: off-by-one in SVE reverse tail
Fix off-by-one error in `rtruffleExecSVE` tail processing.

### noodle SVE: incorrect return types and scan length
- Change return type from `hwlmcb_rv_t` to `hwlm_error_t` to match actual function signatures.
- Fix `scanDouble` short-path condition to use `(e - d)` instead of `scan_len`, which could be stale after adjusting `d` for history.
- Fix signedness mismatch in pointer comparison.

### simd_utils: rshift64 macros and misc bugs
- Convert `rshift64_m128`/`m256`/`m512` macros to inline functions supporting runtime (non-constant) shift amounts on x86, matching existing `lshift64` implementations.
- Fix `lshift64_m256`/`rshift64_m256` parameter type from `int` to `unsigned` in non-256-bit fallback.
- Fix `isnonzero512`: remove redundant self-OR operations.
- Fix `load512`: correct alignment assertion to check `m512` instead of `m256`.

### sheng tests: DFA state transition table size mismatch
Add missing sentinel element to state transition vectors for 16-state and 32-state DFA test configurations.

### gtest: uninitialized variable warning
Initialize `dummy` variable in `StackGrowsDown()` to suppress `-Wuninitialized`.

...and some minor fixes.

## Tests Added

- **vermicelli** (new file): small buffers, alignment sweep, VECTORSIZE boundaries, per-position match, double/masked/reverse/negated variants, cross-boundary stress, forward+reverse consistency (~750 lines)
- **noodle**: early termination, no-match, empty/minimal buffers, large buffers, case-insensitive, unaligned, alignment boundaries, all-match dense buffers (~413 lines)
- **truffle**: SVE reverse tail, boundary conditions, large buffers, varying lengths, high-byte and NUL chars, alignment sweep, character class coverage (~475 lines)
- **shufti**: double shufti regression tests for vector boundary false positives (~186 lines)

## Commits

- 2c195c814b04 vermicelli: correct AVX-512 nvermicelli tail scan masking bug
- 85c0b3c3cb0a noodle: add comprehensive noodle engine unit tests
- e75bacc5ab78 sheng: correct DFA state transition table sizes
- 36c3548fe594 gtest: initialize variable to suppress -Wuninitialized warning
- 2414ae9e2004 hwlm: correct return types and scan length in SVE noodle engine
- dbbba02354af simd: convert rshift64 macros to functions and fix simd_utils bugs
- 69972cb1612d vermicelli: Add vermicelli accelerator unit tests for edge cases
- 6d8becc2bf28 truffle: fix off-by-one in rtruffleExecSVE tail and add unit tests
- f58f253227b8 shufti-double: use predicate mask to prevent false positives
- 059e94b0abf4 state-compress: fix compiler error in storecompressed128_64bit

## Files Changed

13 files changed, 1892 insertions(+), 40 deletions(-)

@AhnLab-OSS @AhnLab-OSSG