### PR TITLE
fix(cmake): determine the fat runtime output object without rev

### DIFF
--- a/cmake/build_wrapper.sh
+++ b/cmake/build_wrapper.sh
@@ -12,7 +12,19 @@ PREFIX=$1
 KEEPSYMS_IN=$2
 shift 2
 # $@ contains the actual build command
-OUT=$(echo "$@" | rev | cut -d ' ' -f 2- | rev | sed 's/.* -o \(.*\.o\).*/\1/')
+# The output object is the argument following the last -o.
+OUT=
+_prev=
+for _arg in "$@"; do
+    if [ "${_prev}" = "-o" ]; then
+        OUT=${_arg}
+    fi
+    _prev=${_arg}
+done
+if [ -z "${OUT}" ]; then
+    echo "$0: could not determine the output object from the build command" >&2
+    exit 1
+fi
 trap cleanup INT QUIT EXIT
 SYMSFILE=$(mktemp -p /tmp ${PREFIX}_rename.syms.XXXXX)
 KEEPSYMS=$(mktemp -p /tmp keep.syms.XXXXX)


### PR DESCRIPTION
In summary, on machines without the `rev` utility the fat build fails to link because the `-o` argument is not extracted correctly. This PR fixes it by avoiding `rev` and also fixes other potential issues (e.g. paths with spaces).

<details>
<summary>:robot: Click to see an LLM generated explanation that goes into more detail.</summary>

> build_wrapper.sh extracted the -o argument by shelling out to `rev`:
> 
>     OUT=$(echo "$@" | rev | cut -d ' ' -f 2- | rev | sed 's/.* -o \(.*\.o\).*/\1/')
> 
> `rev` is part of util-linux and is not present in every build environment; minimal container images routinely omit it. Because the pipeline is not run with `set -o pipefail` and `sed` still exits 0 when nothing matches, a missing `rev` does not fail here. Instead the extraction silently yields an empty OUT, `nm` is then invoked with no operand, the symbol list comes out empty, and `objcopy` is never run.
> 
> The fat runtime components are consequently left with unprefixed symbols and the final link fails with undefined references to avx2_*, corei7_*, simde_* and friends -- an error that gives no hint that a missing tool at the start of the build was the cause.
> 
> Walk the argument list instead. That needs no external tools, is not confused by paths containing spaces (the old `echo "$@"` flattened the arguments into one string before splitting on spaces), and takes the argument after the last -o rather than pattern-matching on a trailing `.o`. Fail loudly when no output object can be found, so a future regression surfaces at the point of failure rather than at link time.
> 
> Found while packaging 5.4.13 for conda-forge, whose Alma Linux 10 build image does not ship util-linux.

</details>