### PR TITLE
Fix compiler errors with clang21, gcc15/gcc16.

### DIFF
--- a/src/nfa/shengcompile.cpp
+++ b/src/nfa/shengcompile.cpp
@@ -100,7 +100,9 @@ struct dfa_info {
     }
     dstate &next(dstate_id_t idx, u16 chr) {
         const auto &src = (*this)[idx];
-        auto next_id = src.next[raw.alpha_remap[chr]];
+        const auto idx2 = raw.alpha_remap[chr];
+        if (idx2 >= src.next.size()) return floating;
+        auto next_id = src.next[idx2];
         return states[next_id];
     }
     // get original idx from adjusted idx

--- a/unit/gtest/gtest-all.cc
+++ b/unit/gtest/gtest-all.cc
@@ -7480,7 +7480,7 @@ void StackLowerThanAddress(const void* ptr, bool* result) {
 }
 
 bool StackGrowsDown() {
-  int dummy;
+  int dummy{0};
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
Builds with clang21 fail to complete because of uninitialized `dummy` variable in gtest-all.cc, for example: 

https://buildbot-ci.vectorcamp.gr/#/builders/469/builds/22

Furthermore, with gcc15/gcc16, shengcompiler.cpp throws an exception in Sheng16.std_compile_header due to some different behaviour in std::vector. Adding the check doesn't hurt anyway and the tests pass.

Example failure: 

https://buildbot-ci.vectorcamp.gr/#/builders/481/builds/23