### PR TITLE
Right Shift in rshift64_m128 fallback path (ARM NEON)

### DIFF
--- a/src/util/arch/arm/simd_utils.h
+++ b/src/util/arch/arm/simd_utils.h
@@ -113,7 +113,7 @@ m128 lshift_m128(m128 a, unsigned b) {
     }
 #endif
   int32x4_t shift_indices = vdupq_n_s32(b);
-  return (m128) vshlq_s32(a, shift_indices);
+  return (m128) vshlq_u32((uint32x4_t)a, shift_indices);
 }
 
 static really_really_inline
@@ -124,7 +124,7 @@ m128 rshift_m128(m128 a, unsigned b) {
     }
 #endif
   int32x4_t shift_indices = vdupq_n_s32(-b);
-  return (m128) vshlq_s32(a, shift_indices);
+  return (m128) vshlq_u32((uint32x4_t)a, shift_indices);
 }
 
 static really_really_inline
@@ -135,7 +135,7 @@ m128 lshift64_m128(m128 a, unsigned b) {
     }
 #endif
   int64x2_t shift_indices = vdupq_n_s64(b);
-  return (m128) vshlq_s64((int64x2_t) a, shift_indices);
+  return (m128) vshlq_u64((uint64x2_t) a, shift_indices);
 }
 
 static really_really_inline
@@ -146,7 +146,7 @@ m128 rshift64_m128(m128 a, unsigned b) {
     }
 #endif
   int64x2_t shift_indices = vdupq_n_s64(-b);
