### PR TITLE
vermicelli: correct AVX-512 nvermicelli tail scan masking bug

### DIFF
--- a/src/nfa/vermicelli_simd.cpp
+++ b/src/nfa/vermicelli_simd.cpp
@@ -175,7 +175,7 @@ static const u8 *nvermicelliExecReal(SuperVector<S> const chars, SuperVector<S> 
 
     if (d != buf_end) {
         SuperVector<S> data = SuperVector<S>::loadu(buf_end - S);
-        rv = vermicelliBlockNeg(data, chars, casemask, buf_end - S, buf_end - d);
+        rv = vermicelliBlockNeg(data, chars, casemask, buf_end - S, S);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end) return rv;
     }


### PR DESCRIPTION
In nvermicelliExecReal, the tail path loads a vector from (buf_end - S) so the unprocessed tail bytes sit at the END of the vector (high offsets). However, first_zero_match_inverted<64> applies a mask selecting only the FIRST 'len' bytes (low offsets), which means it re-checks the already-scanned overlap region and completely misses the actual tail bytes.

This only affects AVX-512 (S=64) because the 16-byte and 32-byte specializations of first_zero_match_inverted mark 'len' as UNUSED and always check the full vector.

Fix by passing S instead of (buf_end - d) as the length, so the full vector is checked. The overlap bytes are guaranteed to already match, so no false positives are possible, and the existing (rv < buf_end) guard prevents out-of-range results.

Fixes: 87d8b357a98a ("Feature/refactor fdr (#251)")

@AhnLab-OSS @AhnLab-OSSG