### PR TITLE
Fix stack buffer overflow in `rvermicelliDoubleExecReal()`

### DIFF
--- a/src/nfa/vermicelli_simd.cpp
+++ b/src/nfa/vermicelli_simd.cpp
@@ -368,9 +368,6 @@ const u8 *rvermicelliDoubleExecReal(char c1, char c2, SuperVector<S> const casem
     assert(buf < buf_end);
     DEBUG_PRINTF("rverm %p len %zu\n", buf, buf_end - buf);
     DEBUG_PRINTF("b %s\n", buf);
-    char s[255];
-    snprintf(s, buf_end - buf + 1, "%s", buf);
-    DEBUG_PRINTF("b %s\n", s);
 
     const u8 *d = buf_end;
     const u8 *rv;


### PR DESCRIPTION
In [rvermicelliDoubleExecReal()](https://github.com/VectorCamp/vectorscan/blob/ecab70848ad41c8b5a0302bfaeb387203118045e/src/nfa/vermicelli_simd.cpp#L366), the `snprintf()` size parameter is derived from input buffer length rather than the destination buffer capacity. This triggers stack buffer overflow on inputs >255 bytes with patterns like ".*literal", causing process crashes with "buffer overflow detected" in my release builds.

The `snprintf()` on line 372 executes unconditionally (not debug-only) and writes `buf_end-buf+1` bytes into a 255-byte stack buffer.

This was unnecessary, as a previous debug print already existed for the same buffer.