-  return (m128) vshlq_s64((int64x2_t) a, shift_indices);
+  return (m128) vshlq_u64((uint64x2_t) a, shift_indices);
 }
 
 static really_inline m128 eq128(m128 a, m128 b) {

--- a/unit/hyperscan/regressions.cpp
+++ b/unit/hyperscan/regressions.cpp
@@ -464,7 +464,12 @@ TEST(ArmRegression, NoDotAll_Long) {
     hs_free_database(db);
 }
 
+
 TEST(utf8, charclass_issue_326) {
+    /*
+     * This is a modified test case from https://github.com/VectorCamp/vectorscan/issues/326
+     * It includes both test patterns mentioned in the issue.
+     */
     vector<pattern> unicode_patterns = {
     pattern(R"(\x{ff15}\x{ff10}\x{ff17}\x{ff15}\x{ff10}[\x{ff10}-\x{ff19}]{7})",
         HS_FLAG_DOTALL | HS_FLAG_PREFILTER | HS_FLAG_MULTILINE | HS_FLAG_CASELESS | HS_FLAG_UCP | HS_FLAG_UTF8, 1),

--- a/unit/hyperscan/regressions.cpp
+++ b/unit/hyperscan/regressions.cpp
@@ -463,3 +463,45 @@ TEST(ArmRegression, NoDotAll_Long) {
     hs_free_scratch(scratch);
     hs_free_database(db);
 }
+
+unsigned countMatchesById(const vector<MatchRecord> &matches, int id) {
+    unsigned count = 0;
+    for (vector<MatchRecord>::const_iterator it = matches.begin();
+         it != matches.end(); ++it) {
+        if (id == it->id) {
+            count++;
+        }
+    }
+    return count;
+}
+
+TEST(utf8, charclass_issue_326) {
+    vector<pattern> patterns = {
+    pattern(R"(\x{ff15}\x{ff10}\x{ff17}\x{ff15}\x{ff10}[\x{ff10}-\x{ff19}]{7})",
+        HS_FLAG_DOTALL | HS_FLAG_PREFILTER | HS_FLAG_MULTILINE | HS_FLAG_CASELESS | HS_FLAG_UCP | HS_FLAG_UTF8, 1),
+    pattern(R"(NL[0-9\x{ff10}-\x{ff19}]{2}[A-Z\x{ff21}-\x{ff3a}a-z\x{ff41}-\x{ff5a}]{4}[0-9\x{ff10}-\x{ff19}]{10})",
+        HS_FLAG_PREFILTER | HS_FLAG_SINGLEMATCH| HS_FLAG_UTF8, 2)
+    };
+    const char *data1 = "５０７５０７８３２４０１";
+    const char *data2 = "NL２０INGB０００１２３４567";
+
+    hs_database_t *db = buildDB(patterns, HS_MODE_NOSTREAM);
+    ASSERT_NE(nullptr, db);
+
+    hs_scratch_t *scratch = nullptr;
+    hs_error_t err = hs_alloc_scratch(db, &scratch);
+    ASSERT_EQ(HS_SUCCESS, err);
+
+    CallBackContext c1, c2;
+    err = hs_scan(db, data1, strlen(data1), 0, scratch, record_cb, (void *)&c1);
+    ASSERT_EQ(HS_SUCCESS, err);
+    
+    err = hs_scan(db, data2, strlen(data2), 0, scratch, record_cb, (void *)&c2);
+    ASSERT_EQ(HS_SUCCESS, err);
+
+    EXPECT_EQ(1, countMatchesById(c1.matches, 1));
+    EXPECT_EQ(1, countMatchesById(c2.matches, 2));
+    err = hs_free_scratch(scratch);
+    ASSERT_EQ(HS_SUCCESS, err);
+    hs_free_database(db);
+}

--- a/unit/hyperscan/regressions.cpp
+++ b/unit/hyperscan/regressions.cpp
@@ -464,19 +464,8 @@ TEST(ArmRegression, NoDotAll_Long) {
     hs_free_database(db);
 }
 
-unsigned countMatchesById(const vector<MatchRecord> &matches, int id) {
-    unsigned count = 0;
-    for (vector<MatchRecord>::const_iterator it = matches.begin();
-         it != matches.end(); ++it) {
-        if (id == it->id) {
-            count++;
-        }
-    }
-    return count;
-}
-
 TEST(utf8, charclass_issue_326) {
-    vector<pattern> patterns = {
+    vector<pattern> unicode_patterns = {
     pattern(R"(\x{ff15}\x{ff10}\x{ff17}\x{ff15}\x{ff10}[\x{ff10}-\x{ff19}]{7})",
         HS_FLAG_DOTALL | HS_FLAG_PREFILTER | HS_FLAG_MULTILINE | HS_FLAG_CASELESS | HS_FLAG_UCP | HS_FLAG_UTF8, 1),
     pattern(R"(NL[0-9\x{ff10}-\x{ff19}]{2}[A-Z\x{ff21}-\x{ff3a}a-z\x{ff41}-\x{ff5a}]{4}[0-9\x{ff10}-\x{ff19}]{10})",
@@ -485,7 +474,7 @@ TEST(utf8, charclass_issue_326) {
     const char *data1 = "５０７５０７８３２４０１";
     const char *data2 = "NL２０INGB０００１２３４567";
 
-    hs_database_t *db = buildDB(patterns, HS_MODE_NOSTREAM);
+    hs_database_t *db = buildDB(unicode_patterns, HS_MODE_NOSTREAM);
     ASSERT_NE(nullptr, db);
 
     hs_scratch_t *scratch = nullptr;
@@ -493,14 +482,14 @@ TEST(utf8, charclass_issue_326) {
     ASSERT_EQ(HS_SUCCESS, err);
 
     CallBackContext c1, c2;
-    err = hs_scan(db, data1, strlen(data1), 0, scratch, record_cb, (void *)&c1);
+    err = hs_scan(db, data1, strlen(data1), 0, scratch, record_cb, reinterpret_cast<void *>(&c1));
     ASSERT_EQ(HS_SUCCESS, err);
     
-    err = hs_scan(db, data2, strlen(data2), 0, scratch, record_cb, (void *)&c2);
+    err = hs_scan(db, data2, strlen(data2), 0, scratch, record_cb, reinterpret_cast<void *>(&c2));
     ASSERT_EQ(HS_SUCCESS, err);
 
-    EXPECT_EQ(1, countMatchesById(c1.matches, 1));
-    EXPECT_EQ(1, countMatchesById(c2.matches, 2));
+    ASSERT_EQ(MatchRecord(36, 1), c1.matches[0]);
+    ASSERT_EQ(MatchRecord(36, 2), c2.matches[0]);
     err = hs_free_scratch(scratch);
     ASSERT_EQ(HS_SUCCESS, err);
     hs_free_database(db);


### PR DESCRIPTION
HAVE__BUILTIN_CONSTANT_P is only defined for gcc (see cmake/cflags-generic.cmake:63-64), so:
* gcc takes the vshrq_n_u64 path -> logical right shift
* clang takes the vshlq_s64 fallback -> arithmetic right shift (sign-extends from MSB)

The shufti nibble-extraction pattern rshift64(andnot(0x0F, data), 4) is used to get the high nibble of each byte as an index for pshufb table lookup. Several callers use this result directly without an and(0x0F) post-mask:
* validateShuftiMask16x16 (validate_shufti.h:53)
* validateShuftiMask32x8 (validate_shufti.h:107)
* validateMultipathShuftiMask64 (validate_shufti.h:356)
* GET_HI_4 macro in counting_miracle.h