### PR TITLE
Fix #339 by correcting assert in buildFragmentPrograms

### DIFF
--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -2994,9 +2994,8 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
         if (pfrag.included_delay_frag_id != INVALID_FRAG_ID &&
             !rebuild_prog.empty()) {
             const auto &cfrag = fragments[pfrag.included_delay_frag_id];
-            /** assert(pfrag.s.length() >= cfrag.s.length() && **/
-            assert(pfrag.s.length() == cfrag.s.length() &&
-                   !pfrag.s.any_nocase() != !cfrag.s.any_nocase());
+            // cppcheck-suppress comparisonOfTwoFuncsReturningBoolError
+            assert(pfrag.s.length() >= cfrag.s.length() && !pfrag.s.any_nocase() >= !cfrag.s.any_nocase());
             u32 child_offset = cfrag.delay_program_offset;
             DEBUG_PRINTF("child %u offset %u\n", cfrag.fragment_id,
                          child_offset);

--- a/unit/hyperscan/regressions.cpp
+++ b/unit/hyperscan/regressions.cpp
@@ -499,3 +499,10 @@ TEST(utf8, charclass_issue_326) {
     ASSERT_EQ(HS_SUCCESS, err);
     hs_free_database(db);
 }
+
+TEST(bug339, delayed_fragment_assert) {
+    hs_database_t *db = buildDB(R"((?:1\d|3[01])(?:0[1-9]|1[01])\d)", 0, 0, HS_MODE_STREAM);
+    ASSERT_NE(nullptr, db);
+
+    hs_free_database(db);
+}


### PR DESCRIPTION
Fix #399 by correcting the assert in `buildFragmentPrograms` from `rose_build_bytecode.cpp` to match the one nearby. This assert will fail for some patterns when compiled into a streaming database. I believe it was modified by mistake. I also added a regression test that checks against a pattern that triggers this issue.