### PR TITLE
truffle: add AArch64 wide path using vqtbl2q

### DIFF
--- a/src/nfa/arm/truffle.hpp
+++ b/src/nfa/arm/truffle.hpp
@@ -230,6 +230,34 @@ svuint8_t blockSingleMaskWide(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_m
 #endif //HAVE_SVE2
 #endif //HAVE_SVE
 
+#if defined(CAN_USE_WIDE_TRUFFLE) && !defined(HAVE_SVE)
+/* require wide truffle compilation. The 256b mask is split between the two parameters */
+
+template <uint16_t S>
+static really_inline
+const SuperVector<S> blockSingleMaskWide(SuperVector<S> shuf_mask_lo_highclear, SuperVector<S> shuf_mask_lo_highset, SuperVector<S> chars) {
+    chars.print8("chars");
+    shuf_mask_lo_highclear.print8("shuf_mask_lo_highclear");
+
+    uint8x16x2_t tbl = {{shuf_mask_lo_highclear.u.u8x16[0], shuf_mask_lo_highset.u.u8x16[0]}};
+
+    SuperVector<S> idx = chars & SuperVector<S>::dup_u8(31);
+    idx.print8("idx");
+    SuperVector<S> byte_select = SuperVector<S>(vqtbl2q_u8(tbl, idx.u.u8x16[0]));
+    byte_select.print8("byte_select");
+
+    SuperVector<S> bits = chars.template vshr_8_imm<5>();
+    bits.print8("bits");
+    SuperVector<S> bit_select = SuperVector<S>(
+        vshlq_u8(vdupq_n_u8(1), vreinterpretq_s8_u8(bits.u.u8x16[0])));
+    bit_select.print8("bit_select");
+
+    SuperVector<S> res = bit_select & byte_select;
+    res.print8("bit_select & byte_select");
+    return !res.eq(SuperVector<S>::Zeroes());
+}
+
+#endif
 /* require normal truffle compilation. The 256b mask is split between the two parameters */
 template <uint16_t S>
 static really_inline

--- a/src/nfa/truffle.cpp
+++ b/src/nfa/truffle.cpp
@@ -58,7 +58,15 @@ const u8 *rtruffleExecWide(m256 mask, const u8 *buf,
     }
 }
 #else // HAVE_SVE
-#error "Wide truffle enabled for the target architecture but no implementation found"
+const u8 *truffleExecWide(m256 mask, const u8 *buf,
+                      const u8 *buf_end) {
+    return truffleExecReal<VECTORSIZE, true>(mask.lo, mask.hi, buf, buf_end);
+}
+
+const u8 *rtruffleExecWide(m256 mask, const u8 *buf,
+                       const u8 *buf_end) {
+    return rtruffleExecReal<VECTORSIZE, true>(mask.lo, mask.hi, buf, buf_end);
+}
 #endif // HAVE_SVE
 #endif // CAN_USE_WIDE_TRUFFLE
 
@@ -84,11 +92,11 @@ const u8 *rtruffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
 #else
 const u8 *truffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
                       const u8 *buf_end) {
-    return truffleExecReal<VECTORSIZE>(mask_lo, mask_hi, buf, buf_end);
+    return truffleExecReal<VECTORSIZE, false>(mask_lo, mask_hi, buf, buf_end);
 }
 
 const u8 *rtruffleExec(m128 mask_lo, m128 mask_hi, const u8 *buf,
                        const u8 *buf_end) {
-    return rtruffleExecReal<VECTORSIZE>(mask_lo, mask_hi, buf, buf_end);
+    return rtruffleExecReal<VECTORSIZE, false>(mask_lo, mask_hi, buf, buf_end);
 }
 #endif //HAVE_SVE

--- a/src/nfa/truffle_simd.hpp
+++ b/src/nfa/truffle_simd.hpp
@@ -54,6 +54,11 @@ static really_inline
 svuint8_t blockSingleMaskWide(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_highset, svuint8_t chars);
 #endif //HAVE_SVE2
 #else
+#ifdef CAN_USE_WIDE_TRUFFLE
+template <uint16_t S>
+static really_inline
+const SuperVector<S> blockSingleMaskWide(SuperVector<S> shuf_mask_lo_highclear, SuperVector<S> shuf_mask_lo_highset, SuperVector<S> chars);
+#endif
 template <uint16_t S>
 static really_inline
 const SuperVector<S> blockSingleMask(SuperVector<S> shuf_mask_lo_highclear, SuperVector<S> shuf_mask_lo_highset, SuperVector<S> chars);
