### PR TITLE
truffle: small optimization for the NEON path

### DIFF
--- a/src/nfa/arm/truffle.hpp
+++ b/src/nfa/arm/truffle.hpp
@@ -250,9 +250,9 @@ const SuperVector<S> blockSingleMask(SuperVector<S> shuf_mask_lo_highclear, Supe
     t1.print8("t1");
     SuperVector<S> shuf2 = shuf_mask_lo_highset.pshufb(t1);
     shuf2.print8("shuf2");
-    SuperVector<S> t2 = highconst.opandnot(chars.template vshr_64_imm<4>());
+    SuperVector<S> t2 = chars.template vshr_8_imm<4>();
     t2.print8("t2");
-    SuperVector<S> shuf3 = shuf_mask_hi.pshufb(t2);
+    SuperVector<S> shuf3 = shuf_mask_hi.template pshufb<false>(t2);
     shuf3.print8("shuf3");
     SuperVector<S> res = (shuf1 | shuf2) & shuf3;
     res.print8("(shuf1 | shuf2) & shuf3");


### PR DESCRIPTION
`blockSingleMask()` in `src/nfa/arm/truffle.hpp`:

1) NEON has `vshr_8_imm(vshrq_n_u8)`, so using it you can set zeros in the upper bits of each lane. This saves one instruction.
2) Default `pshufb` does an `& 0x8f`, this makes no sense here, because `vshr_8_imm` already brings all lanes into the [0, 16) range, so you can use `pshufb<false>`.

This PR saves 2 instructions in total.

I tested it this way(apple m5):
```
cmake --build build --target unit-internal unit-hyperscan
./build/bin/unit-hyperscan
./build/bin/unit-internal
```