### PR TITLE
do not assume page_size is 4k, fails on Apple Silicon

### DIFF
--- a/unit/internal/shufti.cpp
+++ b/unit/internal/shufti.cpp
@@ -951,7 +951,7 @@ TEST(DoubleShufti, ExecNoOverreadPageBoundary) {
                                       reinterpret_cast<u8 *>(&lo2), reinterpret_cast<u8 *>(&hi2));
     ASSERT_TRUE(ret);
 
-    const size_t page_size = 4096;
+    const size_t page_size = sysconf(_SC_PAGE_SIZE);
     // Map two pages, then unmap the second to create a guard page.
     u8 *pages = reinterpret_cast<u8 *>(mmap(nullptr, 2 * page_size,
                            PROT_READ | PROT_WRITE,


### PR DESCRIPTION
Assuming page_size is 4k makes other OSes fail this unit test, eg:

https://buildbot-ci.vectorcamp.gr/#/builders/62/builds/390

But it might also fail on Linux with 64k page size. 
Using sysconf(_SC_PAGE_SIZE) to get the right value fixes this.