@@ -95,6 +100,7 @@ const u8 *scanBlock(svuint8_t shuf_mask_lo_highclear, svuint8_t shuf_mask_lo_hig
 #else
             DEBUG_PRINTF("Wide Truffle is not supported with 128b vectors unless SVE2 is enabled");
             assert(false);
+            return nullptr;
 #endif
         } else {
             result_mask = blockSingleMaskWide32(shuf_mask_lo_highclear, chars);
@@ -260,14 +266,24 @@ const u8 *rtruffleExecSVE(m256 shuf_mask_32, const u8 *buf, const u8 *buf_end){
     return buf - 1;
 }
 #else
-template <uint16_t S>
+template <uint16_t S, bool is_wide>
 static really_inline
 const u8 *fwdBlock(SuperVector<S> shuf_mask_lo_highclear, SuperVector<S> shuf_mask_lo_highset, SuperVector<S> chars, const u8 *buf) {
-    SuperVector<S> res = blockSingleMask(shuf_mask_lo_highclear, shuf_mask_lo_highset, chars);
-    return first_zero_match_inverted<S>(buf, res);
+    if constexpr (is_wide) {
+#ifdef CAN_USE_WIDE_TRUFFLE
+        SuperVector<S> res = blockSingleMaskWide(shuf_mask_lo_highclear, shuf_mask_lo_highset, chars);
+        return first_zero_match_inverted<S>(buf, res);
+#else
+        assert(false);
+        return nullptr;
+#endif
+    } else {
+        SuperVector<S> res = blockSingleMask(shuf_mask_lo_highclear, shuf_mask_lo_highset, chars);
+        return first_zero_match_inverted<S>(buf, res);
+    }
 }
 
-template <uint16_t S>
+template <uint16_t S, bool is_wide>
 const u8 *truffleExecReal(const m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_highset, const u8 *buf, const u8 *buf_end) {
     assert(buf && buf_end);
     assert(buf < buf_end);
@@ -289,7 +305,7 @@ const u8 *truffleExecReal(const m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_
         if (!ISALIGNED_N(d, S)) {
             SuperVector<S> chars = SuperVector<S>::loadu(d);
             const u8 *dup = ROUNDUP_PTR(d, S);
-            rv = fwdBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d);
+            rv = fwdBlock<S, is_wide>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d);
             if (rv && rv < dup) return rv;
             d = dup;
         }
@@ -298,7 +314,7 @@ const u8 *truffleExecReal(const m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_
             __builtin_prefetch(d + 16*64);
             DEBUG_PRINTF("d %p \n", d);
             SuperVector<S> chars = SuperVector<S>::load(d);
-            rv = fwdBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d);
+            rv = fwdBlock<S, is_wide>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d);
             if (rv) return rv;
             d += S;
         }
@@ -317,7 +333,7 @@ const u8 *truffleExecReal(const m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_
           chars = SuperVector<S>::loadu(buf_end - S);
           end_buf = buf_end - S;
         }
-        rv = fwdBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, end_buf);
+        rv = fwdBlock<S, is_wide>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, end_buf);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end) return rv;
     }
@@ -325,15 +341,25 @@ const u8 *truffleExecReal(const m128 &shuf_mask_lo_highclear, m128 shuf_mask_lo_
     return buf_end;
 }
 
-template <uint16_t S>
+template <uint16_t S, bool is_wide>
 static really_inline
