### PR TITLE
bug 349: remove dead code

### DIFF
--- a/src/nfa/limex_common_impl.h
+++ b/src/nfa/limex_common_impl.h
@@ -165,7 +165,7 @@ char PROCESS_ACCEPTS_IMPL_FN(const IMPL_NFA_T *limex, const STATE_T *s,
 }
 
 static never_inline
-char PROCESS_ACCEPTS_FN(const IMPL_NFA_T *limex, STATE_T *s,
+char PROCESS_ACCEPTS_FN(const IMPL_NFA_T *limex, const STATE_T *s,
                         const STATE_T *acceptMask,
                         const struct NFAAccept *acceptTable, u64a offset,
                         NfaCallback callback, void *context) {
@@ -173,8 +173,6 @@ char PROCESS_ACCEPTS_FN(const IMPL_NFA_T *limex, STATE_T *s,
     STATE_T squash = ONES_STATE;
     return PROCESS_ACCEPTS_IMPL_FN(limex, s, &squash, acceptMask, acceptTable,
                                    offset, callback, context);
-
-    *s = AND_STATE(*s, squash);
 }
 
 static never_inline


### PR DESCRIPTION
This should fix the compiler warning in #349 , this code was never executed. In release mode it was optimized away.