### PR TITLE
Fix out-of-bounds read in shuftiDoubleExecReal tail handling

### DIFF
--- a/src/nfa/shufti_simd.hpp
+++ b/src/nfa/shufti_simd.hpp
@@ -272,18 +272,33 @@ const u8 *shuftiDoubleExecReal(m128 mask1_lo, m128 mask1_hi, m128 mask2_lo, m128
         }
     }
 
-    ptrdiff_t last_mask_len = S;
     DEBUG_PRINTF("tail d %p e %p \n", d, buf_end);
     // finish off tail
 
     if (d != buf_end) {
-        SuperVector<S> chars = SuperVector<S>::loadu(d);
-        rv = fwdBlockDouble(wide_mask1_lo, wide_mask1_hi, wide_mask2_lo, wide_mask2_hi, &first_char_mask, chars, d);
+        SuperVector<S> chars;
+        const u8 *tail_buf;
+        if (buf_end - buf < S) {
+            // Buffer is shorter than one vector width: copy valid bytes into
+            // a zeroed vector to avoid reading past the buffer.
+            chars = SuperVector<S>::Zeroes();
+            memcpy(&chars.u, buf, buf_end - buf);
+            tail_buf = buf;
+        } else {
+            // Read the last S bytes of the buffer (may overlap with the
+            // previous main-loop block, but stays in bounds).
+            chars = SuperVector<S>::loadu(buf_end - S);
+            tail_buf = buf_end - S;
+        }
+        // Reset first_char_mask: the backward read re-covers enough context
+        // for any cross-boundary two-char match to be found within this block.
+        first_char_mask = SuperVector<S>::Ones();
+        rv = fwdBlockDouble(wide_mask1_lo, wide_mask1_hi, wide_mask2_lo, wide_mask2_hi, &first_char_mask, chars, tail_buf);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end - 1) return rv;
-        last_mask_len = buf_end - d;
     }
 
+    ptrdiff_t last_mask_len = (buf_end - buf < S) ? (buf_end - buf) : S;
     rv = check_last_byte(wide_mask2_lo, wide_mask2_hi, first_char_mask, last_mask_len, buf_end);
     if (rv) return rv;
     return buf_end;

--- a/unit/internal/shufti.cpp
+++ b/unit/internal/shufti.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 
 #include <set>
+#include <sys/mman.h>
 
 #include "gtest/gtest.h"
 #include "nfa/shufti.h"
@@ -934,6 +935,59 @@ TEST(DoubleShufti, ExecNoMatchVectorEdge) {
 
         ASSERT_EQ(reinterpret_cast<const u8 *>(t1 + len), rv);
     }
+}
+
+// Regression test: shuftiDoubleExecReal used to read a full vector (S bytes)
+// in the tail, which could overread past buf_end. If the buffer ends at a page
+// boundary followed by an unmapped page, this causes a SIGSEGV.
+TEST(DoubleShufti, ExecNoOverreadPageBoundary) {
+    m128 lo1, hi1, lo2, hi2;
+
+    flat_set<pair<u8, u8>> lits;
+    lits.insert(make_pair('a','b'));
+
+    bool ret = shuftiBuildDoubleMasks(CharReach(), lits,
+                                      reinterpret_cast<u8 *>(&lo1), reinterpret_cast<u8 *>(&hi1),
+                                      reinterpret_cast<u8 *>(&lo2), reinterpret_cast<u8 *>(&hi2));
+    ASSERT_TRUE(ret);
+
+    const size_t page_size = 4096;
+    // Map two pages, then unmap the second to create a guard page.
+    u8 *pages = reinterpret_cast<u8 *>(mmap(nullptr, 2 * page_size,
+                           PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(MAP_FAILED, reinterpret_cast<void *>(pages));
+    ASSERT_EQ(0, munmap(pages + page_size, page_size));
+
+    u8 *page_end = pages + page_size;
+
+    // Test various buffer lengths ending right at the page boundary.
+    // Without the fix, lengths that are not a multiple of the vector size will
+    // cause the tail code to read past page_end into the unmapped guard page.
+    for (size_t len = 1; len <= 256; len++) {
+        u8 *buf = page_end - len;
+        memset(buf, 'c', len); // fill with non-matching data
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2, buf, page_end);
+        // No match expected: rv should be at or past buf_end
+        ASSERT_GE((size_t)rv, (size_t)(page_end - 1))
+            << "Unexpected match at len=" << len;
+    }
+
+    // Also test with an actual match near the end.
+    for (size_t len = 2; len <= 256; len++) {
+        u8 *buf = page_end - len;
+        memset(buf, 'c', len);
+        // Place matching pair "ab" near the end of the buffer.
+        buf[len - 2] = 'a';
+        buf[len - 1] = 'b';
+
+        const u8 *rv = shuftiDoubleExec(lo1, hi1, lo2, hi2, buf, page_end);
+        ASSERT_EQ((size_t)(page_end - 2), (size_t)rv)
+            << "Match not found at expected position for len=" << len;
+    }
+
+    munmap(pages, page_size);
 }
 
 TEST(ReverseShufti, ExecNoMatch1) {


### PR DESCRIPTION
Commit 9e9a10ad ("Fix double shufti's vector end false positive", #325) changed the tail code in shuftiDoubleExecReal to read a full vector from the current pointer (loadu(d)), which can overread past buf_end by up to S-1 bytes. When the buffer ends at a page boundary followed by unmapped memory, this causes a SIGSEGV.

Fix by reading the last S bytes backward from buf_end (matching the approach used in shuftiExecReal), and falling back to memcpy for buffers shorter than one vector width.

------

Full disclosure - this change is entirely AI generated (but I understand the bug it tries to fix :) So I'm unsure if this is the correct way to fix it, I'm not acquainted with this project enough. Feel free to overtake this PR, or to close it and fix it someway else.

We've hit this crash in one of our apps after upgrading to 5.4.12 and this seems to be the root cause. Due to the bug's nature I wasn't able to verify that this fix eliminates the problem (this is statistical, depends on whether we try to scan buffers that happen to end on a page boundary followed by an unmapped page).
The added test segfaults without the fix, and the code bytes provided by the kernel match the code bytes the kernel reported when our app crashed.
```
Mar 18 23:20:13 yonatan kernel: unit-internal[3411287]: segfault at 716770493000 ip 00005b9365d6b839 sp 00007ffc46d84d80 error 4 in unit-internal[47b839,5b936596d000+7df000] likely on CPU 3 (core 12, socket 0)
Mar 18 23:20:13 yonatan kernel: Code: ff e9 00 01 00 00 0f 1f 00 c5 cd 76 f6 48 39 fa 0f 84 1b 01 00 00 48 b8 0f 0f 0f 0f 0f 0f 0f 0f c4 e1 f9 6e c0 c4 e2 7d 59 c0 <c5> fd df 22 c5 fd db 02 c5 dd 73 d4 04 c4 62 2d 00 d0 c4 e2 75 00
```