-const u8 *revBlock(SuperVector<S> shuf_mask_lo_highclear, SuperVector<S> shuf_mask_lo_highset, SuperVector<S> v, 
+const u8 *revBlock(SuperVector<S> shuf_mask_lo_highclear, SuperVector<S> shuf_mask_lo_highset, SuperVector<S> v,
                     const u8 *buf) {
-    SuperVector<S> res = blockSingleMask(shuf_mask_lo_highclear, shuf_mask_lo_highset, v);
-    return last_zero_match_inverted<S>(buf, res);
+    if constexpr (is_wide) {
+#ifdef CAN_USE_WIDE_TRUFFLE
+        SuperVector<S> res = blockSingleMaskWide(shuf_mask_lo_highclear, shuf_mask_lo_highset, v);
+        return last_zero_match_inverted<S>(buf, res);
+#else
+        assert(false);
+        return nullptr;
+#endif
+    } else {
+        SuperVector<S> res = blockSingleMask(shuf_mask_lo_highclear, shuf_mask_lo_highset, v);
+        return last_zero_match_inverted<S>(buf, res);
+    }
 }
 
-template <uint16_t S>
+template <uint16_t S, bool is_wide>
 const u8 *rtruffleExecReal(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highset, const u8 *buf, const u8 *buf_end){
     assert(buf && buf_end);
     assert(buf < buf_end);
@@ -355,7 +381,7 @@ const u8 *rtruffleExecReal(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highse
         if (!ISALIGNED_N(d, S)) {
             SuperVector<S> chars = SuperVector<S>::loadu(d - S);
             const u8 *dbot = ROUNDDOWN_PTR(d, S);
-            rv = revBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d - S);
+            rv = revBlock<S, is_wide>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d - S);
             DEBUG_PRINTF("rv %p \n", rv);
             if (rv >= dbot) return rv;
             d = dbot;
@@ -368,7 +394,7 @@ const u8 *rtruffleExecReal(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highse
 
             d -= S;
             SuperVector<S> chars = SuperVector<S>::load(d);
-            rv = revBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d);
+            rv = revBlock<S, is_wide>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, d);
             if (rv) return rv;
         }
     }
@@ -383,7 +409,7 @@ const u8 *rtruffleExecReal(m128 shuf_mask_lo_highclear, m128 shuf_mask_lo_highse
         } else {
           chars = SuperVector<S>::loadu(buf);
         }
-        rv = revBlock(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, buf);
+        rv = revBlock<S, is_wide>(wide_shuf_mask_lo_highclear, wide_shuf_mask_lo_highset, chars, buf);
         DEBUG_PRINTF("rv %p \n", rv);
         if (rv && rv < buf_end) return rv;
     }

--- a/src/util/arch/arm/arm.h
+++ b/src/util/arch/arm/arm.h
@@ -57,6 +57,8 @@
 #define CAN_USE_WIDE_TRUFFLE 1
 #elif defined(HAVE_SVE)
 #define CAN_USE_WIDE_TRUFFLE (svcntb() >= 32)
+#elif defined(HAVE_NEON) && defined(ARCH_AARCH64) && !defined(VS_SIMDE_BACKEND)
+#define CAN_USE_WIDE_TRUFFLE 1
 #endif
 
 #endif // UTIL_ARCH_ARM_H_

--- a/src/util/supervector/arch/arm/impl.cpp
+++ b/src/util/supervector/arch/arm/impl.cpp
@@ -363,6 +363,7 @@ template SuperVector<16> SuperVector<16>::vshl_128_imm<1>() const;
 template SuperVector<16> SuperVector<16>::vshl_128_imm<4>() const;
 template SuperVector<16> SuperVector<16>::vshr_8_imm<1>() const;
 template SuperVector<16> SuperVector<16>::vshr_8_imm<4>() const;
+template SuperVector<16> SuperVector<16>::vshr_8_imm<5>() const;
 template SuperVector<16> SuperVector<16>::vshr_16_imm<1>() const;
 template SuperVector<16> SuperVector<16>::vshr_64_imm<1>() const;
 template SuperVector<16> SuperVector<16>::vshr_64_imm<4>() const;

--- a/unit/internal/truffleWide.cpp
+++ b/unit/internal/truffleWide.cpp
@@ -36,7 +36,7 @@
 #include "util/simd_utils.h"
 
 #include "util/arch.h"
-#ifdef HAVE_SVE
+#ifdef CAN_USE_WIDE_TRUFFLE
 using namespace ue2;
 
 #define SKIP_IF_NO_WIDE_AVAILABLE() \


### PR DESCRIPTION
The default NEON path uses 3 pshufb and bit-ops, even though AArch64 has a 32-byte tbl. So, this PR fixes it. Also, blockSingleMaskWide uses vshlq_u8(vdupq_n(1), ...) instead of tbl. This gave a speedup of about 30%   

