### PR TITLE
Bug #210: Throw error at invalid character classes

### DIFF
--- a/src/parser/Parser.rl
+++ b/src/parser/Parser.rl
@@ -1099,6 +1099,12 @@ unichar readUtf8CodePoint4c(const char *s) {
                   throwInvalidUtf8();
               };
 
+              # Nested character classes are not supported (issue #210)
+              '[' => { throw LocatedParseError("Nested character classes are not supported"); };
+
+              # Character class intersection/subtraction (Java-style) not supported (issue #210)
+              '&&' => { throw LocatedParseError("Character class intersection/subtraction is not supported"); };
+
               # Literal character
               (any - ']') => {
                   currentCls->add((u8)*ts);

--- a/unit/hyperscan/bad_patterns.txt
+++ b/unit/hyperscan/bad_patterns.txt
@@ -158,3 +158,7 @@
 161:/141/C #No logical operation.
 162:/119 & 121/C #Unknown sub-expression id.
 163:/166 & 167/C #Unknown sub-expression id.
+164:/[a-d[m-p]]/ #Nested character classes are not supported at index 4.
+165:/[a-z&&[def]]/ #Character class intersection/subtraction is not supported at index 4.
+166:/[a-z&&[^bc]]/ #Character class intersection/subtraction is not supported at index 4.
+167:/[a-z&&[^m-p]]/ #Character class intersection/subtraction is not supported at index 4.

--- a/unit/hyperscan/bad_patterns_fast.txt
+++ b/unit/hyperscan/bad_patterns_fast.txt
@@ -157,3 +157,7 @@
 161:/141/C #No logical operation.
 162:/119 & 121/C #Unknown sub-expression id.
 163:/166 & 167/C #Unknown sub-expression id.
+164:/[a-d[m-p]]/ #Nested character classes are not supported at index 4.
+165:/[a-z&&[def]]/ #Character class intersection/subtraction is not supported at index 4.
+166:/[a-z&&[^bc]]/ #Character class intersection/subtraction is not supported at index 4.
+167:/[a-z&&[^m-p]]/ #Character class intersection/subtraction is not supported at index 4.


### PR DESCRIPTION
This issue is a bit old and it would probably be more work to fix it properly and recognize the patterns as valid and match them, but throwing an error is better than throwing false negatives.

Closes: #210 