Also, before in /internal/TruffleWide was a gate by HAVE_SVE instead of CAN_USE_WIDE_TRUFFLE.

```
| Matcher              | max_matches |      size | loops | total_sec | avg_time |    max_bw |    avg_bw |
|:---------------------|------------:|----------:|------:|----------:|---------:|----------:|----------:|
| Truffle              |           0 |     16000 | 62500 |     0.068 |    1.087 | 14040.935 |         0 |
| Truffle              |           0 |     64000 | 15625 |     0.034 |    2.200 | 27744.867 |         0 |
| Truffle              |           0 |    256000 |  3906 |     0.034 |    8.777 | 27815.111 |         0 |
| Truffle              |           0 |   1024000 |   976 |     0.034 |   35.207 | 27737.763 |         0 |
| Truffle              |           0 |   4096000 |   244 |     0.035 |  142.434 | 27424.901 |         0 |
| Truffle              |           0 |  16384000 |    61 |     0.034 |  565.049 | 27652.460 |         0 |
| Truffle              |           0 |  65536000 |    15 |     0.035 | 2306.267 | 27100.075 |         0 |
| Truffle              |           0 | 262144000 |     3 |     0.027 | 9026.000 | 27697.762 |         0 |
| Reverse Truffle      |           0 |     16000 | 62500 |     0.107 |    1.712 |  8914.344 |         0 |
| Reverse Truffle      |           0 |     64000 | 15625 |     0.053 |    3.403 | 17937.335 |         0 |
| Reverse Truffle      |           0 |    256000 |  3906 |     0.039 |    9.975 | 24476.099 |         0 |
| Reverse Truffle      |           0 |   1024000 |   976 |     0.035 |   36.370 | 26850.861 |         0 |
| Reverse Truffle      |           0 |   4096000 |   244 |     0.034 |  141.225 | 27659.683 |         0 |
| Reverse Truffle      |           0 |  16384000 |    61 |     0.035 |  569.836 | 27420.167 |         0 |
| Reverse Truffle      |           0 |  65536000 |    15 |     0.034 | 2256.467 | 27698.171 |         0 |
| Reverse Truffle      |           0 | 262144000 |     3 |     0.027 | 9131.667 | 27377.259 |         0 |
| Truffle Wide         |           0 |     16000 | 62500 |     0.061 |    0.977 | 15621.969 |         0 |
| Truffle Wide         |           0 |     64000 | 15625 |     0.028 |    1.763 | 34617.384 |         0 |
| Truffle Wide         |           0 |    256000 |  3906 |     0.026 |    6.729 | 36282.513 |         0 |
| Truffle Wide         |           0 |   1024000 |   976 |     0.027 |   27.908 | 34992.474 |         0 |
| Truffle Wide         |           0 |   4096000 |   244 |     0.027 |  112.475 | 34729.813 |         0 |
| Truffle Wide         |           0 |  16384000 |    61 |     0.028 |  455.377 | 34312.226 |         0 |
| Truffle Wide         |           0 |  65536000 |    15 |     0.027 | 1822.867 | 34286.655 |         0 |
| Truffle Wide         |           0 | 262144000 |     3 |     0.022 | 7262.000 | 34425.778 |         0 |
| Reverse Truffle Wide |           0 |     16000 | 62500 |     0.098 |    1.569 |  9724.425 |         0 |
| Reverse Truffle Wide |           0 |     64000 | 15625 |     0.043 |    2.764 | 22085.508 |         0 |
| Reverse Truffle Wide |           0 |    256000 |  3906 |     0.029 |    7.381 | 33074.822 |         0 |
| Reverse Truffle Wide |           0 |   1024000 |   976 |     0.025 |   25.967 | 37607.521 |         0 |
| Reverse Truffle Wide |           0 |   4096000 |   244 |     0.024 |   99.902 | 39100.960 |         0 |
| Reverse Truffle Wide |           0 |  16384000 |    61 |     0.025 |  405.918 | 38492.993 |         0 |
| Reverse Truffle Wide |           0 |  65536000 |    15 |     0.025 | 1633.867 | 38252.815 |         0 |
| Reverse Truffle Wide |           0 | 262144000 |     3 |     0.019 | 6469.000 | 38645.849 |         0 |
| Truffle              |           5 |     16000 | 62500 |     0.072 |     0.466 | 27173.112 | 20930.097 |
| Truffle              |           5 |     64000 | 15625 |     0.070 |     1.790 | 27585.431 | 21821.484 |
| Truffle              |           5 |    256000 |  3906 |     0.069 |     7.087 | 27665.021 | 22050.189 |
| Truffle              |           5 |   1024000 |   976 |     0.069 |    28.234 | 27816.285 | 22150.179 |
| Truffle              |           5 |   4096000 |   244 |     0.069 |   113.306 | 27979.598 | 22085.727 |
| Truffle              |           5 |  16384000 |    61 |     0.069 |   454.928 | 28086.784 | 22023.373 |
| Truffle              |           5 |  65536000 |    15 |     0.068 |  1818.973 | 27592.804 | 21975.848 |
| Truffle              |           5 | 262144000 |     3 |     0.054 |  7260.000 | 27849.981 | 22069.129 |
| Reverse Truffle      |           5 |     16000 | 62500 |     0.071 |     0.679 | 27175.370 | 21288.299 |
| Reverse Truffle      |           5 |     64000 | 15625 |     0.069 |     2.664 | 27780.968 | 21946.189 |
| Reverse Truffle      |           5 |    256000 |  3906 |     0.069 |    10.618 | 27773.796 | 22101.429 |
| Reverse Truffle      |           5 |   1024000 |   976 |     0.069 |    42.468 | 28004.260 | 22161.031 |
| Reverse Truffle      |           5 |   4096000 |   244 |     0.069 |   170.344 | 27765.640 | 22060.683 |
| Reverse Truffle      |           5 |  16384000 |    61 |     0.070 |   687.203 | 27867.115 | 21913.221 |
| Reverse Truffle      |           5 |  65536000 |    15 |     0.068 |  2722.853 | 27989.252 | 22120.801 |
| Reverse Truffle      |           5 | 262144000 |     3 |     0.055 | 10928.467 | 27958.993 | 22100.953 |
| Truffle Wide         |           5 |     16000 | 62500 |     0.058 |    0.377 | 33780.804 | 25889.973 |
| Truffle Wide         |           5 |     64000 | 15625 |     0.056 |    1.429 | 34533.085 | 27323.010 |
| Truffle Wide         |           5 |    256000 |  3906 |     0.055 |    5.666 | 34790.707 | 27607.786 |
| Truffle Wide         |           5 |   1024000 |   976 |     0.054 |   22.223 | 36434.442 | 28200.155 |
| Truffle Wide         |           5 |   4096000 |   244 |     0.055 |   90.159 | 34970.648 | 27756.995 |
| Truffle Wide         |           5 |  16384000 |    61 |     0.055 |  362.977 | 34690.628 | 27577.485 |
| Truffle Wide         |           5 |  65536000 |    15 |     0.055 | 1458.573 | 34547.883 | 27401.251 |
| Truffle Wide         |           5 | 262144000 |     3 |     0.043 | 5782.400 | 34802.784 | 27669.569 |
| Reverse Truffle Wide |           5 |     16000 | 62500 |     0.051 |    0.491 | 37505.626 | 29484.573 |
| Reverse Truffle Wide |           5 |     64000 | 15625 |     0.049 |    1.894 | 38953.306 | 30835.465 |
| Reverse Truffle Wide |           5 |    256000 |  3906 |     0.049 |    7.558 | 39577.227 | 31063.787 |
| Reverse Truffle Wide |           5 |   1024000 |   976 |     0.049 |   30.186 | 39763.246 | 31286.766 |
| Reverse Truffle Wide |           5 |   4096000 |   244 |     0.049 |  121.105 | 39177.571 | 31027.281 |
| Reverse Truffle Wide |           5 |  16384000 |    61 |     0.049 |  481.967 | 39078.516 | 31118.562 |
| Reverse Truffle Wide |           5 |  65536000 |    15 |     0.048 | 1928.080 | 39172.673 | 30887.119 |
| Reverse Truffle Wide |           5 | 262144000 |     3 |     0.039 | 7768.733 | 38900.415 | 30817.083 |
```

Btw I also added `return nullptr` in each branch with `assert(false)` to truffle_simd.hpp and `template SuperVector<16> SuperVector<16>::vshr_8_imm<5>() const` into impl.cpp.